### PR TITLE
legato-fix: don't await safe_state()

### DIFF
--- a/helao/drivers/pump/legato_driver.py
+++ b/helao/drivers/pump/legato_driver.py
@@ -123,7 +123,7 @@ class KDS100:
         await self.poll_signalq.put(False)
 
     async def poll_signal_loop(self):
-        await self.safe_state()
+        self.safe_state()
         while True:
             self.polling = await self.poll_signalq.get()
             self.base.print_message("polling signal received")


### PR DESCRIPTION
Merge this fix now and work on pump visualizer on a newer branch so we can merge ccsi-dev and take advantage of new MFC driver on main.