### PR TITLE
feat: non-blocking actions

### DIFF
--- a/helao.py
+++ b/helao.py
@@ -376,7 +376,7 @@ def launcher(confArg, confDict, helao_root):
                         cmd = ["python", "bokeh_launcher.py", confArg, server]
                         p = subprocess.Popen(cmd, cwd=helao_root)
                         try:
-                            time.sleep(3)
+                            time.sleep(5)
                             ppid = pidd.find_bokeh(servHost, servPort)
                         except:
                             print_message(

--- a/helao/configs/eche4.py
+++ b/helao/configs/eche4.py
@@ -7,13 +7,13 @@ config["dummy"] = True
 config["simulation"] = False
 
 config["builtin_ref_motorxy"] = [110, 12]  # absolute plate coords
-config["experiment_libraries"] = ["samples_exp", "ECHE_exp", "ECHEUVIS_exp", "UVIS_exp"]
+config["experiment_libraries"] = ["samples_exp", "ECHE_exp", "ECHEUVIS_exp", "UVIS_exp", "TEST_exp"]
 config["experiment_params"] = {
     "toggle_is_shutter": False,
     "gamrychannelwait": -1,
     "gamrychannelsend": 0,
 }
-config["sequence_libraries"] = ["ECHE_seq", "ECHEUVIS_seq", "UVIS_T_seq"]
+config["sequence_libraries"] = ["ECHE_seq", "ECHEUVIS_seq", "UVIS_T_seq", "TEST_seq"]
 config["sequence_params"] = {
     "led_wavelengths_nm": [-1],
     "led_intensities_mw": [0.432],

--- a/helao/drivers/io/galil_io_driver.py
+++ b/helao/drivers/io/galil_io_driver.py
@@ -492,6 +492,7 @@ class AiMonExec(Executor):
             status = HloStatus.active
         else:
             status = HloStatus.finished
+        await asyncio.sleep(0.001)
         return {
             "error": ErrorCodes.none,
             "status": status,

--- a/helao/drivers/io/nidaqmx_driver.py
+++ b/helao/drivers/io/nidaqmx_driver.py
@@ -865,6 +865,7 @@ class DevMonExec(Executor):
             status = HloStatus.active
         else:
             status = HloStatus.finished
+        await asyncio.sleep(0.001)
         return {
             "error": ErrorCodes.none,
             "status": status,

--- a/helao/drivers/io/nidaqmx_driver.py
+++ b/helao/drivers/io/nidaqmx_driver.py
@@ -18,7 +18,7 @@ from nidaqmx.constants import UnitsPreScaled
 from nidaqmx.constants import TriggerType
 
 from helao.helpers.premodels import Action
-from helao.servers.base import Base
+from helao.servers.base import Base, Executor
 from helaocore.error import ErrorCodes
 from helao.helpers.make_str_enum import make_str_enum
 from helao.helpers.sample_api import UnifiedSampleDataAPI
@@ -26,6 +26,7 @@ from helaocore.models.sample import SampleInheritance, SampleStatus
 from helaocore.models.file import FileConnParams, HloHeaderModel
 from helao.helpers.active_params import ActiveParams
 from helaocore.models.data import DataModel
+from helaocore.models.hlostatus import HloStatus
 
 
 class cNIMAX:
@@ -840,3 +841,32 @@ class cNIMAX:
         self.Heatloop_run = False
         self.monitorloop_run = False
         self.IOloop_run = False
+
+
+class DevMonExec(Executor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.active.base.print_message("DevMonExec initialized.")
+        self.start_time = time.time()
+        self.duration = self.active.action.action_params.get("duration", -1)
+
+    async def _poll(self):
+        """Read analog inputs from live buffer."""
+        data_dict = {}
+        times = []
+        for monitor_name in self.active.base.fastapp.driver.task_monitor_keys:
+            val, epoch_s = self.active.base.get_lbuf(monitor_name)
+            data_dict[monitor_name] = val
+            times.append(epoch_s)
+        data_dict["epoch_s"] = max(times)
+        iter_time = time.time()
+        elapsed_time = iter_time - self.start_time
+        if (self.duration < 0) or (elapsed_time < self.duration):
+            status = HloStatus.active
+        else:
+            status = HloStatus.finished
+        return {
+            "error": ErrorCodes.none,
+            "status": status,
+            "data": data_dict,
+        }

--- a/helao/drivers/mfc/alicat_driver.py
+++ b/helao/drivers/mfc/alicat_driver.py
@@ -317,6 +317,7 @@ class MfcExec(Executor):
             status = HloStatus.active
         else:
             status = HloStatus.finished
+        await asyncio.sleep(0.001)
         return {
             "error": ErrorCodes.none,
             "status": status,

--- a/helao/drivers/mfc/alicat_driver.py
+++ b/helao/drivers/mfc/alicat_driver.py
@@ -1,9 +1,10 @@
 """ A device class for the AliCat mass flow controller.
 
 This device class uses the python implementation from https://github.com/numat/alicat
-which has been added to the 'helao' conda environment. The default gas list included in
-the module code differs from our MFC at G16 (i-C4H10), G25 (He-25), and G26 (He-75).
-Update the gas list registers in case any of the 3 gases are used.
+and additional methods from https://documents.alicat.com/Alicat-Serial-Primer.pdf. The 
+default gas list included in the module code differs from our MFC at G16 (i-C4H10),
+G25 (He-25), and G26 (He-75). Update the gas list registers in case any of the 3 gases 
+are used.
 
 """
 

--- a/helao/drivers/mfc/alicat_driver.py
+++ b/helao/drivers/mfc/alicat_driver.py
@@ -277,13 +277,12 @@ class AliCatMFC:
 
 class MfcExec(Executor):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # current plan is 1 flow controller per COM
         self.device_name = list(self.active.base.server_params["devices"].keys())[0]
+        super().__init__(*args, **kwargs, exid=self.device_name)
+        # current plan is 1 flow controller per COM
         self.active.base.print_message("MFCExec initialized.")
         self.start_time = time.time()
         self.duration = self.active.action.action_params.get("duration", -1)
-        self.exid = self.device_name
 
     async def _pre_exec(self):
         "Set flow rate."

--- a/helao/drivers/pump/legato_driver.py
+++ b/helao/drivers/pump/legato_driver.py
@@ -428,6 +428,7 @@ class PumpExec(Executor):
         live_buffer, _ = self.active.base.get_lbuf(self.pump_name)
         pump_status = live_buffer["status"]
         # self.active.base.print_message(f"poll iter status: {pump_status}")
+        await asyncio.sleep(0.001)
         if pump_status in ["infusing", "withdrawing"]:
             return {"error": ErrorCodes.none, "status": HloStatus.active}
         elif pump_status == "stalled":

--- a/helao/drivers/sensor/sprintir_driver.py
+++ b/helao/drivers/sensor/sprintir_driver.py
@@ -389,6 +389,7 @@ class CO2MonExec(Executor):
             status = HloStatus.active
         else:
             status = HloStatus.finished
+        await asyncio.sleep(0.001)
         return {
             "error": ErrorCodes.none,
             "status": status,

--- a/helao/experiments/TEST_exp.py
+++ b/helao/experiments/TEST_exp.py
@@ -1,0 +1,35 @@
+"""
+Experiment library for Orchestrator testing
+server_key must be a FastAPI action server defined in config
+"""
+
+__all__ = []
+
+
+from typing import Optional
+from socket import gethostname
+
+from helao.helpers.premodels import Experiment, ActionPlanMaker
+from helaocore.models.action_start_condition import ActionStartCondition
+from helaocore.models.machine import MachineModel as MM
+from helaocore.models.process_contrib import ProcessContrib
+
+from helao.drivers.io.enum import TriggerType
+
+
+EXPERIMENTS = __all__
+
+ORCH_server = MM(server_name="ORCH", machine_name=gethostname()).json_dict()
+PAL_server = MM(server_name="PAL", machine_name=gethostname()).json_dict()
+CALC_server = MM(server_name="CALC", machine_name=gethostname()).json_dict()
+
+
+def TEST_sub_noblocking(
+    experiment: Experiment,
+    experiment_version: int = 1,
+    wait_time: float = 10.0,
+    reason: str = "wait",
+):
+    apm = ActionPlanMaker()
+    apm.add(ORCH_server, "interrupt", {"reason": apm.pars.reason})
+    return apm.action_list

--- a/helao/experiments/TEST_exp.py
+++ b/helao/experiments/TEST_exp.py
@@ -27,9 +27,9 @@ CALC_server = MM(server_name="CALC", machine_name=gethostname()).json_dict()
 def TEST_sub_noblocking(
     experiment: Experiment,
     experiment_version: int = 1,
-    wait_time: float = 10.0,
-    reason: str = "wait",
+    wait_time: float = 3.0,
 ):
     apm = ActionPlanMaker()
-    apm.add(ORCH_server, "interrupt", {"reason": apm.pars.reason})
+    apm.add(ORCH_server, "wait", {"waittime": apm.pars.wait_time*10}, nonblocking=True)
+    apm.add(ORCH_server, "wait", {"waittime": apm.pars.wait_time})
     return apm.action_list

--- a/helao/experiments/TEST_exp.py
+++ b/helao/experiments/TEST_exp.py
@@ -3,7 +3,7 @@ Experiment library for Orchestrator testing
 server_key must be a FastAPI action server defined in config
 """
 
-__all__ = []
+__all__ = ["TEST_sub_noblocking"]
 
 
 from typing import Optional

--- a/helao/helpers/premodels.py
+++ b/helao/helpers/premodels.py
@@ -241,7 +241,7 @@ class Action(Experiment, ActionModel):
     def __str__(self):
         return f"action_name:{self.action_name}"
 
-    def get_act(self):
+    def get_actmodel(self):
         return ActionModel(**self.dict())
 
     def init_act(self, time_offset: float = 0, force: Optional[bool] = None):

--- a/helao/sequences/TEST_seq.py
+++ b/helao/sequences/TEST_seq.py
@@ -2,7 +2,7 @@
 Sequence library for Orchestrator testing
 """
 
-__all__ = []
+__all__ = ["TEST_consecutive_noblocking"]
 
 
 from helao.helpers.premodels import ExperimentPlanMaker

--- a/helao/sequences/TEST_seq.py
+++ b/helao/sequences/TEST_seq.py
@@ -1,0 +1,22 @@
+"""
+Sequence library for Orchestrator testing
+"""
+
+__all__ = []
+
+
+from helao.helpers.premodels import ExperimentPlanMaker
+
+
+SEQUENCES = __all__
+
+
+def TEST_consecutive_noblocking(
+    sequence_version: int = 1,
+    wait_time: float = 10.0,
+    cycles: int = 5
+):
+    epm = ExperimentPlanMaker()
+    epm.add_experiment("TEST_sub_noblocking", {"wait_time": wait_time})
+
+    return epm.experiment_plan_list  # returns complete experiment list

--- a/helao/sequences/TEST_seq.py
+++ b/helao/sequences/TEST_seq.py
@@ -13,10 +13,12 @@ SEQUENCES = __all__
 
 def TEST_consecutive_noblocking(
     sequence_version: int = 1,
-    wait_time: float = 10.0,
+    wait_time: float = 3.0,
     cycles: int = 5
 ):
     epm = ExperimentPlanMaker()
-    epm.add_experiment("TEST_sub_noblocking", {"wait_time": wait_time})
+
+    for _ in range(cycles):
+        epm.add_experiment("TEST_sub_noblocking", {"wait_time": wait_time})
 
     return epm.experiment_plan_list  # returns complete experiment list

--- a/helao/servers/action/co2sensor_server.py
+++ b/helao/servers/action/co2sensor_server.py
@@ -11,7 +11,7 @@ from fastapi import Body
 from helao.helpers.premodels import Action
 from helao.servers.base import makeActionServ
 from helaocore.models.sample import SampleUnion
-from helao.drivers.sensor.sprintir_driver import SprintIR
+from helao.drivers.sensor.sprintir_driver import SprintIR, CO2MonExec
 from helao.helpers.config_loader import config_loader
 
 
@@ -36,10 +36,28 @@ def makeApp(confPrefix, servKey, helao_root):
         acquisition_rate: Optional[float] = 0.2,
         fast_samples_in: Optional[List[SampleUnion]] = Body([], embed=True),
     ):
-        """Acquire spectra based on external trigger."""
-        A = await app.base.setup_action()
-        A.action_abbr = "CO2"
-        active_dict = await app.driver.acquire_co2(A)
-        return active_dict
+        """Record CO2 ppm level."""
+        active = await app.base.setup_and_contain_action()
+        active.action.action_abbr = "CO2"
+        executor = CO2MonExec(
+            active=active,
+            oneoff=False,
+            poll_rate=active.action.action_params["acquisition_rate"],
+        )
+        active_action_dict = active.start_executor(executor)
+        return active_action_dict
+
+    @app.post(f"/{servKey}/cancel_acquire_co2")
+    async def cancel_acquire_co2(
+        action: Optional[Action] = Body({}, embed=True),
+        action_version: int = 1,
+    ):
+        """Stop running CO2 acquisition."""
+        active = await app.base.setup_and_contain_action()
+        for exid, executor in app.base.executors.items():
+            if exid.split()[0] == "acquire_co2":
+                await executor.stop_action_task()
+        finished_action = await active.finish()
+        return finished_action.as_dict()
 
     return app

--- a/helao/servers/action/co2sensor_server.py
+++ b/helao/servers/action/co2sensor_server.py
@@ -44,7 +44,7 @@ def makeApp(confPrefix, servKey, helao_root):
             oneoff=False,
             poll_rate=active.action.action_params["acquisition_rate"],
         )
-        active_action_dict = active.start_executor(executor)
+        active_action_dict = await active.start_executor(executor)
         return active_action_dict
 
     @app.post(f"/{servKey}/cancel_acquire_co2")

--- a/helao/servers/action/galil_io.py
+++ b/helao/servers/action/galil_io.py
@@ -17,7 +17,7 @@ async def galil_dyn_endpoints(app=None):
 
         if app.driver.dev_ai:
 
-            @app.post(f"/{servKey}/get_analog_in"
+            @app.post(f"/{servKey}/get_analog_in")
             async def get_analog_in(
                 action: Optional[Action] = Body({}, embed=True),
                 action_version: int = 2,

--- a/helao/servers/action/mfc_server.py
+++ b/helao/servers/action/mfc_server.py
@@ -41,7 +41,7 @@ def makeApp(confPrefix, servKey, helao_root):
         acquisition_rate: Optional[float] = 0.2,
         fast_samples_in: Optional[List[SampleUnion]] = Body([], embed=True),
     ):
-        """Acquire spectra based on external trigger."""
+        """Set flow rate and record."""
         active = await app.base.setup_and_contain_action()
         active.action.action_abbr = "acq_flow"
         executor = MfcExec(
@@ -63,7 +63,7 @@ def makeApp(confPrefix, servKey, helao_root):
         acquisition_rate: Optional[float] = 0.2,
         fast_samples_in: Optional[List[SampleUnion]] = Body([], embed=True),
     ):
-        """Acquire spectra based on external trigger."""
+        """Set pressure and record."""
         active = await app.base.setup_and_contain_action()
         active.action.action_abbr = "acq_pres"
         executor = PfcExec(

--- a/helao/servers/action/mfc_server.py
+++ b/helao/servers/action/mfc_server.py
@@ -49,7 +49,7 @@ def makeApp(confPrefix, servKey, helao_root):
             oneoff=False,
             poll_rate=active.action.action_params["acquisition_rate"],
         )
-        active_action_dict = active.start_executor(executor)
+        active_action_dict = await active.start_executor(executor)
         return active_action_dict
 
     @app.post(f"/{servKey}/acquire_pressure")
@@ -71,7 +71,7 @@ def makeApp(confPrefix, servKey, helao_root):
             oneoff=False,
             poll_rate=active.action.action_params["acquisition_rate"],
         )
-        active_action_dict = active.start_executor(executor)
+        active_action_dict = await active.start_executor(executor)
         return active_action_dict
 
     @app.post(f"/{servKey}/cancel_acquire")

--- a/helao/servers/action/nidaqmx_server.py
+++ b/helao/servers/action/nidaqmx_server.py
@@ -318,7 +318,7 @@ def makeApp(confPrefix, servKey, helao_root):
                 oneoff=False,
                 poll_rate=active.action.action_params["acquisition_rate"],
             )
-            active_action_dict = active.start_executor(executor)
+            active_action_dict = await active.start_executor(executor)
             return active_action_dict
 
         @app.post(f"/{servKey}/cancel_acquire_monitors")

--- a/helao/servers/action/syringe_server.py
+++ b/helao/servers/action/syringe_server.py
@@ -46,7 +46,7 @@ def makeApp(confPrefix, servKey, helao_root):
     ):
         active = await app.base.setup_and_contain_action()
         executor = PumpExec(direction=1, active=active, oneoff=False, poll_rate=0.2)
-        active_action_dict = active.start_executor(executor)
+        active_action_dict = await active.start_executor(executor)
         return active_action_dict
 
     @app.post(f"/{servKey}/withdraw")
@@ -58,7 +58,7 @@ def makeApp(confPrefix, servKey, helao_root):
     ):
         active = await app.base.setup_and_contain_action()
         executor = PumpExec(direction=-1, active=active, oneoff=False, poll_rate=0.2)
-        active_action_dict = active.start_executor(executor)
+        active_action_dict = await active.start_executor(executor)
         return active_action_dict
 
     @app.post(f"/set_present_volume")

--- a/helao/servers/base.py
+++ b/helao/servers/base.py
@@ -614,10 +614,10 @@ class Base:
     async def send_nbstatuspackage(
         self,
         client_servkey: str,
-        actionmodel_dict: dict,
+        actionmodel: ActionModel,
     ):
         # needs private dispatcher
-        json_dict = {"actionmodel": actionmodel_dict}
+        json_dict = {"actionmodel": actionmodel.json_dict()}
         self.print_message(f"sending non-blocking status: {json_dict}")
         response, error_code = await async_private_dispatcher(
             world_config_dict=self.world_cfg,
@@ -1954,7 +1954,7 @@ class Active:
             for _ in range(retry_limit):
                 response, error_code = await self.base.send_nbstatuspackage(
                     client_servkey=client_servkey,
-                    actionmodel_dict=self.action.get_actmodel().clean_dict(),
+                    actionmodel=self.action.get_actmodel(),
                 )
 
                 if response.get("success", False) and error_code == ErrorCodes.none:

--- a/helao/servers/base.py
+++ b/helao/servers/base.py
@@ -614,10 +614,10 @@ class Base:
     async def send_nbstatuspackage(
         self,
         client_servkey: str,
-        actionmodel: ActionModel,
+        actionmodel_dict: dict,
     ):
         # needs private dispatcher
-        json_dict = {"actionmodel": actionmodel}
+        json_dict = {"actionmodel": actionmodel_dict}
         self.print_message(f"sending non-blocking status: {json_dict}")
         response, error_code = await async_private_dispatcher(
             world_config_dict=self.world_cfg,
@@ -1954,7 +1954,7 @@ class Active:
             for _ in range(retry_limit):
                 response, error_code = await self.base.send_nbstatuspackage(
                     client_servkey=client_servkey,
-                    actionmodel=ActionModel(**self.action.get_actmodel().clean_dict()),
+                    actionmodel_dict=self.action.get_actmodel(),
                 )
 
                 if response.get("success", False) and error_code == ErrorCodes.none:

--- a/helao/servers/base.py
+++ b/helao/servers/base.py
@@ -1100,7 +1100,9 @@ class Active:
         self.action_loop_running = False
         self.action_task = None
 
-    def start_executor(self, executor: Executor):
+    async def start_executor(self, executor: Executor):
+        if executor.active.action.nonblocking:
+            await self.send_nonblocking_status()
         self.action_task = self.base.aloop.create_task(self.action_loop_task(executor))
         return self.action.as_dict()
 
@@ -1975,8 +1977,6 @@ class Active:
         """Generic replacement for 'IOloop'."""
 
         self.base.print_message("action_loop_task started")
-        if self.action.nonblocking:
-            await self.send_nonblocking_status()
         # pre-action operations
         setup_state = await executor._pre_exec()
         setup_error = setup_state.get("error", ErrorCodes.none)

--- a/helao/servers/base.py
+++ b/helao/servers/base.py
@@ -171,6 +171,10 @@ def makeActionServ(
     def get_lbuf():
         return app.base.live_buffer
 
+    @app.post("/get_executors", tags=["private"])
+    def get_executors():
+        return list(app.base.executors.keys())
+
     @app.post("/shutdown", tags=["private"])
     async def post_shutdown():
         await shutdown_event()

--- a/helao/servers/base.py
+++ b/helao/servers/base.py
@@ -617,7 +617,8 @@ class Base:
         actionmodel: ActionModel,
     ):
         # needs private dispatcher
-        json_dict = {"actionmodel": actionmodel}
+        json_dict = {"actionmodel": actionmodel.clean_dict()}
+        self.print_message(f"sending non-blocking status: {json_dict}")
         response, error_code = await async_private_dispatcher(
             world_config_dict=self.world_cfg,
             server=client_servkey,
@@ -625,6 +626,7 @@ class Base:
             params_dict={},
             json_dict=json_dict,
         )
+        self.print_message(f"update_nonblocking request got response: {response}")
         return response, error_code
 
     async def attach_client(self, client_servkey: str, retry_limit=5):
@@ -1944,7 +1946,7 @@ class Active:
     async def send_nonblocking_status(self, retry_limit: int = 3):
         for client_servkey in self.base.status_clients:
             self.base.print_message(
-                f"log_status_task trying to send status to {client_servkey}."
+                f"executor trying to send non-blocking status to {client_servkey}."
             )
             success = False
             for _ in range(retry_limit):
@@ -1953,7 +1955,7 @@ class Active:
                     actionmodel=ActionModel(**self.action.get_actmodel().clean_dict()),
                 )
 
-                if response and error_code == ErrorCodes.none:
+                if response.get("success", False) and error_code == ErrorCodes.none:
                     success = True
                     break
 

--- a/helao/servers/base.py
+++ b/helao/servers/base.py
@@ -1222,9 +1222,7 @@ class Active:
             f"Adding {str(action.action_uuid)} to {action.action_name} status list."
         )
 
-        if action.nonblocking:
-            await self.send_nonblocking_status()
-        else:
+        if not action.nonblocking:
             await self.base.status_q.put(action.get_actmodel())
 
     async def set_estop(self, action: Optional[Action] = None):
@@ -1976,6 +1974,8 @@ class Active:
     async def action_loop_task(self, executor: Executor):
         """Generic replacement for 'IOloop'."""
 
+        if self.action.nonblocking:
+            await self.send_nonblocking_status()
         self.base.print_message("action_loop_task started")
         # pre-action operations
         setup_state = await executor._pre_exec()
@@ -2042,7 +2042,6 @@ class Active:
             self.base.print_message("Error encountered during executor cleanup.")
 
         _ = self.base.executors.pop(executor.exid)
-
         await self.finish()
         if self.action.nonblocking:
             await self.send_nonblocking_status()

--- a/helao/servers/base.py
+++ b/helao/servers/base.py
@@ -171,8 +171,8 @@ def makeActionServ(
     def get_lbuf():
         return app.base.live_buffer
 
-    @app.post("/get_executors", tags=["private"])
-    def get_executors():
+    @app.post("/list_executors", tags=["private"])
+    def list_executors():
         return list(app.base.executors.keys())
 
     @app.post("/shutdown", tags=["private"])

--- a/helao/servers/base.py
+++ b/helao/servers/base.py
@@ -617,7 +617,7 @@ class Base:
         actionmodel: ActionModel,
     ):
         # needs private dispatcher
-        json_dict = {"actionmodel": actionmodel.clean_dict()}
+        json_dict = {"actionmodel": actionmodel}
         self.print_message(f"sending non-blocking status: {json_dict}")
         response, error_code = await async_private_dispatcher(
             world_config_dict=self.world_cfg,

--- a/helao/servers/base.py
+++ b/helao/servers/base.py
@@ -1954,7 +1954,7 @@ class Active:
             for _ in range(retry_limit):
                 response, error_code = await self.base.send_nbstatuspackage(
                     client_servkey=client_servkey,
-                    actionmodel_dict=self.action.get_actmodel(),
+                    actionmodel_dict=self.action.get_actmodel().clean_dict(),
                 )
 
                 if response.get("success", False) and error_code == ErrorCodes.none:

--- a/helao/servers/base.py
+++ b/helao/servers/base.py
@@ -1220,9 +1220,7 @@ class Active:
             f"Adding {str(action.action_uuid)} to {action.action_name} status list."
         )
 
-        if (
-            not action.nonblocking
-        ):  # skip non-blocking actions which send status via action_task
+        if not action.nonblocking:  # skip non-blocking actions which send status via action_task
             await self.base.status_q.put(action.get_actmodel())
 
     async def set_estop(self, action: Optional[Action] = None):

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -319,6 +319,10 @@ def makeOrchServ(
         """Return a list of all endpoints on this server."""
         return app.orch.get_endpoint_urls()
 
+    @app.post("/stop_executor", tags=["private"])
+    def stop_executor(executor_id: str):
+        return app.orch.stop_executor(executor_id)
+
     @app.post("/shutdown", tags=["private"])
     def post_shutdown():
         shutdown_event()

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -232,10 +232,10 @@ def makeOrchServ(
         action: Optional[Action] = Body({}, embed=True),
         action_version: int = 1,
     ):
-        """Stop galil analog input acquisition."""
+        """Stop sleep action."""
         active = await app.orch.setup_and_contain_action()
         for exid, executor in app.orch.executors.items():
-            if exid.split()[0] == "acquire_analog_in":
+            if exid.split()[0] == "wait":
                 await executor.stop_action_task()
         finished_action = await active.finish()
         return finished_action.as_dict()

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -58,7 +58,7 @@ colorama.init(strip=not sys.stdout.isatty())
 # colorama.init()
 
 hlotags_metadata = [
-    {"name": "public", "description": "prublic orchestrator endpoints"},
+    {"name": "public", "description": "public orchestrator endpoints"},
     {"name": "private", "description": "private orchestrator endpoints"},
 ]
 

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -1564,35 +1564,28 @@ class WaitExec(Executor):
         self.poll_rate = 0.01
         self.duration = self.active.action.action_params.get("waittime", -1)
         self.print_every_secs = kwargs.get("print_every_secs", 5)
+        self.start_time = time.time()
 
     async def _exec(self):
-        self.active.base.print_message(" ... wait action:", self.duration)
-        self.start_time = time.time()
+        self.active.base.print_message(f" ... wait action: {self.duration}")
         self.last_print_time = self.start_time
-        return {
-            "data": {},
-            "error": ErrorCodes.none,
-        }
+        return {"data": {}, "error": ErrorCodes.none}
 
     async def _poll(self):
         """Read analog inputs from live buffer."""
         check_time = time.time()
+        elapsed_time = check_time - self.start_time
         if check_time - self.last_print_time > self.print_every_secs - 0.01:
             self.active.base.print_message(
-                f" ... orch waited {(check_time-self.start_time):.1f} sec / {self.duration:.1f} sec"
+                f" ... orch waited {elapsed_time:.1f} sec / {self.duration:.1f} sec"
             )
             self.last_print_time = check_time
-        if (self.duration < 0) or (check_time < self.duration):
+        if (self.duration < 0) or (elapsed_time < self.duration):
             status = HloStatus.active
         else:
             status = HloStatus.finished
-        return {
-            "error": ErrorCodes.none,
-            "status": status,
-        }
-    
+        return {"error": ErrorCodes.none, "status": status}
+
     async def _post_exec(self):
         self.active.base.print_message(" ... wait action done")
-        return {
-            "error": ErrorCodes.none,
-        }
+        return {"error": ErrorCodes.none}

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -559,6 +559,7 @@ class Orch(Base):
         """Clear method for orch to purge non-blocking action ids."""
         resp_tups = []
         for server_key, exid in self.nonblocking:
+            print(server_key, exid)
             response, error_code = await async_private_dispatcher(
                 world_config_dict=self.world_cfg,
                 server=server_key,

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -563,8 +563,8 @@ class Orch(Base):
                 world_config_dict=self.world_cfg,
                 server=server_key,
                 private_action="stop_executor",
-                params_dict={},
-                json_dict={"executor_id": exid},
+                params_dict={"executor_id": exid},
+                json_dict={},
             )
             resp_tups.append((response, error_code))
         return resp_tups

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -33,7 +33,7 @@ from helao.servers.operator.bokeh_operator import Operator
 from helaocore.models.action_start_condition import ActionStartCondition
 from helaocore.models.sequence import SequenceModel
 from helaocore.models.experiment import ExperimentModel
-from helaocore.models.Action import ActionModel
+from helaocore.models.action import ActionModel
 from helaocore.models.hlostatus import HloStatus
 from helaocore.models.server import ActionServerModel, GlobalStatusModel
 from helaocore.models.orchstatus import OrchStatus

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -219,7 +219,7 @@ def makeOrchServ(
             active=active,
             oneoff=False,
         )
-        active_action_dict = active.start_executor(executor)
+        active_action_dict = await active.start_executor(executor)
         return active_action_dict
         # active = await app.orch.setup_and_contain_action()
         # partial_action = active.action.as_dict()

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -113,7 +113,7 @@ def makeOrchServ(
         actionmodel: ActionModel,
     ):
         app.orch.print_message(
-            f"orch '{app.orch.server.server_name}' "
+            f"'{app.orch.server.server_name.upper()}' "
             f"got nonblocking status from "
             f"'{actionmodel.action_server.server_name}': "
             f"exid: {actionmodel.exid} -- status: {actionmodel.action_status}"

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -33,6 +33,7 @@ from helao.servers.operator.bokeh_operator import Operator
 from helaocore.models.action_start_condition import ActionStartCondition
 from helaocore.models.sequence import SequenceModel
 from helaocore.models.experiment import ExperimentModel
+from helaocore.models.Action import ActionModel
 from helaocore.models.hlostatus import HloStatus
 from helaocore.models.server import ActionServerModel, GlobalStatusModel
 from helaocore.models.orchstatus import OrchStatus
@@ -338,6 +339,7 @@ class Orch(Base):
         self.sequence_dq = zdeque([])
         self.experiment_dq = zdeque([])
         self.action_dq = zdeque([])
+        self.noblock_actions = {}
 
         # holder for tracking dispatched action in status
         self.last_dispatched_action_uuid = None
@@ -495,6 +497,9 @@ class Orch(Base):
                 "Orchestrator cannot action experiment_dq unless "
                 "all FastAPI servers in config file are accessible."
             )
+
+    async def update_nonblocking(self, action_model: ActionModel):
+        pass
 
     async def update_status(
         self, actionservermodel: Optional[ActionServerModel] = None
@@ -1256,14 +1261,14 @@ class Orch(Base):
     def list_active_actions(self):
         """Return the current queue running actions."""
         return [
-            statusmodel.act
+            statusmodel
             for uuid, statusmodel in self.orchstatusmodel.active_dict.items()
         ]
 
     def list_actions(self, limit=10):
         """Return the current queue of action_dq."""
         return [
-            self.action_dq[i].get_act() for i in range(min(len(self.action_dq), limit))
+            self.action_dq[i].get_actmodel() for i in range(min(len(self.action_dq), limit))
         ]
 
     def supplement_error_action(self, check_uuid: UUID, sup_action: Action):

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -331,9 +331,13 @@ def makeOrchServ(
         # emergencyStop = True
         time.sleep(0.75)
 
-    @app.post("/get_executors", tags=["private"])
-    def get_executors():
+    @app.post("/list_executors", tags=["private"])
+    def list_executors():
         return list(app.orch.executors.keys())
+
+    @app.post("/list_nonblocking", tags=["private"])
+    def list_non_blocking():
+        return app.orch.nonblocking
 
     return app
 

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -118,7 +118,8 @@ def makeOrchServ(
             f"'{actionmodel.action_server.server_name}': "
             f"exid: {actionmodel.exid} -- status: {actionmodel.action_status}"
         )
-        return await app.orch.update_nonblocking()
+        result_dict = await app.orch.update_nonblocking()
+        return result_dict
 
     @app.post("/attach_client", tags=["private"])
     async def attach_client(client_servkey: str):
@@ -547,7 +548,7 @@ class Orch(Base):
             self.nonblocking.append(server_exid)
         else:
             self.nonblocking.remove(server_exid)
-        return True
+        return {"success": True}
 
     async def clear_nonblocking(self):
         """Clear method for orch to purge non-blocking action ids."""

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -1584,6 +1584,7 @@ class WaitExec(Executor):
             status = HloStatus.active
         else:
             status = HloStatus.finished
+        await asyncio.sleep(0.001)
         return {"error": ErrorCodes.none, "status": status}
 
     async def _post_exec(self):

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -118,7 +118,7 @@ def makeOrchServ(
             f"'{actionmodel.action_server.server_name}': "
             f"exid: {actionmodel.exid} -- status: {actionmodel.action_status}"
         )
-        result_dict = await app.orch.update_nonblocking()
+        result_dict = await app.orch.update_nonblocking(actionmodel)
         return result_dict
 
     @app.post("/attach_client", tags=["private"])

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -546,6 +546,7 @@ class Orch(Base):
 
     def update_nonblocking(self, actionmodel: ActionModel):
         """Update method for action server to push non-blocking action ids."""
+        print(actionmodel.clean_dict())
         server_key = actionmodel.action_server.server_name
         server_exid = (server_key, actionmodel.exid)
         if "active" in actionmodel.action_status:
@@ -562,8 +563,8 @@ class Orch(Base):
                 world_config_dict=self.world_cfg,
                 server=server_key,
                 private_action="stop_executor",
-                params_dict={"executor_id": exid},
-                json_dict={},
+                params_dict={},
+                json_dict={"executor_id": exid},
             )
             resp_tups.append((response, error_code))
         return resp_tups

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -110,15 +110,16 @@ def makeOrchServ(
 
     @app.post("/update_nonblocking", tags=["private"])
     async def update_nonblocking(
-        actionmodel: ActionModel,
+        actionmodel: dict,
     ):
+        actmodel = ActionModel(**actionmodel)
         app.orch.print_message(
             f"'{app.orch.server.server_name.upper()}' "
             f"got nonblocking status from "
-            f"'{actionmodel.action_server.server_name}': "
-            f"exid: {actionmodel.exid} -- status: {actionmodel.action_status}"
+            f"'{actmodel.action_server.server_name}': "
+            f"exid: {actmodel.exid} -- status: {actmodel.action_status}"
         )
-        result_dict = await app.orch.update_nonblocking(actionmodel)
+        result_dict = await app.orch.update_nonblocking(actmodel)
         return result_dict
 
     @app.post("/attach_client", tags=["private"])

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -331,6 +331,10 @@ def makeOrchServ(
         # emergencyStop = True
         time.sleep(0.75)
 
+    @app.post("/get_executors", tags=["private"])
+    def get_executors():
+        return list(app.orch.executors.keys())
+
     return app
 
 

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -110,16 +110,15 @@ def makeOrchServ(
 
     @app.post("/update_nonblocking", tags=["private"])
     async def update_nonblocking(
-        actionmodel: dict,
+        actionmodel: Optional[ActionModel] = Body({}, embed=True)
     ):
-        actmodel = ActionModel(**actionmodel)
         app.orch.print_message(
             f"'{app.orch.server.server_name.upper()}' "
             f"got nonblocking status from "
-            f"'{actmodel.action_server.server_name}': "
-            f"exid: {actmodel.exid} -- status: {actmodel.action_status}"
+            f"'{actionmodel.action_server.server_name}': "
+            f"exid: {actionmodel.exid} -- status: {actionmodel.action_status}"
         )
-        result_dict = await app.orch.update_nonblocking(actmodel)
+        result_dict = await app.orch.update_nonblocking(actionmodel)
         return result_dict
 
     @app.post("/attach_client", tags=["private"])

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -118,7 +118,7 @@ def makeOrchServ(
             f"'{actionmodel.action_server.server_name}': "
             f"exid: {actionmodel.exid} -- status: {actionmodel.action_status}"
         )
-        result_dict = await app.orch.update_nonblocking(actionmodel)
+        result_dict = app.orch.update_nonblocking(actionmodel)
         return result_dict
 
     @app.post("/attach_client", tags=["private"])

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -1,3 +1,16 @@
+"""Orchestrator class and FastAPI server templating function
+
+    TODO:
+    1. Create an additional "non-blocking" action queue for Executor-based actions which
+    will be ignored during ActionStartCondition checks and will be terminated after the
+    final action in an experiment using Executor's stop method. Orch will track non-blocking
+    Executor tasks in a dict of lists, keyed by server name, list values are active
+    executor identifiers.
+    2. Update Base class and server templating function with common endpoint to expose
+    Executor stopping method.
+
+"""
+
 __all__ = ["Orch", "makeOrchServ"]
 
 import asyncio

--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -543,6 +543,7 @@ class Orch(Base):
             self.nonblocking.append(server_exid)
         else:
             self.nonblocking.remove(server_exid)
+        return True
 
     async def clear_nonblocking(self):
         """Clear method for orch to purge non-blocking action ids."""


### PR DESCRIPTION
Non-blocking actions are ignored by orchestrator's ActionStartCondition checks. This type of action is meant to simplify experiment design with concurrent actions that should run over the entire duration of an experiment, e.g. sensor value recording.

Only Executor-style actions are supported, which have a consistent interface for starting and stopping an action loop (evolved 'IOloop'). The CO2, temperature, and pressure sensor recording actions have been updated to use Executor. The ORCH/wait action is also implemented as an Executor, but only meant for testing.