### PR TITLE
fix: REF600E on older fw 3.50

### DIFF
--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -805,7 +805,7 @@ class gamry:
                     self.base.print_message(f"Pstat did not send additional data after 5 d_t intervals, ending measurement.")
                     sink_status = "done"
                 else:
-                    self.base.print_message(f"counter: {counter}, tmpc: {tmpc}")
+                    # self.base.print_message(f"counter: {counter}, tmpc: {tmpc}")
                     counter = tmpc
                     sink_status = self.dtaqsink.status
 

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -134,6 +134,7 @@ class gamry:
         # for Dtaq
         self.dtaqsink = dummy_sink()
         self.dtaq = None
+        self.sample_rate = 0.1
 
         # for global IOloop
         # replaces while loop w/async trigger
@@ -753,6 +754,7 @@ class gamry:
             client.PumpEvents(0.001)
             sink_status = self.dtaqsink.status
             counter = 0
+            last_update = time.time()
 
             while (
                 # counter < len(self.dtaqsink.acquired_points)
@@ -797,10 +799,17 @@ class gamry:
                                     data=data, errors=[], status=HloStatus.active
                                 )
                             )
-                    counter = tmpc
+                    # counter = tmpc
+                    last_update = time.time()
 
-                sink_status = self.dtaqsink.status
-                self.base.print_message(f"sink_status: {sink_status}, tmpc: {tmpc}")
+                # if time.time() - last_update < 10 * self.sample_rate:
+                #     self.base.print_message(f"Pstat did not send additional data after 10 d_t intervals, ending measurement.")
+                #     sink_status = "done"
+                # else:
+                if 1:
+                    self.base.print_message(f"counter: {counter}, tmpc: {tmpc}}")
+                    counter = tmpc
+                    sink_status = self.dtaqsink.status
 
             self.close_pstat_connection()
             return {"measure": f"done_{self.IO_meas_mode}"}
@@ -948,6 +957,7 @@ class gamry:
     async def technique_wrapper(
         self, act, measmode, sigfunc, sigfunc_params, samplerate, eta=0.0, setupargs=[]
     ):
+        self.sample_rate = samplerate
         act.action_etc = eta
         act.error_code = ErrorCodes.none
         samples_in = await self.unified_db.get_samples(act.samples_in)

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -800,6 +800,7 @@ class gamry:
                     counter = tmpc
 
                 sink_status = self.dtaqsink.status
+                self.base.print_message(f"sink_status: {sink_status}, tmpc: {tmpc}")
 
             self.close_pstat_connection()
             return {"measure": f"done_{self.IO_meas_mode}"}

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -799,14 +799,12 @@ class gamry:
                                     data=data, errors=[], status=HloStatus.active
                                 )
                             )
-                    # counter = tmpc
                     last_update = time.time()
 
-                # if time.time() - last_update < 10 * self.sample_rate:
-                #     self.base.print_message(f"Pstat did not send additional data after 10 d_t intervals, ending measurement.")
-                #     sink_status = "done"
-                # else:
-                if 1:
+                if time.time() - last_update > 5 * self.sample_rate:
+                    self.base.print_message(f"Pstat did not send additional data after 5 d_t intervals, ending measurement.")
+                    sink_status = "done"
+                else:
                     self.base.print_message(f"counter: {counter}, tmpc: {tmpc}")
                     counter = tmpc
                     sink_status = self.dtaqsink.status

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -1047,9 +1047,10 @@ class gamry:
                 # clear old samples_in first
                 self.active.action.samples_in = []
                 # now add updated samples to sample_in again
-                await self.active.append_sample(
-                    samples=[sample_in for sample_in in self.samples_in], IO="in"
-                )
+                if self.samples_in:
+                    await self.active.append_sample(
+                        samples=[sample_in for sample_in in self.samples_in], IO="in"
+                    )
 
                 # signal the IOloop to start the measrurement
                 await self.set_IO_signalq(True)
@@ -1057,7 +1058,7 @@ class gamry:
                 # need to wait now for the activation of the meas routine
                 # and that the active object is activated and sets action status
                 while not self.IO_continue:
-                    await asyncio.sleep(1)
+                    await asyncio.sleep(0.1)
 
                 # reset continue flag
                 self.IO_continue = False

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -807,7 +807,7 @@ class gamry:
                 #     sink_status = "done"
                 # else:
                 if 1:
-                    self.base.print_message(f"counter: {counter}, tmpc: {tmpc}}")
+                    self.base.print_message(f"counter: {counter}, tmpc: {tmpc}")
                     counter = tmpc
                     sink_status = self.dtaqsink.status
 

--- a/helao/servers/action/galil_motion.py
+++ b/helao/servers/action/galil_motion.py
@@ -85,7 +85,7 @@ async def galil_dyn_endpoints(app=None):
             plateid: int = 6353,  # None
         ):
             """starts the plate aligning process, matrix is return when fully done"""
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             active_dict = await app.driver.run_aligner(A)
             return active_dict
 

--- a/helao/servers/action/gamry_server.py
+++ b/helao/servers/action/gamry_server.py
@@ -73,7 +73,7 @@ async def gamry_dyn_endpoints(app=None):
             """Linear Sweep Voltammetry (unlike CV no backward scan is done)
             use 4bit bitmask for triggers
             IErange depends on gamry model used (test actual limit before using)"""
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "LSV"
             # A.save_data = True
             active_dict = await app.driver.technique_LSV(A)
@@ -99,7 +99,7 @@ async def gamry_dyn_endpoints(app=None):
             use 4bit bitmask for triggers
             IErange depends on gamry model used
             (test actual limit before using)"""
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "CA"
             # A.save_data = True
             active_dict = await app.driver.technique_CA(A)
@@ -124,7 +124,7 @@ async def gamry_dyn_endpoints(app=None):
             """Chronopotentiometry (Potential response on controlled current)
             use 4bit bitmask for triggers
             IErange depends on gamry model used (test actual limit before using)"""
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "CP"
             # A.save_data = True
             active_dict = await app.driver.technique_CP(A)
@@ -154,7 +154,7 @@ async def gamry_dyn_endpoints(app=None):
             for acquireing information about electrochemical reactions)
             use 4bit bitmask for triggers
             IErange depends on gamry model used (test actual limit before using)"""
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "CV"
             # A.save_data = True
             active_dict = await app.driver.technique_CV(A)
@@ -185,7 +185,7 @@ async def gamry_dyn_endpoints(app=None):
             NOT TESTED
             use 4bit bitmask for triggers
             IErange depends on gamry model used (test actual limit before using)"""
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "EIS"
             # A.save_data = True
             active_dict = await app.driver.technique_EIS(A)
@@ -209,7 +209,7 @@ async def gamry_dyn_endpoints(app=None):
             """mesasures open circuit potential
             use 4bit bitmask for triggers
             IErange depends on gamry model used (test actual limit before using)"""
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "OCV"
             # A.save_data = True
             active_dict = await app.driver.technique_OCV(A)

--- a/helao/servers/action/nidaqmx_server.py
+++ b/helao/servers/action/nidaqmx_server.py
@@ -327,7 +327,7 @@ def makeApp(confPrefix, server_key, helao_root):
                  SampleRate: samples per second
                  Tval: time of measurement in seconds
                  TTLwait: trigger channel, -1 disables, else select TTL channel"""
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "multiCV"
             active_dict = await app.driver.run_cell_IV(A)
             return active_dict
@@ -404,7 +404,7 @@ def makeApp(confPrefix, server_key, helao_root):
 
         @app.post("/monloop", tags=["private"])
         async def monloop():
-            # A = await app.base.setup_action()
+            # A =  app.base.setup_action()
             A = await app.driver.monitorloop()
 
         @app.post(f"/{server_key}/heatloop", tags=["action"])
@@ -417,7 +417,7 @@ def makeApp(confPrefix, server_key, helao_root):
             reservoir2_min_C: float = 84.5,
             reservoir2_max_C: float = 85.5,
         ):
-            # A = await app.base.setup_action()
+            # A =  app.base.setup_action()
             A = await app.driver.Heatloop(
                 duration_h=duration_hrs,
                 celltemp_min=celltemp_min_C,

--- a/helao/servers/action/pal_server.py
+++ b/helao/servers/action/pal_server.py
@@ -157,7 +157,7 @@ def makeApp(confPrefix, server_key, helao_root):
             timeoffset: float = 0.0,
         ):
             """universal pal action"""
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             active_dict = await app.driver.method_arbitrary(A)
             return active_dict
 
@@ -183,7 +183,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = True,
             wash4: bool = False,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "GC_injection"
             active_dict = await app.driver.method_ANEC_aliquot(A)
             return active_dict
@@ -203,7 +203,7 @@ def makeApp(confPrefix, server_key, helao_root):
             source: dev_customitems = "cell1_we",
             volume_ul_GC: int = 300,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "GC_injection"
             active_dict = await app.driver.method_ANEC_GC(A)
             return active_dict
@@ -232,7 +232,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = True,
             wash4: bool = False,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "GC_injection"
             active_dict = await app.driver.method_injection_tray_GC(A)
             return active_dict
@@ -259,7 +259,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = True,
             wash4: bool = False,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "GC_injection"
             active_dict = await app.driver.method_injection_custom_GC(A)
             return active_dict
@@ -279,7 +279,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = True,
             wash4: bool = False,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "HPLC_injection"
             active_dict = await app.driver.method_injection_custom_HPLC(A)
             return active_dict
@@ -301,7 +301,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = True,
             wash4: bool = False,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "HPLC_injection"
             active_dict = await app.driver.method_injection_tray_HPLC(A)
             return active_dict
@@ -330,7 +330,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = True,
             wash4: bool = False,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "transfer"
             active_dict = await app.driver.method_transfer_tray_tray(A)
             return active_dict
@@ -357,7 +357,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = True,
             wash4: bool = False,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "transfer"
             active_dict = await app.driver.method_transfer_tray_custom(A)
             return active_dict
@@ -384,7 +384,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = True,
             wash4: bool = False,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "transfer"
             active_dict = await app.driver.method_transfer_custom_tray(A)
             return active_dict
@@ -408,7 +408,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = True,
             wash4: bool = False,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "transfer"
             active_dict = await app.driver.method_transfer_custom_custom(A)
             return active_dict
@@ -431,7 +431,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = False,
             wash4: bool = False,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "archive"
             active_dict = await app.driver.method_archive(A)
             return active_dict
@@ -450,7 +450,7 @@ def makeApp(confPrefix, server_key, helao_root):
     #         wash3: bool = False,
     #         wash4: bool = False,
     #     ):
-    #         A = await app.base.setup_action()
+    #         A =  app.base.setup_action()
     #         A.action_abbr = "fill"
     #         active_dict = await app.driver.method_fill(A)
     #         return active_dict
@@ -469,7 +469,7 @@ def makeApp(confPrefix, server_key, helao_root):
     #         wash3: bool = False,
     #         wash4: bool = False,
     #     ):
-    #         A = await app.base.setup_action()
+    #         A =  app.base.setup_action()
     #         A.action_abbr = "fillfixed"
     #         active_dict = await app.driver.method_fillfixed(A)
     #         return active_dict
@@ -489,7 +489,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = True,
             wash4: bool = True,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "deepclean"
             active_dict = await app.driver.method_deepclean(A)
             return active_dict
@@ -515,7 +515,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = True,
             wash4: bool = True,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "dilute"
             active_dict = await app.driver.method_dilute(A)
             return active_dict
@@ -538,7 +538,7 @@ def makeApp(confPrefix, server_key, helao_root):
             wash3: bool = True,
             wash4: bool = True,
         ):
-            A = await app.base.setup_action()
+            A =  app.base.setup_action()
             A.action_abbr = "autodilute"
             active_dict = await app.driver.method_autodilute(A)
             return active_dict

--- a/helao/servers/action/spec_server.py
+++ b/helao/servers/action/spec_server.py
@@ -110,7 +110,7 @@ def makeApp(confPrefix, server_key, helao_root):
         duration: float = -1,
     ):
         """Acquire spectra based on external trigger."""
-        A = await app.base.setup_action()
+        A =  app.base.setup_action()
         A.action_abbr = "OPT"
         # app.base.print_message("Setting up external trigger.", info=True)
         active_dict = await app.driver.acquire_spec_extrig(A)

--- a/helao/servers/base.py
+++ b/helao/servers/base.py
@@ -436,7 +436,7 @@ class Base:
             url_list.append(routeD)
         return url_list
 
-    async def _get_action(self, frame) -> Action:
+    def _get_action(self, frame) -> Action:
         _args, _varargs, _keywords, _locals = inspect.getargvalues(frame)
         action = None
         paramdict = {}
@@ -521,8 +521,8 @@ class Base:
         action.action_codehash = get_filehash(sys._getframe(2).f_code.co_filename)
         return action
 
-    async def setup_action(self) -> Action:
-        return await self._get_action(frame=inspect.currentframe().f_back)
+    def setup_action(self) -> Action:
+        return self._get_action(frame=inspect.currentframe().f_back)
 
     async def setup_and_contain_action(
         self,
@@ -533,7 +533,7 @@ class Base:
     ):
         """This is a simple shortcut for very basic endpoints
         which just want to return some simple data"""
-        action = await self._get_action(frame=inspect.currentframe().f_back)
+        action = self._get_action(frame=inspect.currentframe().f_back)
         if action_abbr is not None:
             action.action_abbr = action_abbr
         active = await self.contain_action(

--- a/helao/servers/visualizer/gamry_vis.py
+++ b/helao/servers/visualizer/gamry_vis.py
@@ -273,7 +273,7 @@ class C_potvis:
         self.plot_prev.renderers = []
 
         self.plot.title.text = f"active action_uuid: {self.cur_action_uuid}"
-        self.plot_prev.title.text = f"last {len(self.prev_action_uuids) - 1} actions"
+        self.plot_prev.title.text = f"last {len(self.prev_action_uuids)} actions"
         xstr = self.data_dict_keys[self.xaxis_selector_group.active]
         ystr = self.data_dict_keys[self.yaxis_selector_group.active]
         colors = ["red", "blue", "yellow", "green"]

--- a/helao/servers/visualizer/gamry_vis.py
+++ b/helao/servers/visualizer/gamry_vis.py
@@ -54,7 +54,7 @@ class C_potvis:
         self.data_dict = {key: [] for key in self.data_dict_keys}
 
         self.datasource = ColumnDataSource(data=self.data_dict)
-        self.data_prev = {}
+        self.data_prev = {key: [] for key in self.data_dict_keys}
         self.datasource_prev = ColumnDataSource(data=self.data_prev)
         self.cur_action_uuid = ""
         self.prev_action_uuid = ""
@@ -286,16 +286,15 @@ class C_potvis:
             name=self.cur_action_uuid,
             legend_label=ystr,
         )
-        if self.prev_action_uuids:
-            for i, puuid in enumerate(self.prev_action_uuids):
-                self.plot_prev.line(
-                    x=xstr + f"__{puuid}",
-                    y=ystr + f"__{puuid}",
-                    line_color=colors[i % len(colors)],
-                    source=self.datasource_prev,
-                    name=puuid,
-                    legend_label=puuid.split("-")[0],
-                )
+        for i, puuid in enumerate(self.prev_action_uuids):
+            self.plot_prev.line(
+                x=xstr + f"__{puuid}",
+                y=ystr + f"__{puuid}",
+                line_color=colors[i % len(colors)],
+                source=self.datasource_prev,
+                name=puuid,
+                legend_label=puuid.split("-")[0],
+            )
 
     def reset_plot(self, new_action_uuid: UUID, forceupdate: bool = False):
         if (new_action_uuid != self.cur_action_uuid) or forceupdate:
@@ -303,6 +302,7 @@ class C_potvis:
             self.prev_action_uuid = self.cur_action_uuid
             self.cur_action_uuid = new_action_uuid
             self.prev_action_uuids.append(self.prev_action_uuid)
+            self.vis.print_message(f"previous uuids: {self.prev_action_uuids}")
 
             # copy old data to "prev" plot
             self.data_prev.update(
@@ -311,6 +311,9 @@ class C_potvis:
                     for key, val in self.data_dict.items()
                 }
             )
+            for k in self.data_dict_keys:
+                if k in self.data_prev:
+                    self.data_prev.pop(k)
             while len(self.prev_action_uuids) > self.max_prev:
                 rp = self.prev_action_uuids.pop(0)
                 for k in self.data_prev:

--- a/helao/servers/visualizer/gamry_vis.py
+++ b/helao/servers/visualizer/gamry_vis.py
@@ -287,14 +287,16 @@ class C_potvis:
             legend_label=ystr,
         )
         for i, puuid in enumerate(self.prev_action_uuids):
-            self.plot_prev.line(
-                x=xstr + f"__{puuid}",
-                y=ystr + f"__{puuid}",
-                line_color=colors[i % len(colors)],
-                source=self.datasource_prev,
-                name=puuid,
-                legend_label=puuid.split("-")[0],
-            )
+            if puuid != "":
+                self.vis.print_message(f"Adding {puuid} to previous plots")
+                self.plot_prev.line(
+                    x=xstr + f"__{puuid}",
+                    y=ystr + f"__{puuid}",
+                    line_color=colors[i % len(colors)],
+                    source=self.datasource_prev,
+                    name=puuid,
+                    legend_label=puuid.split("-")[0],
+                )
 
     def reset_plot(self, new_action_uuid: UUID, forceupdate: bool = False):
         if (new_action_uuid != self.cur_action_uuid) or forceupdate:
@@ -308,7 +310,7 @@ class C_potvis:
             self.data_prev.update(
                 {
                     key + f"__{self.prev_action_uuid}": val
-                    for key, val in self.data_dict.items()
+                    for key, val in self.datasource.data.items()
                 }
             )
             while len(self.prev_action_uuids) > self.max_prev + 1:

--- a/helao/servers/visualizer/gamry_vis.py
+++ b/helao/servers/visualizer/gamry_vis.py
@@ -54,8 +54,7 @@ class C_potvis:
         self.data_dict = {key: [] for key in self.data_dict_keys}
 
         self.datasource = ColumnDataSource(data=self.data_dict)
-        self.data_prev = {key: [] for key in self.data_dict_keys}
-        self.datasource_prev = ColumnDataSource(data=self.data_prev)
+        self.datasource_prev = ColumnDataSource(data=deepcopy(self.data_dict))
         self.cur_action_uuid = ""
         self.prev_action_uuid = ""
         self.prev_action_uuids = []
@@ -307,7 +306,7 @@ class C_potvis:
             self.vis.print_message(f"previous uuids: {self.prev_action_uuids}")
 
             # copy old data to "prev" plot
-            self.data_prev.update(
+            self.datasource_prev.data.update(
                 {
                     key + f"__{self.prev_action_uuid}": val
                     for key, val in self.datasource.data.items()
@@ -315,12 +314,11 @@ class C_potvis:
             )
             while len(self.prev_action_uuids) > self.max_prev + 1:
                 rp = self.prev_action_uuids.pop(0)
-                for k in self.data_prev:
+                for k in self.datasource_prev.data:
                     if k.endswith(rp):
-                        self.data_prev.pop(k)
+                        self.datasource_prev.data.pop(k)
             self.data_dict = {key: [] for key in self.data_dict_keys}
             self.datasource.data = self.data_dict
-            self.datasource_prev.data = self.data_prev
 
             self._add_plots()
 

--- a/helao/servers/visualizer/gamry_vis.py
+++ b/helao/servers/visualizer/gamry_vis.py
@@ -125,7 +125,7 @@ class C_potvis:
         self.xselect = self.xaxis_selector_group.active
         self.yselect = self.yaxis_selector_group.active
 
-        self.reset_plot(self.cur_action_uuid, forceupdate=True)
+        # self.reset_plot(self.cur_action_uuid, forceupdate=True)
 
         self.vis.doc.add_root(self.layout)
         self.vis.doc.add_root(Spacer(height=10))
@@ -286,7 +286,7 @@ class C_potvis:
             name=self.cur_action_uuid,
             legend_label=ystr,
         )
-        if self.data_prev:
+        if self.prev_action_uuids:
             for i, puuid in enumerate(self.prev_action_uuids):
                 self.plot_prev.line(
                     x=xstr + f"__{puuid}",
@@ -313,9 +313,9 @@ class C_potvis:
             )
             while len(self.prev_action_uuids) > self.max_prev:
                 rp = self.prev_action_uuids.pop(0)
-                for k in self.data_prev.keys():
+                for k in self.data_prev:
                     if k.endswith(rp):
-                        self.datasource_prev.data.pop(k)
+                        self.data_prev.pop(k)
             self.data_dict = {key: [] for key in self.data_dict_keys}
             self.datasource.data = self.data_dict
             self.datasource_prev.data = self.data_prev

--- a/helao/servers/visualizer/gamry_vis.py
+++ b/helao/servers/visualizer/gamry_vis.py
@@ -307,7 +307,7 @@ class C_potvis:
 
             # copy old data to "prev" plot
             self.prev_datasources[self.prev_action_uuid] = ColumnDataSource(
-                data={key: val for key, val in self.datasource.data.items()}
+                data=deepcopy(self.datasource.data)
             )
             while len(self.prev_action_uuids) > self.max_prev:
                 rp = self.prev_action_uuids.pop(0)

--- a/helao/servers/visualizer/gamry_vis.py
+++ b/helao/servers/visualizer/gamry_vis.py
@@ -309,7 +309,7 @@ class C_potvis:
             self.prev_datasources[self.prev_action_uuid] = ColumnDataSource(
                 data={key: val for key, val in self.datasource.data.items()}
             )
-            while len(self.prev_action_uuids) > self.max_prev + 1:
+            while len(self.prev_action_uuids) > self.max_prev:
                 rp = self.prev_action_uuids.pop(0)
                 self.prev_datasources.pop(rp)
             self.data_dict = {key: [] for key in self.data_dict_keys}

--- a/helao/servers/visualizer/gamry_vis.py
+++ b/helao/servers/visualizer/gamry_vis.py
@@ -54,7 +54,7 @@ class C_potvis:
         self.data_dict = {key: [] for key in self.data_dict_keys}
 
         self.datasource = ColumnDataSource(data=self.data_dict)
-        self.datasource_prev = ColumnDataSource(data=deepcopy(self.data_dict))
+        self.prev_datasources = {}
         self.cur_action_uuid = ""
         self.prev_action_uuid = ""
         self.prev_action_uuids = []
@@ -289,10 +289,10 @@ class C_potvis:
             if puuid != "":
                 self.vis.print_message(f"Adding {puuid} to previous plots")
                 self.plot_prev.line(
-                    x=xstr + f"__{puuid}",
-                    y=ystr + f"__{puuid}",
+                    x=xstr,
+                    y=ystr,
                     line_color=colors[i % len(colors)],
-                    source=self.datasource_prev,
+                    source=self.prev_datasources[puuid],
                     name=puuid,
                     legend_label=puuid.split("-")[0],
                 )
@@ -306,17 +306,12 @@ class C_potvis:
             self.vis.print_message(f"previous uuids: {self.prev_action_uuids}")
 
             # copy old data to "prev" plot
-            self.datasource_prev.data.update(
-                {
-                    key + f"__{self.prev_action_uuid}": val
-                    for key, val in self.datasource.data.items()
-                }
+            self.prev_datasources[self.prev_action_uuid] = ColumnDataSource(
+                data={key: val for key, val in self.datasource.data.items()}
             )
             while len(self.prev_action_uuids) > self.max_prev + 1:
                 rp = self.prev_action_uuids.pop(0)
-                for k in self.datasource_prev.data:
-                    if k.endswith(rp):
-                        self.datasource_prev.data.pop(k)
+                self.prev_datasources.pop(rp)
             self.data_dict = {key: [] for key in self.data_dict_keys}
             self.datasource.data = self.data_dict
 

--- a/helao/servers/visualizer/gamry_vis.py
+++ b/helao/servers/visualizer/gamry_vis.py
@@ -274,7 +274,7 @@ class C_potvis:
         self.plot_prev.renderers = []
 
         self.plot.title.text = f"active action_uuid: {self.cur_action_uuid}"
-        self.plot_prev.title.text = f"last {len(self.prev_action_uuids)} actions"
+        self.plot_prev.title.text = f"last {len(self.prev_action_uuids) - 1} actions"
         xstr = self.data_dict_keys[self.xaxis_selector_group.active]
         ystr = self.data_dict_keys[self.yaxis_selector_group.active]
         colors = ["red", "blue", "yellow", "green"]
@@ -311,10 +311,7 @@ class C_potvis:
                     for key, val in self.data_dict.items()
                 }
             )
-            for k in self.data_dict_keys:
-                if k in self.data_prev:
-                    self.data_prev.pop(k)
-            while len(self.prev_action_uuids) > self.max_prev:
+            while len(self.prev_action_uuids) > self.max_prev + 1:
                 rp = self.prev_action_uuids.pop(0)
                 for k in self.data_prev:
                     if k.endswith(rp):


### PR DESCRIPTION
The Gamry REF600E with older instrument firmware 3.50 required for Windows 7 support (Gamry Framework 6.33) does not properly trigger the "OnDataDone" event at the end of a measurement. The workaround implemented here uses the SampleRate measurement parameter as a timing interval and manually ends the measurement after seeing no new data for 5 consecutive intervals.