### PR TITLE
Gamry & Orch/Operator features

### DIFF
--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -541,6 +541,10 @@ class gamry:
                     ierangeval = self.pstat.TestIERange(setpointie)
                     self.pstat.SetIERange(ierangeval)
                     # subset of stop conditions
+                    
+                    self.base.print_message(
+                        f"Using vmin threshold = {act_params['stop_vmin']}, {type(act_params['stop_vmin'])}"
+                    )
                     if act_params.get("stop_vmin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopXMin(True, act_params["stop_vmin"])
@@ -606,9 +610,6 @@ class gamry:
                     self.pstat.SetVchRange(vchrangeval)
                     # subset of stop conditions
                     if act_params.get("stop_imin", None) is not None:
-                        self.base.print_message(
-                            f"Using imin threshold = {act_params['stop_imin']}"
-                        )
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
                         )

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -480,19 +480,19 @@ class gamry:
                     vchrangeval = self.pstat.TestVchRange(setpointv * 1.1)
                     self.pstat.SetVchRange(vchrangeval)
                     # subset of stop conditions
-                    if "stop_imin" in act_params:
+                    if act_params.get("stop_imin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
-                    if "stop_imax" in act_params:
+                    if act_params.get("stop_imax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
-                    if "stopdelay_imin" in act_params:
+                    if act_params.get("stopdelay_imin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayIMin(
                                 act_params["stopdelay_imin"]
@@ -500,7 +500,7 @@ class gamry:
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayIMin(1))
-                    if "stopdelay_imax" in act_params:
+                    if act_params.get("stopdelay_imax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayIMax(
                                 act_params["stopdelay_imax"]
@@ -529,19 +529,19 @@ class gamry:
                     ierangeval = self.pstat.TestIERange(setpointie)
                     self.pstat.SetIERange(ierangeval)
                     # subset of stop conditions
-                    if "stop_vmin" in act_params:
+                    if act_params.get("stop_vmin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopVMin(True, act_params["stop_vmin"])
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopVMin(False, 0.0))
-                    if "stop_vmax" in act_params:
+                    if act_params.get("stop_vmax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopVMax(True, act_params["stop_vmax"])
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopVMax(False, 0.0))
-                    if "stopdelay_vmin" in act_params:
+                    if act_params.get("stopdelay_vmin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayVMin(
                                 act_params["stopdelay_vmin"]
@@ -549,7 +549,7 @@ class gamry:
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayVMin(1))
-                    if "stopdelay_vmax" in act_params:
+                    if act_params.get("stopdelay_vmax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayVMax(
                                 act_params["stopdelay_vmax"]
@@ -581,19 +581,19 @@ class gamry:
                     vchrangeval = self.pstat.TestVchRange(setpointv * 1.1)
                     self.pstat.SetVchRange(vchrangeval)
                     # subset of stop conditions
-                    if "stop_imin" in act_params:
+                    if act_params.get("stop_imin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
-                    if "stop_imax" in act_params:
+                    if act_params.get("stop_imax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
-                    if "stopdelay_imin" in act_params:
+                    if act_params.get("stopdelay_imin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayIMin(
                                 act_params["stopdelay_imin"]
@@ -601,7 +601,7 @@ class gamry:
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayIMin(1))
-                    if "stopdelay_imax" in act_params:
+                    if act_params.get("stopdelay_imax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayIMax(
                                 act_params["stopdelay_imax"]
@@ -631,19 +631,19 @@ class gamry:
                     setpointv = np.max(np.abs(setpointvs))
                     vchrangeval = self.pstat.TestVchRange(setpointv * 1.1)
                     self.pstat.SetVchRange(vchrangeval)
-                    if "stop_imin" in act_params:
+                    if act_params.get("stop_imin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
-                    if "stop_imax" in act_params:
+                    if act_params.get("stop_imax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
-                    if "stop_dimin" in act_params:
+                    if act_params.get("stop_dimin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopDIMin(
                                 True, act_params["stop_dimin"]
@@ -651,7 +651,7 @@ class gamry:
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopDIMin(False, 0.0))
-                    if "stop_dimax" in act_params:
+                    if act_params.get("stop_dimax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopDIMax(
                                 True, act_params["stop_dimax"]
@@ -659,7 +659,7 @@ class gamry:
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopDIMax(False, 0.0))
-                    if "stop_adimin" in act_params:
+                    if act_params.get("stop_adimin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopADIMin(
                                 True, act_params["stop_adimin"]
@@ -667,7 +667,7 @@ class gamry:
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopADIMin(False, 0.0))
-                    if "stop_adimax" in act_params:
+                    if act_params.get("stop_adimax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopADIMax(
                                 True, act_params["stop_adimax"]
@@ -675,7 +675,7 @@ class gamry:
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopADIMax(False, 0.0))
-                    if "stopdelay_imin" in act_params:
+                    if act_params.get("stopdelay_imin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayIMin(
                                 act_params["stopdelay_imin"]
@@ -683,7 +683,7 @@ class gamry:
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayIMin(1))
-                    if "stopdelay_imax" in act_params:
+                    if act_params.get("stopdelay_imax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayIMax(
                                 act_params["stopdelay_imax"]
@@ -691,7 +691,7 @@ class gamry:
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayIMax(1))
-                    if "stopdelay_dimin" in act_params:
+                    if act_params.get("stopdelay_dimin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayDIMin(
                                 act_params["stopdelay_dimin"]
@@ -699,7 +699,7 @@ class gamry:
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayDIMin(1))
-                    if "stopdelay_dimax" in act_params:
+                    if act_params.get("stopdelay_dimax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayDIMax(
                                 act_params["stopdelay_dimax"]
@@ -707,7 +707,7 @@ class gamry:
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayDIMax(1))
-                    if "stopdelay_adimin" in act_params:
+                    if act_params.get("stopdelay_adimin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayADIMin(
                                 act_params["stopdelay_adimin"]
@@ -715,7 +715,7 @@ class gamry:
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayADIMin(1))
-                    if "stopdelay_adimax" in act_params:
+                    if act_params.get("stopdelay_adimax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayADIMax(
                                 act_params["stopdelay_adimax"]
@@ -761,19 +761,15 @@ class gamry:
                     self.pstat.SetCtrlMode(self.GamryCOM.PstatMode)
                     self.pstat.SetVchRangeMode(True)
                     # subset of stop conditions
-                    if "stop_advmin" in act_params:
+                    if act_params.get("stop_advmin", None) is not None:
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetStopADVMin(
-                                True, act_params["stop_advmin"]
-                            )
+                            lambda dtaq: dtaq.SetStopADVMin(True, act_params["stop_advmin"])
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopADVMin(False, 0.0))
-                    if "stop_advmax" in act_params:
+                    if act_params.get("stop_advmax", None) is not None:
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetStopADVMax(
-                                True, act_params["stop_advmax"]
-                            )
+                            lambda dtaq: dtaq.SetStopADVMax(True, act_params["stop_advmax"])
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopADVMax(False, 0.0))

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -787,6 +787,8 @@ class gamry:
                             self.dtaq.Init(self.pstat, Dtaqtype, *argv)
                         else:
                             self.dtaq.Init(self.pstat, *argv)
+                        for limfn in dtaq_lims:
+                            limfn(self.dtaq)
 
                     except Exception as e:
                         tb = "".join(

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -457,6 +457,8 @@ class gamry:
                 # the format of the data array is dependent upon the specific Dtaq
                 # e.g. which subheader to use
 
+                dtaq_lims = []
+
                 if mode == Gamry_modes.CA:
                     Dtaqmode = "GamryCOM.GamryDtaqChrono"
                     Dtaqtype = self.GamryCOM.ChronoAmp
@@ -477,6 +479,35 @@ class gamry:
                     setpointv = np.abs(act_params["Vval__V"])
                     vchrangeval = self.pstat.TestVchRange(setpointv * 1.1)
                     self.pstat.SetVchRange(vchrangeval)
+                    # subset of stop conditions
+                    if "stop_imin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
+                    if "stop_imax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
+                    if "stopdelay_imin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopAtDelayIMin(
+                                act_params["stopdelay_imin"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayIMin(1))
+                    if "stopdelay_imax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopAtDelayIMax(
+                                act_params["stopdelay_imax"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayIMax(1))
                 elif mode == Gamry_modes.CP:
                     Dtaqmode = "GamryCOM.GamryDtaqChrono"
                     Dtaqtype = self.GamryCOM.ChronoPot
@@ -497,6 +528,35 @@ class gamry:
                     setpointie = np.abs(act_params["Ival__A"])
                     ierangeval = self.pstat.TestIERange(setpointie)
                     self.pstat.SetIERange(ierangeval)
+                    # subset of stop conditions
+                    if "stop_vmin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopVMin(True, act_params["stop_vmin"])
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopVMin(False, 0.0))
+                    if "stop_vmax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopVMax(True, act_params["stop_vmax"])
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopVMax(False, 0.0))
+                    if "stopdelay_vmin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopAtDelayVMin(
+                                act_params["stopdelay_vmin"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayVMin(1))
+                    if "stopdelay_vmax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopAtDelayVMax(
+                                act_params["stopdelay_vmax"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayVMax(1))
                 elif mode == Gamry_modes.CV:
                     Dtaqmode = "GamryCOM.GamryDtaqRcv"
                     Dtaqtype = None
@@ -520,6 +580,35 @@ class gamry:
                     setpointv = np.max(np.abs(setpointvs))
                     vchrangeval = self.pstat.TestVchRange(setpointv * 1.1)
                     self.pstat.SetVchRange(vchrangeval)
+                    # subset of stop conditions
+                    if "stop_imin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
+                    if "stop_imax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
+                    if "stopdelay_imin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopAtDelayIMin(
+                                act_params["stopdelay_imin"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayIMin(1))
+                    if "stopdelay_imax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopAtDelayIMax(
+                                act_params["stopdelay_imax"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayIMax(1))
                 elif mode == Gamry_modes.LSV:
                     Dtaqmode = "GamryCOM.GamryDtaqCpiv"
                     Dtaqtype = None
@@ -542,6 +631,98 @@ class gamry:
                     setpointv = np.max(np.abs(setpointvs))
                     vchrangeval = self.pstat.TestVchRange(setpointv * 1.1)
                     self.pstat.SetVchRange(vchrangeval)
+                    if "stop_imin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
+                    if "stop_imax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
+                    if "stop_dimin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopDIMin(
+                                True, act_params["stop_dimin"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopDIMin(False, 0.0))
+                    if "stop_dimax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopDIMax(
+                                True, act_params["stop_dimax"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopDIMax(False, 0.0))
+                    if "stop_adimin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopADIMin(
+                                True, act_params["stop_adimin"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopADIMin(False, 0.0))
+                    if "stop_adimax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopADIMax(
+                                True, act_params["stop_adimax"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopADIMax(False, 0.0))
+                    if "stopdelay_imin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopAtDelayIMin(
+                                act_params["stopdelay_imin"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayIMin(1))
+                    if "stopdelay_imax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopAtDelayIMax(
+                                act_params["stopdelay_imax"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayIMax(1))
+                    if "stopdelay_dimin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopAtDelayDIMin(
+                                act_params["stopdelay_dimin"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayDIMin(1))
+                    if "stopdelay_dimax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopAtDelayDIMax(
+                                act_params["stopdelay_dimax"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayDIMax(1))
+                    if "stopdelay_adimin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopAtDelayADIMin(
+                                act_params["stopdelay_adimin"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayADIMin(1))
+                    if "stopdelay_adimax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopAtDelayADIMax(
+                                act_params["stopdelay_adimax"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayADIMax(1))
                 elif mode == Gamry_modes.EIS:
                     #                Dtaqmode = "GamryCOM.GamryReadZ"
                     Dtaqmode = "GamryCOM.GamryDtaqEis"
@@ -579,6 +760,23 @@ class gamry:
                     ]
                     self.pstat.SetCtrlMode(self.GamryCOM.PstatMode)
                     self.pstat.SetVchRangeMode(True)
+                    # subset of stop conditions
+                    if "stop_advmin" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopADVMin(
+                                True, act_params["stop_advmin"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopADVMin(False, 0.0))
+                    if "stop_advmax" in act_params:
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetStopADVMax(
+                                True, act_params["stop_advmax"]
+                            )
+                        )
+                    else:
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopADVMax(False, 0.0))
                 else:
                     self.base.print_message(f"'mode {mode} not supported'", error=True)
                     error = ErrorCodes.not_available
@@ -593,6 +791,7 @@ class gamry:
                             self.dtaq.Init(self.pstat, Dtaqtype, *argv)
                         else:
                             self.dtaq.Init(self.pstat, *argv)
+
                     except Exception as e:
                         tb = "".join(
                             traceback.format_exception(type(e), e, e.__traceback__)

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -787,6 +787,7 @@ class gamry:
                             self.dtaq.Init(self.pstat, Dtaqtype, *argv)
                         else:
                             self.dtaq.Init(self.pstat, *argv)
+                        self.base.print_message(f"applying {len(dtaq_lims)} limits")
                         for limfn in dtaq_lims:
                             limfn(self.dtaq)
 

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -484,7 +484,11 @@ class gamry:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetThreshIMin(
+                                True, act_params["stop_imin"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(False, 0.0))
@@ -492,7 +496,11 @@ class gamry:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetThreshIMax(
+                                True, act_params["stop_imax"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(False, 0.0))
@@ -537,7 +545,11 @@ class gamry:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopVMin(True, act_params["stop_vmin"])
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetTreshVMin(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetTreshVMin(
+                                True, act_params["stop_vmin"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopVMin(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetTreshVMin(False, 0.0))
@@ -545,7 +557,11 @@ class gamry:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopVMax(True, act_params["stop_vmax"])
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshVMax(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetThreshVMax(
+                                True, act_params["stop_vmax"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopVMax(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshVMax(False, 0.0))
@@ -596,7 +612,11 @@ class gamry:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetThreshIMin(
+                                True, act_params["stop_imin"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(False, 0.0))
@@ -604,7 +624,11 @@ class gamry:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetThreshIMax(
+                                True, act_params["stop_imax"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(False, 0.0))
@@ -650,7 +674,11 @@ class gamry:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetThreshIMin(
+                                True, act_params["stop_imin"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(False, 0.0))
@@ -658,7 +686,11 @@ class gamry:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetThreshIMax(
+                                True, act_params["stop_imax"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(False, 0.0))
@@ -668,7 +700,11 @@ class gamry:
                                 True, act_params["stop_dimin"]
                             )
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshDIMin(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetThreshDIMin(
+                                True, act_params["stop_dimin"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopDIMin(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshDIMin(False, 0.0))
@@ -678,7 +714,11 @@ class gamry:
                                 True, act_params["stop_dimax"]
                             )
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshDIMax(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetThreshDIMax(
+                                True, act_params["stop_dimax"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopDIMax(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshDIMax(False, 0.0))
@@ -688,7 +728,11 @@ class gamry:
                                 True, act_params["stop_adimin"]
                             )
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshADIMin(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetThreshADIMin(
+                                True, act_params["stop_adimin"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopADIMin(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshADIMin(False, 0.0))
@@ -794,7 +838,11 @@ class gamry:
                                 True, act_params["stop_advmin"]
                             )
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshADVMin(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetThreshADVMin(
+                                True, act_params["stop_advmin"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopADVMin(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshADVMin(False, 0.0))
@@ -804,7 +852,11 @@ class gamry:
                                 True, act_params["stop_advmax"]
                             )
                         )
-                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshADVMax(True, 0.0))
+                        dtaq_lims.append(
+                            lambda dtaq: dtaq.SetThreshADVMax(
+                                True, act_params["stop_advmax"]
+                            )
+                        )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopADVMax(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshADVMax(False, 0.0))

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -484,14 +484,18 @@ class gamry:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(False, 0.0))
                     if act_params.get("stop_imax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(False, 0.0))
                     if act_params.get("stopdelay_imin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayIMin(
@@ -533,14 +537,18 @@ class gamry:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopVMin(True, act_params["stop_vmin"])
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetTreshVMin(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopVMin(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetTreshVMin(False, 0.0))
                     if act_params.get("stop_vmax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopVMax(True, act_params["stop_vmax"])
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshVMax(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopVMax(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshVMax(False, 0.0))
                     if act_params.get("stopdelay_vmin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayVMin(
@@ -582,17 +590,24 @@ class gamry:
                     self.pstat.SetVchRange(vchrangeval)
                     # subset of stop conditions
                     if act_params.get("stop_imin", None) is not None:
+                        self.base.print_message(
+                            f"Using imin threshold = {act_params['stop_imin']}"
+                        )
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(False, 0.0))
                     if act_params.get("stop_imax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(False, 0.0))
                     if act_params.get("stopdelay_imin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayIMin(
@@ -635,46 +650,58 @@ class gamry:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(False, 0.0))
                     if act_params.get("stop_imax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(False, 0.0))
                     if act_params.get("stop_dimin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopDIMin(
                                 True, act_params["stop_dimin"]
                             )
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshDIMin(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopDIMin(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshDIMin(False, 0.0))
                     if act_params.get("stop_dimax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopDIMax(
                                 True, act_params["stop_dimax"]
                             )
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshDIMax(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopDIMax(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshDIMax(False, 0.0))
                     if act_params.get("stop_adimin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopADIMin(
                                 True, act_params["stop_adimin"]
                             )
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshADIMin(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopADIMin(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshADIMin(False, 0.0))
                     if act_params.get("stop_adimax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopADIMax(
                                 True, act_params["stop_adimax"]
                             )
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshADIMax(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopADIMax(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshADIMax(False, 0.0))
                     if act_params.get("stopdelay_imin", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopAtDelayIMin(
@@ -763,16 +790,24 @@ class gamry:
                     # subset of stop conditions
                     if act_params.get("stop_advmin", None) is not None:
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetStopADVMin(True, act_params["stop_advmin"])
+                            lambda dtaq: dtaq.SetStopADVMin(
+                                True, act_params["stop_advmin"]
+                            )
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshADVMin(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopADVMin(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshADVMin(False, 0.0))
                     if act_params.get("stop_advmax", None) is not None:
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetStopADVMax(True, act_params["stop_advmax"])
+                            lambda dtaq: dtaq.SetStopADVMax(
+                                True, act_params["stop_advmax"]
+                            )
                         )
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshADVMax(True, 0.0))
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopADVMax(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshADVMax(False, 0.0))
                 else:
                     self.base.print_message(f"'mode {mode} not supported'", error=True)
                     error = ErrorCodes.not_available
@@ -1026,6 +1061,7 @@ class gamry:
         if self.IO_measuring:
             # file and Gamry connection will be closed with the meas loop
             self.IO_do_meas = False  # will stop meas loop
+            self.dtaq.Stop()
             await self.set_IO_signalq(False)
 
     async def estop(self, switch: bool, *args, **kwargs):
@@ -1036,6 +1072,7 @@ class gamry:
         if self.IO_measuring:
             if switch:
                 self.IO_do_meas = False  # will stop meas loop
+                self.dtaq.Stop()
                 await self.set_IO_signalq(False)
                 if self.active:
                     # add estop status to active.status

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -482,7 +482,7 @@ class gamry:
                     # subset of stop conditions
                     if act_params.get("stop_imin", None) is not None:
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetStopIMin(True, act_params["stop_imin"])
+                            lambda dtaq: dtaq.SetStopXMin(True, act_params["stop_imin"])
                         )
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetThreshIMin(
@@ -490,11 +490,11 @@ class gamry:
                             )
                         )
                     else:
-                        dtaq_lims.append(lambda dtaq: dtaq.SetStopIMin(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopXMin(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMin(False, 0.0))
                     if act_params.get("stop_imax", None) is not None:
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetStopIMax(True, act_params["stop_imax"])
+                            lambda dtaq: dtaq.SetStopXMax(True, act_params["stop_imax"])
                         )
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetThreshIMax(
@@ -502,24 +502,24 @@ class gamry:
                             )
                         )
                     else:
-                        dtaq_lims.append(lambda dtaq: dtaq.SetStopIMax(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopXMax(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshIMax(False, 0.0))
                     if act_params.get("stopdelay_imin", None) is not None:
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetStopAtDelayIMin(
+                            lambda dtaq: dtaq.SetStopAtDelayXMin(
                                 act_params["stopdelay_imin"]
                             )
                         )
                     else:
-                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayIMin(1))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayXMin(1))
                     if act_params.get("stopdelay_imax", None) is not None:
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetStopAtDelayIMax(
+                            lambda dtaq: dtaq.SetStopAtDelayXMax(
                                 act_params["stopdelay_imax"]
                             )
                         )
                     else:
-                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayIMax(1))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayXMax(1))
                 elif mode == Gamry_modes.CP:
                     Dtaqmode = "GamryCOM.GamryDtaqChrono"
                     Dtaqtype = self.GamryCOM.ChronoPot
@@ -543,7 +543,7 @@ class gamry:
                     # subset of stop conditions
                     if act_params.get("stop_vmin", None) is not None:
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetStopVMin(True, act_params["stop_vmin"])
+                            lambda dtaq: dtaq.SetStopXMin(True, act_params["stop_vmin"])
                         )
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetTreshVMin(
@@ -551,11 +551,11 @@ class gamry:
                             )
                         )
                     else:
-                        dtaq_lims.append(lambda dtaq: dtaq.SetStopVMin(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopXMin(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetTreshVMin(False, 0.0))
                     if act_params.get("stop_vmax", None) is not None:
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetStopVMax(True, act_params["stop_vmax"])
+                            lambda dtaq: dtaq.SetStopXMax(True, act_params["stop_vmax"])
                         )
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetThreshVMax(
@@ -563,24 +563,24 @@ class gamry:
                             )
                         )
                     else:
-                        dtaq_lims.append(lambda dtaq: dtaq.SetStopVMax(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopXMax(False, 0.0))
                         dtaq_lims.append(lambda dtaq: dtaq.SetThreshVMax(False, 0.0))
                     if act_params.get("stopdelay_vmin", None) is not None:
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetStopAtDelayVMin(
+                            lambda dtaq: dtaq.SetStopAtDelayXMin(
                                 act_params["stopdelay_vmin"]
                             )
                         )
                     else:
-                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayVMin(1))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayXMin(1))
                     if act_params.get("stopdelay_vmax", None) is not None:
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetStopAtDelayVMax(
+                            lambda dtaq: dtaq.SetStopAtDelayXMax(
                                 act_params["stopdelay_vmax"]
                             )
                         )
                     else:
-                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayVMax(1))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetStopAtDelayXMax(1))
                 elif mode == Gamry_modes.CV:
                     Dtaqmode = "GamryCOM.GamryDtaqRcv"
                     Dtaqtype = None

--- a/helao/drivers/pstat/gamry_driver.py
+++ b/helao/drivers/pstat/gamry_driver.py
@@ -546,13 +546,13 @@ class gamry:
                             lambda dtaq: dtaq.SetStopXMin(True, act_params["stop_vmin"])
                         )
                         dtaq_lims.append(
-                            lambda dtaq: dtaq.SetTreshVMin(
+                            lambda dtaq: dtaq.SetThreshVMin(
                                 True, act_params["stop_vmin"]
                             )
                         )
                     else:
                         dtaq_lims.append(lambda dtaq: dtaq.SetStopXMin(False, 0.0))
-                        dtaq_lims.append(lambda dtaq: dtaq.SetTreshVMin(False, 0.0))
+                        dtaq_lims.append(lambda dtaq: dtaq.SetThreshVMin(False, 0.0))
                     if act_params.get("stop_vmax", None) is not None:
                         dtaq_lims.append(
                             lambda dtaq: dtaq.SetStopXMax(True, act_params["stop_vmax"])

--- a/helao/helpers/premodels.py
+++ b/helao/helpers/premodels.py
@@ -163,7 +163,6 @@ class Experiment(Sequence, ExperimentModel):
                     exp.samples_in[identical].action_uuid.append(actm.action_uuid)
 
             for _sample in actm.samples_out:
-
                 identical = self._check_sample(
                     new_sample=_sample, sample_list=exp.samples_out
                 )
@@ -249,10 +248,11 @@ class Action(Experiment, ActionModel):
             self.manual_action = True
             self.access = "manual"
             # -- (1) -- set missing sequence parameters
-            self.sequence_name = "manual_seq"
+            manual_suffix = f"{self.action_server.server_name}-{self.action_name}"
+            self.sequence_name = f"mseq-ACT_{manual_suffix}"
             self.init_seq(time_offset=time_offset)
             # -- (2) -- set missing experiment parameters
-            self.experiment_name = "MANUAL"
+            self.experiment_name = f"mexp-ACT_{manual_suffix}"
             self.init_exp(time_offset=time_offset)
 
         if force or self.action_timestamp is None:

--- a/helao/servers/action/gamry_server.py
+++ b/helao/servers/action/gamry_server.py
@@ -69,6 +69,19 @@ async def gamry_dyn_endpoints(app=None):
                 -1, ge=-1, le=3
             ),  # -1 disables, else select TTL 0-3
             IErange: app.driver.gamry_range_enum = "auto",
+            stop_imin: Optional[float] = None,
+            stop_imax: Optional[float] = None,
+            stop_dimin: Optional[float] = None,
+            stop_dimax: Optional[float] = None,
+            stop_adimin: Optional[float] = None,
+            stop_adimax: Optional[float] = None,
+            stopdelay_imin: Optional[int] = None,
+            stopdelay_imax: Optional[int] = None,
+            stopdelay_dimin: Optional[int] = None,
+            stopdelay_dimax: Optional[int] = None,
+            stopdelay_adimin: Optional[int] = None,
+            stopdelay_adimax: Optional[int] = None,
+            **kwargs,
         ):
             """Linear Sweep Voltammetry (unlike CV no backward scan is done)
             use 4bit bitmask for triggers
@@ -94,6 +107,11 @@ async def gamry_dyn_endpoints(app=None):
                 -1, ge=-1, le=3
             ),  # -1 disables, else select TTL 0-3
             IErange: app.driver.gamry_range_enum = "auto",
+            stop_imin: Optional[float] = None,
+            stop_imax: Optional[float] = None,
+            stopdelay_imin: Optional[int] = None,
+            stopdelay_imax: Optional[int] = None,
+            **kwargs,
         ):
             """Chronoamperometry (current response on amplied potential)
             use 4bit bitmask for triggers
@@ -120,6 +138,11 @@ async def gamry_dyn_endpoints(app=None):
                 -1, ge=-1, le=3
             ),  # -1 disables, else select TTL 0-3
             IErange: app.driver.gamry_range_enum = "auto",
+            stop_vmin: Optional[float] = None,
+            stop_vmax: Optional[float] = None,
+            stopdelay_vmin: Optional[int] = None,
+            stopdelay_vmax: Optional[int] = None,
+            **kwargs,
         ):
             """Chronopotentiometry (Potential response on controlled current)
             use 4bit bitmask for triggers
@@ -149,6 +172,11 @@ async def gamry_dyn_endpoints(app=None):
                 -1, ge=-1, le=3
             ),  # -1 disables, else select TTL 0-3
             IErange: app.driver.gamry_range_enum = "auto",
+            stop_imin: Optional[float] = None,
+            stop_imax: Optional[float] = None,
+            stopdelay_imin: Optional[int] = None,
+            stopdelay_imax: Optional[int] = None,
+            **kwargs,
         ):
             """Cyclic Voltammetry (most widely used technique
             for acquireing information about electrochemical reactions)
@@ -180,6 +208,7 @@ async def gamry_dyn_endpoints(app=None):
                 -1, ge=-1, le=3
             ),  # -1 disables, else select TTL 0-3
             IErange: app.driver.gamry_range_enum = "auto",
+            **kwargs,
         ):
             """Electrochemical Impendance Spectroscopy
             NOT TESTED
@@ -205,6 +234,9 @@ async def gamry_dyn_endpoints(app=None):
                 -1, ge=-1, le=3
             ),  # -1 disables, else select TTL 0-3
             IErange: app.driver.gamry_range_enum = "auto",
+            stop_advmin: Optional[float] = None,
+            stop_advmax: Optional[float] = None,
+            **kwargs,
         ):
             """mesasures open circuit potential
             use 4bit bitmask for triggers

--- a/helao/servers/action/gamry_server.py
+++ b/helao/servers/action/gamry_server.py
@@ -81,7 +81,6 @@ async def gamry_dyn_endpoints(app=None):
             stopdelay_dimax: Optional[int] = None,
             stopdelay_adimin: Optional[int] = None,
             stopdelay_adimax: Optional[int] = None,
-            **kwargs,
         ):
             """Linear Sweep Voltammetry (unlike CV no backward scan is done)
             use 4bit bitmask for triggers
@@ -111,7 +110,6 @@ async def gamry_dyn_endpoints(app=None):
             stop_imax: Optional[float] = None,
             stopdelay_imin: Optional[int] = None,
             stopdelay_imax: Optional[int] = None,
-            **kwargs,
         ):
             """Chronoamperometry (current response on amplied potential)
             use 4bit bitmask for triggers
@@ -142,7 +140,6 @@ async def gamry_dyn_endpoints(app=None):
             stop_vmax: Optional[float] = None,
             stopdelay_vmin: Optional[int] = None,
             stopdelay_vmax: Optional[int] = None,
-            **kwargs,
         ):
             """Chronopotentiometry (Potential response on controlled current)
             use 4bit bitmask for triggers
@@ -176,7 +173,6 @@ async def gamry_dyn_endpoints(app=None):
             stop_imax: Optional[float] = None,
             stopdelay_imin: Optional[int] = None,
             stopdelay_imax: Optional[int] = None,
-            **kwargs,
         ):
             """Cyclic Voltammetry (most widely used technique
             for acquireing information about electrochemical reactions)
@@ -208,7 +204,6 @@ async def gamry_dyn_endpoints(app=None):
                 -1, ge=-1, le=3
             ),  # -1 disables, else select TTL 0-3
             IErange: app.driver.gamry_range_enum = "auto",
-            **kwargs,
         ):
             """Electrochemical Impendance Spectroscopy
             NOT TESTED
@@ -236,7 +231,6 @@ async def gamry_dyn_endpoints(app=None):
             IErange: app.driver.gamry_range_enum = "auto",
             stop_advmin: Optional[float] = None,
             stop_advmax: Optional[float] = None,
-            **kwargs,
         ):
             """mesasures open circuit potential
             use 4bit bitmask for triggers

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -244,31 +244,31 @@ class Operator:
 
         if self.orch.step_thru_actions:
             self.orch_stepact_button = Button(
-                label="STEP-THRU actions", button_type="danger", width=70
+                label="STEP-THRU actions", button_type="danger", width=150
             )
         else:
             self.orch_stepact_button = Button(
-                label="RUN-THRU actions", button_type="success", width=70
+                label="RUN-THRU actions", button_type="success", width=150
             )
         self.orch_stepact_button.on_event(ButtonClick, self.callback_toggle_stepact)
 
         if self.orch.step_thru_experiments:
             self.orch_stepexp_button = Button(
-                label="STEP-THRU experiments", button_type="danger", width=70
+                label="STEP-THRU experiments", button_type="danger", width=150
             )
         else:
             self.orch_stepexp_button = Button(
-                label="RUN-THRU experiments", button_type="success", width=70
+                label="RUN-THRU experiments", button_type="success", width=150
             )
         self.orch_stepexp_button.on_event(ButtonClick, self.callback_toggle_stepexp)
 
         if self.orch.step_thru_experiments:
             self.orch_stepseq_button = Button(
-                label="STEP-THRU sequences", button_type="danger", width=70
+                label="STEP-THRU sequences", button_type="danger", width=150
             )
         else:
             self.orch_stepseq_button = Button(
-                label="RUN-THRU sequences", button_type="success", width=70
+                label="RUN-THRU sequences", button_type="success", width=150
             )
         self.orch_stepseq_button.on_event(ButtonClick, self.callback_toggle_stepseq)
 

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -250,7 +250,7 @@ class Operator:
             self.orch_stepact_button = Toggle(
                 label="RUN-THRU\nactions", button_type="success", width=70
             )
-        self.orch.stepact_button.on_event(ButtonClick, self.callback_toggle_stepact)
+        self.orch_stepact_button.on_event(ButtonClick, self.callback_toggle_stepact)
 
         if self.orch.step_thru_experiments:
             self.orch_stepexp_button = Toggle(
@@ -260,7 +260,7 @@ class Operator:
             self.orch_stepexp_button = Toggle(
                 label="RUN-THRU\nexperiments", button_type="success", width=70
             )
-        self.orch.stepexp_button.on_event(ButtonClick, self.callback_toggle_stepexp)
+        self.orch_stepexp_button.on_event(ButtonClick, self.callback_toggle_stepexp)
 
         if self.orch.step_thru_experiments:
             self.orch_stepseq_button = Toggle(
@@ -270,7 +270,7 @@ class Operator:
             self.orch_stepseq_button = Toggle(
                 label="RUN-THRU\nasequences", button_type="success", width=70
             )
-        self.orch.stepseq_button.on_event(ButtonClick, self.callback_toggle_stepseq)
+        self.orch_stepseq_button.on_event(ButtonClick, self.callback_toggle_stepseq)
 
         self.button_clear_seqs = Button(
             label="Clear seqs", button_type="danger", width=100

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -244,31 +244,31 @@ class Operator:
 
         if self.orch.step_thru_actions:
             self.orch_stepact_button = Button(
-                label="STEP-THRU actions", button_type="danger", width=150
+                label="STEP-THRU actions", button_type="danger", width=170
             )
         else:
             self.orch_stepact_button = Button(
-                label="RUN-THRU actions", button_type="success", width=150
+                label="RUN-THRU actions", button_type="success", width=170
             )
         self.orch_stepact_button.on_event(ButtonClick, self.callback_toggle_stepact)
 
         if self.orch.step_thru_experiments:
             self.orch_stepexp_button = Button(
-                label="STEP-THRU experiments", button_type="danger", width=150
+                label="STEP-THRU experiments", button_type="danger", width=170
             )
         else:
             self.orch_stepexp_button = Button(
-                label="RUN-THRU experiments", button_type="success", width=150
+                label="RUN-THRU experiments", button_type="success", width=170
             )
         self.orch_stepexp_button.on_event(ButtonClick, self.callback_toggle_stepexp)
 
         if self.orch.step_thru_experiments:
             self.orch_stepseq_button = Button(
-                label="STEP-THRU sequences", button_type="danger", width=150
+                label="STEP-THRU sequences", button_type="danger", width=170
             )
         else:
             self.orch_stepseq_button = Button(
-                label="RUN-THRU sequences", button_type="success", width=150
+                label="RUN-THRU sequences", button_type="success", width=170
             )
         self.orch_stepseq_button.on_event(ButtonClick, self.callback_toggle_stepseq)
 
@@ -524,9 +524,9 @@ class Operator:
                         Spacer(height=4),
                         [
                             self.orch_stepact_button,
-                            Spacer(width=100),
+                            Spacer(width=10),
                             self.orch_stepexp_button,
-                            Spacer(width=100),
+                            Spacer(width=10),
                             self.orch_stepseq_button,
                         ],
                         Spacer(height=10),

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -1156,8 +1156,8 @@ class Operator:
             sbutton.button_type = "success"
         else:
             sender_map[sender_type][1] = True
-            sbutton.label = f"RUN-THRU\n{sender_type}"
-            sbutton.button_type = "success"
+            sbutton.label = f"STEP-THRU\n{sender_type}"
+            sbutton.button_type = "danger"
 
     def update_seq_param_layout(self, idx):
         args = self.sequences[idx]["args"]

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -1142,23 +1142,28 @@ class Operator:
     def update_input_value(self, sender, value):
         sender.value = value
 
+    def flip_stepwise_flag(self, sender_type):
+        if sender_type == "actions":
+            self.orch.step_thru_actions = not self.orch.step_thru_actions
+        elif sender_type == "experiments":
+            self.orch.step_thru_experiments = not self.orch.step_thru_experiments
+        elif sender_type == "sequences":
+            self.orch.step_thru_sequences = not self.orch.step_thru_sequences
+
     def update_stepwise_toggle(self, sender):
-        print(sender)
-        print(sender.label, ",", type(sender.label))
         sender_type = sender.label.split()[-1]
         sender_map = {
-            "actions": (self.orch_stepact_button, self.orch.step_thru_actions),
-            "experiments": (self.orch_stepexp_button, self.orch.step_thru_experiments),
-            "sequences": (self.orch_stepseq_button, self.orch.step_thru_sequences),
+            "actions": self.orch_stepact_button,
+            "experiments": self.orch_stepexp_button,
+            "sequences": self.orch_stepseq_button,
         }
-        sbutton, sval = sender_map[sender_type]
-        print("update_stepwise_toggle called on", sbutton.label, sval)
-        if sval:
-            sender_map[sender_type][1] = False
+        sbutton = sender_map[sender_type]
+        print("update_stepwise_toggle called on", sbutton.label)
+        self.flip_stepwise_flag(sender_type)
+        if sbutton.button_type == "danger":
             sbutton.label = f"RUN-THRU {sender_type}"
             sbutton.button_type = "success"
         else:
-            sender_map[sender_type][1] = True
             sbutton.label = f"STEP-THRU {sender_type}"
             sbutton.button_type = "danger"
 

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -521,7 +521,7 @@ class Operator:
                             Spacer(width=10),
                             self.orch_status_button,
                         ],
-                        Spacer(height=10),
+                        Spacer(height=4),
                         [
                             self.orch_stepact_button,
                             Spacer(width=10),
@@ -529,7 +529,7 @@ class Operator:
                             Spacer(width=10),
                             self.orch_stepseq_button,
                         ],
-                        Spacer(height=5),
+                        Spacer(height=10),
                         [
                             Spacer(width=10),
                             Div(
@@ -954,34 +954,19 @@ class Operator:
             self.vis.doc.add_next_tick_callback(partial(self.update_tables))
 
     def callback_toggle_stepact(self, event):
-        if self.orch.step_thru_actions:
-            self.orch.step_thru_actions = False
-            self.orch_stepact_button.label = "RUN-THRU\nactions"
-            self.orch_stepact_button.button_type = "success"
-        else:
-            self.orch.step_thru_actions = True
-            self.orch_stepact_button.label = "STEP-THRU\nactions"
-            self.orch_stepact_button.button_type = "danger"
+        self.vis.doc.add_next_tick_callback(
+            partial(self.update_stepwise_toggle, self.orch_stepact_button)
+        )
 
     def callback_toggle_stepexp(self, event):
-        if self.orch.step_thru_experiments:
-            self.orch.step_thru_experiments = False
-            self.orch_stepexp_button.label = "RUN-THRU\nexperiments"
-            self.orch_stepexp_button.button_type = "success"
-        else:
-            self.orch.step_thru_experiments = True
-            self.orch_stepexp_button.label = "STEP-THRU\nexperiments"
-            self.orch_stepexp_button.button_type = "danger"
+        self.vis.doc.add_next_tick_callback(
+            partial(self.update_stepwise_toggle, self.orch_stepexp_button)
+        )
 
     def callback_toggle_stepseq(self, event):
-        if self.orch.step_thru_sequences:
-            self.orch.step_thru_sequences = False
-            self.orch_stepseq_button.label = "RUN-THRU\nsequences"
-            self.orch_stepseq_button.button_type = "success"
-        else:
-            self.orch.step_thru_sequences = True
-            self.orch_stepseq_button.label = "STEP-THRU\nsequences"
-            self.orch_stepseq_button.button_type = "danger"
+        self.vis.doc.add_next_tick_callback(
+            partial(self.update_stepwise_toggle, self.orch_stepseq_button)
+        )
 
     def callback_stop_orch(self, event):
         self.vis.print_message("stopping operator orch")
@@ -1156,6 +1141,23 @@ class Operator:
 
     def update_input_value(self, sender, value):
         sender.value = value
+
+    def update_stepwise_toggle(self, sender):
+        sender_type = sender.label.split("")[-1]
+        sender_map = {
+            "actions": (self.orch_stepact_button, self.orch.step_thru_actions),
+            "experiments": (self.orch_stepexp_button, self.orch.step_thru_experiments),
+            "sequences": (self.orch_stepseq_button, self.orch.step_thru_sequences),
+        }
+        sbutton, sval = sender_map[sender_type]
+        if sval:
+            sender_map[sender_type][1] = False
+            sbutton.label = f"RUN-THRU\n{sender_type}"
+            sbutton.button_type = "success"
+        else:
+            sender_map[sender_type][1] = True
+            sbutton.label = f"RUN-THRU\n{sender_type}"
+            sbutton.button_type = "success"
 
     def update_seq_param_layout(self, idx):
         args = self.sequences[idx]["args"]
@@ -1769,4 +1771,9 @@ class Operator:
                 self.input_sequence_comment,
                 self.input_sequence_comment2.value,
             )
+        )
+
+    def callback_stepwisetoggle(self, sender):
+        self.vis.doc.add_next_tick_callback(
+            partial(self.update_stepwise_toggle, sender)
         )

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -244,31 +244,31 @@ class Operator:
 
         if self.orch.step_thru_actions:
             self.orch_stepact_button = Toggle(
-                label="STEP-THRU\nactions", button_type="danger", width=70
+                label="STEP-THRU actions", button_type="danger", width=70
             )
         else:
             self.orch_stepact_button = Toggle(
-                label="RUN-THRU\nactions", button_type="success", width=70
+                label="RUN-THRU actions", button_type="success", width=70
             )
         self.orch_stepact_button.on_event(ButtonClick, self.callback_toggle_stepact)
 
         if self.orch.step_thru_experiments:
             self.orch_stepexp_button = Toggle(
-                label="STEP-THRU\nexperiments", button_type="danger", width=70
+                label="STEP-THRU experiments", button_type="danger", width=70
             )
         else:
             self.orch_stepexp_button = Toggle(
-                label="RUN-THRU\nexperiments", button_type="success", width=70
+                label="RUN-THRU experiments", button_type="success", width=70
             )
         self.orch_stepexp_button.on_event(ButtonClick, self.callback_toggle_stepexp)
 
         if self.orch.step_thru_experiments:
             self.orch_stepseq_button = Toggle(
-                label="STEP-THRU\nasequences", button_type="danger", width=70
+                label="STEP-THRU asequences", button_type="danger", width=70
             )
         else:
             self.orch_stepseq_button = Toggle(
-                label="RUN-THRU\nasequences", button_type="success", width=70
+                label="RUN-THRU asequences", button_type="success", width=70
             )
         self.orch_stepseq_button.on_event(ButtonClick, self.callback_toggle_stepseq)
 
@@ -1152,11 +1152,11 @@ class Operator:
         sbutton, sval = sender_map[sender_type]
         if sval:
             sender_map[sender_type][1] = False
-            sbutton.label = f"RUN-THRU\n{sender_type}"
+            sbutton.label = f"RUN-THRU {sender_type}"
             sbutton.button_type = "success"
         else:
             sender_map[sender_type][1] = True
-            sbutton.label = f"STEP-THRU\n{sender_type}"
+            sbutton.label = f"STEP-THRU {sender_type}"
             sbutton.button_type = "danger"
 
     def update_seq_param_layout(self, idx):

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -243,31 +243,31 @@ class Operator:
         )  # success: green, danger: red
 
         if self.orch.step_thru_actions:
-            self.orch_stepact_button = Toggle(
+            self.orch_stepact_button = Button(
                 label="STEP-THRU actions", button_type="danger", width=70
             )
         else:
-            self.orch_stepact_button = Toggle(
+            self.orch_stepact_button = Button(
                 label="RUN-THRU actions", button_type="success", width=70
             )
         self.orch_stepact_button.on_event(ButtonClick, self.callback_toggle_stepact)
 
         if self.orch.step_thru_experiments:
-            self.orch_stepexp_button = Toggle(
+            self.orch_stepexp_button = Button(
                 label="STEP-THRU experiments", button_type="danger", width=70
             )
         else:
-            self.orch_stepexp_button = Toggle(
+            self.orch_stepexp_button = Button(
                 label="RUN-THRU experiments", button_type="success", width=70
             )
         self.orch_stepexp_button.on_event(ButtonClick, self.callback_toggle_stepexp)
 
         if self.orch.step_thru_experiments:
-            self.orch_stepseq_button = Toggle(
+            self.orch_stepseq_button = Button(
                 label="STEP-THRU sequences", button_type="danger", width=70
             )
         else:
-            self.orch_stepseq_button = Toggle(
+            self.orch_stepseq_button = Button(
                 label="RUN-THRU sequences", button_type="success", width=70
             )
         self.orch_stepseq_button.on_event(ButtonClick, self.callback_toggle_stepseq)

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -524,9 +524,9 @@ class Operator:
                         Spacer(height=4),
                         [
                             self.orch_stepact_button,
-                            Spacer(width=10),
+                            Spacer(width=50),
                             self.orch_stepexp_button,
-                            Spacer(width=10),
+                            Spacer(width=50),
                             self.orch_stepseq_button,
                         ],
                         Spacer(height=10),
@@ -1158,7 +1158,6 @@ class Operator:
             "sequences": self.orch_stepseq_button,
         }
         sbutton = sender_map[sender_type]
-        print("update_stepwise_toggle called on", sbutton.label)
         self.flip_stepwise_flag(sender_type)
         if sbutton.button_type == "danger":
             sbutton.label = f"RUN-THRU {sender_type}"

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -1143,6 +1143,8 @@ class Operator:
         sender.value = value
 
     def update_stepwise_toggle(self, sender):
+        print(sender)
+        print(sender.label, ",", type(sender.label))
         sender_type = sender.label.split()[-1]
         sender_map = {
             "actions": (self.orch_stepact_button, self.orch.step_thru_actions),
@@ -1150,6 +1152,7 @@ class Operator:
             "sequences": (self.orch_stepseq_button, self.orch.step_thru_sequences),
         }
         sbutton, sval = sender_map[sender_type]
+        print("update_stepwise_toggle called on", sbutton.label, sval)
         if sval:
             sender_map[sender_type][1] = False
             sbutton.label = f"RUN-THRU {sender_type}"
@@ -1771,9 +1774,4 @@ class Operator:
                 self.input_sequence_comment,
                 self.input_sequence_comment2.value,
             )
-        )
-
-    def callback_stepwisetoggle(self, sender):
-        self.vis.doc.add_next_tick_callback(
-            partial(self.update_stepwise_toggle, sender)
         )

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -524,9 +524,9 @@ class Operator:
                         Spacer(height=4),
                         [
                             self.orch_stepact_button,
-                            Spacer(width=50),
+                            Spacer(width=100),
                             self.orch_stepexp_button,
-                            Spacer(width=50),
+                            Spacer(width=100),
                             self.orch_stepseq_button,
                         ],
                         Spacer(height=10),

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -242,6 +242,36 @@ class Operator:
             label="Disabled", disabled=True, button_type="danger", width=400
         )  # success: green, danger: red
 
+        if self.orch.step_thru_actions:
+            self.orch_stepact_button = Toggle(
+                label="STEP-THRU\nactions", button_type="danger", width=70
+            )
+        else:
+            self.orch_stepact_button = Toggle(
+                label="RUN-THRU\nactions", button_type="success", width=70
+            )
+        self.orch.stepact_button.on_event(ButtonClick, self.callback_toggle_stepact)
+
+        if self.orch.step_thru_experiments:
+            self.orch_stepexp_button = Toggle(
+                label="STEP-THRU\nexperiments", button_type="danger", width=70
+            )
+        else:
+            self.orch_stepexp_button = Toggle(
+                label="RUN-THRU\nexperiments", button_type="success", width=70
+            )
+        self.orch.stepexp_button.on_event(ButtonClick, self.callback_toggle_stepexp)
+
+        if self.orch.step_thru_experiments:
+            self.orch_stepseq_button = Toggle(
+                label="STEP-THRU\nasequences", button_type="danger", width=70
+            )
+        else:
+            self.orch_stepseq_button = Toggle(
+                label="RUN-THRU\nasequences", button_type="success", width=70
+            )
+        self.orch.stepseq_button.on_event(ButtonClick, self.callback_toggle_stepseq)
+
         self.button_clear_seqs = Button(
             label="Clear seqs", button_type="danger", width=100
         )
@@ -492,6 +522,14 @@ class Operator:
                             self.orch_status_button,
                         ],
                         Spacer(height=10),
+                        [
+                            self.orch_stepact_button,
+                            Spacer(width=10),
+                            self.orch_stepexp_button,
+                            Spacer(width=10),
+                            self.orch_stepseq_button,
+                        ],
+                        Spacer(height=5),
                         [
                             Spacer(width=10),
                             Div(
@@ -914,6 +952,36 @@ class Operator:
             # clear current experiment_plan (sequence in operator)
             self.sequence = None
             self.vis.doc.add_next_tick_callback(partial(self.update_tables))
+
+    def callback_toggle_stepact(self, event):
+        if self.orch.step_thru_actions:
+            self.orch.step_thru_actions = False
+            self.orch_stepact_button.label = "RUN-THRU\nactions"
+            self.orch_stepact_button.button_type = "success"
+        else:
+            self.orch.step_thru_actions = True
+            self.orch_stepact_button.label = "STEP-THRU\nactions"
+            self.orch_stepact_button.button_type = "danger"
+
+    def callback_toggle_stepexp(self, event):
+        if self.orch.step_thru_experiments:
+            self.orch.step_thru_experiments = False
+            self.orch_stepexp_button.label = "RUN-THRU\nexperiments"
+            self.orch_stepexp_button.button_type = "success"
+        else:
+            self.orch.step_thru_experiments = True
+            self.orch_stepexp_button.label = "STEP-THRU\nexperiments"
+            self.orch_stepexp_button.button_type = "danger"
+
+    def callback_toggle_stepseq(self, event):
+        if self.orch.step_thru_sequences:
+            self.orch.step_thru_sequences = False
+            self.orch_stepseq_button.label = "RUN-THRU\nsequences"
+            self.orch_stepseq_button.button_type = "success"
+        else:
+            self.orch.step_thru_sequences = True
+            self.orch_stepseq_button.label = "STEP-THRU\nsequences"
+            self.orch_stepseq_button.button_type = "danger"
 
     def callback_stop_orch(self, event):
         self.vis.print_message("stopping operator orch")
@@ -1643,9 +1711,8 @@ class Operator:
         self.IOloop_run = True
         while self.IOloop_run:
             try:
-                await asyncio.sleep(0.1)
-                self.vis.doc.add_next_tick_callback(partial(self.update_tables))
                 _ = await self.update_q.get()
+                self.vis.doc.add_next_tick_callback(partial(self.update_tables))
             except Exception as e:
                 tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
                 self.vis.print_message(

--- a/helao/servers/operator/bokeh_operator.py
+++ b/helao/servers/operator/bokeh_operator.py
@@ -264,11 +264,11 @@ class Operator:
 
         if self.orch.step_thru_experiments:
             self.orch_stepseq_button = Toggle(
-                label="STEP-THRU asequences", button_type="danger", width=70
+                label="STEP-THRU sequences", button_type="danger", width=70
             )
         else:
             self.orch_stepseq_button = Toggle(
-                label="RUN-THRU asequences", button_type="success", width=70
+                label="RUN-THRU sequences", button_type="success", width=70
             )
         self.orch_stepseq_button.on_event(ButtonClick, self.callback_toggle_stepseq)
 
@@ -1143,7 +1143,7 @@ class Operator:
         sender.value = value
 
     def update_stepwise_toggle(self, sender):
-        sender_type = sender.label.split("")[-1]
+        sender_type = sender.label.split()[-1]
         sender_map = {
             "actions": (self.orch_stepact_button, self.orch.step_thru_actions),
             "experiments": (self.orch_stepexp_button, self.orch.step_thru_experiments),


### PR DESCRIPTION
Added "step-thru" functionality to orch queue processing and operator UI. In step-thru modes, orch will pause after dispatching an item for a respective queue. In run-thru mode, the queue will be processed normally.

Implemented current and voltage threshold limits for CP, CA, CV, and OCV Gamry potentiostat measurements.