### PR TITLE
fix: only use premodel objects on ORCH

### DIFF
--- a/helao/servers/orch.py
+++ b/helao/servers/orch.py
@@ -1264,8 +1264,8 @@ class Orch(Base):
     ):
         seq_dict = seq.model_dump()
         D = experimentmodel
-        for k, v in seq_dict.items():
-            setattr(D, k, v)
+        for k in seq_dict.keys():
+            setattr(D, k, getattr(seq, k))
 
         # init uuid now for tracking later
         D.experiment_uuid = gen_uuid()


### PR DESCRIPTION
Limit usage of helao-core models to external data. Orchestrator needs to use premodel subclasses in order to preserve methods and attributes for passing global parameters.