### PR TITLE
feat: log-spam guards for TitledSMTPHandler and file logging

### DIFF
--- a/helao/core/tests/unit_test_logging.py
+++ b/helao/core/tests/unit_test_logging.py
@@ -16,6 +16,7 @@ import logging.handlers
 import os
 import sys
 import tempfile
+import time
 import traceback
 from datetime import datetime
 from logging.handlers import TimedRotatingFileHandler
@@ -24,6 +25,7 @@ from helao.helpers import helao_logging as helao_log
 from helao.helpers.helao_logging import (
     ALERT_LEVEL,
     ColoredNtpOffsetFormatter,
+    DedupTimedRotatingFileHandler,
     GZipRotator,
     NtpOffsetFormatter,
     make_logger,
@@ -252,6 +254,94 @@ def logging_unit_test() -> bool:
         reporter.check(
             "min_interval=0 disables throttling (all alerts mailed)",
             lambda: len(sent_subjects) == 4,
+        )
+
+        reporter.section("DedupTimedRotatingFileHandler collapses repeats")
+
+        def _plain_record(message):
+            return logging.LogRecord(
+                name="dedup",
+                level=logging.INFO,
+                pathname=__file__,
+                lineno=1,
+                msg=message,
+                args=(),
+                exc_info=None,
+            )
+
+        def _read_lines(path):
+            with open(path, "r") as fh:
+                return [ln.rstrip("\n") for ln in fh if ln.strip()]
+
+        # Large interval so only a new message (not elapsed time) triggers flush.
+        dedup_path = os.path.join(tmpdir, "dedup_flush.log")
+        dh = DedupTimedRotatingFileHandler(
+            filename=dedup_path, when="D", interval=1, backupCount=1,
+            dedup_interval=3600,
+        )
+        dh.setFormatter(logging.Formatter("%(message)s"))
+        dh.emit(_plain_record("A"))  # written
+        dh.emit(_plain_record("A"))  # first repeat: cooldown opens, suppressed
+        dh.emit(_plain_record("A"))  # second repeat: counted, suppressed
+        dh.emit(_plain_record("B"))  # new message: flush summary for A, write B
+        dh.close()
+        flush_lines = _read_lines(dedup_path)
+
+        reporter.check(
+            "duplicates suppressed until a new message flushes them "
+            "(3 lines: A, summary, B)",
+            lambda: len(flush_lines) == 3,
+        )
+        reporter.check(
+            "first line is the original message",
+            lambda: flush_lines[0] == "A",
+        )
+        reporter.check(
+            "summary reports the repeat count for the collapsed run",
+            lambda: flush_lines[1] == "A [previous message repeated 2 times]",
+        )
+        reporter.check(
+            "new message is written after the flushed summary",
+            lambda: flush_lines[2] == "B",
+        )
+        reporter.check(
+            "handler state resets after flushing (tracks new message)",
+            lambda: dh._dedup_count == 0 and dh._dedup_last_message == "B",
+        )
+
+        # dedup_interval=0 restores stock behaviour (every record written).
+        stock_path = os.path.join(tmpdir, "dedup_off.log")
+        sh = DedupTimedRotatingFileHandler(
+            filename=stock_path, when="D", interval=1, backupCount=1,
+            dedup_interval=0,
+        )
+        sh.setFormatter(logging.Formatter("%(message)s"))
+        for _ in range(3):
+            sh.emit(_plain_record("SAME"))
+        sh.close()
+        reporter.check(
+            "dedup_interval=0 writes every duplicate (no collapsing)",
+            lambda: _read_lines(stock_path) == ["SAME", "SAME", "SAME"],
+        )
+
+        # Elapsed cooldown flushes a running summary without a new message.
+        elapsed_path = os.path.join(tmpdir, "dedup_elapsed.log")
+        eh = DedupTimedRotatingFileHandler(
+            filename=elapsed_path, when="D", interval=1, backupCount=1,
+            dedup_interval=0.02,
+        )
+        eh.setFormatter(logging.Formatter("%(message)s"))
+        eh.emit(_plain_record("SPAM"))  # written
+        eh.emit(_plain_record("SPAM"))  # cooldown opens, suppressed
+        time.sleep(0.05)
+        eh.emit(_plain_record("SPAM"))  # elapsed: flush summary, reopen window
+        eh.close()
+        elapsed_lines = _read_lines(elapsed_path)
+        reporter.check(
+            "elapsed cooldown flushes a summary line for sustained duplicates",
+            lambda: len(elapsed_lines) == 2
+            and elapsed_lines[0] == "SPAM"
+            and elapsed_lines[1] == "SPAM [previous message repeated 2 times]",
         )
 
         return reporter.success()

--- a/helao/helpers/helao_logging.py
+++ b/helao/helpers/helao_logging.py
@@ -15,6 +15,7 @@ Usage::
     logger = logging.LOGGER
 """
 
+import copy
 import tempfile
 import os
 import subprocess
@@ -45,6 +46,15 @@ logging.addLevelName(ALERT_LEVEL, "ALERT")
 # throttling entirely. Overridden per-deployment via the ``email_interval``
 # key in the alert config referenced by ``alert_config_path``.
 DEFAULT_EMAIL_INTERVAL = 600
+
+# Default seconds over which identical consecutive file-log messages are
+# collapsed into a single summary line. When a message is immediately repeated,
+# further identical records are counted (not written) until a different message
+# arrives or this interval elapses, at which point one summary line reporting
+# the repeat count is written. ``0`` disables de-duplication and restores stock
+# ``TimedRotatingFileHandler`` behaviour. Overridden per-logger via the
+# ``dedup_interval`` argument to :func:`make_logger`.
+DEFAULT_DEDUP_INTERVAL = 10.0
 
 
 def alert(self, message, *args, **kws):
@@ -156,6 +166,87 @@ class TitledSMTPHandler(SMTPHandler):
         super().emit(record)
         self._suppressed_count = 0
         self._suppressed_subjects = []
+
+
+class DedupTimedRotatingFileHandler(TimedRotatingFileHandler):
+    """Rotating file handler that collapses repeated consecutive messages.
+
+    When the same log message — compared by raw content via
+    ``record.getMessage()``, ignoring formatting — is emitted twice in a row,
+    a de-duplication cooldown starts: subsequent identical messages are counted
+    rather than written. The buffered repeat count is flushed as a single
+    summary line when either a different message arrives or the cooldown
+    interval elapses, whichever comes first. Because handlers only act on
+    ``emit``, an elapsed cooldown is detected lazily on the next record; a run
+    of duplicates that simply stops is summarised when the next record (of any
+    kind) arrives. ``dedup_interval`` of ``0`` disables the behaviour and
+    restores stock ``TimedRotatingFileHandler`` semantics.
+    """
+
+    def __init__(self, *args, dedup_interval: float = 0, **kwargs):
+        """Build the handler.
+
+        Args:
+            *args: Positional arguments forwarded to
+                ``TimedRotatingFileHandler``.
+            dedup_interval: Seconds a run of identical consecutive messages is
+                collapsed before a summary line is written. ``0`` (the default)
+                disables de-duplication.
+            **kwargs: Keyword arguments forwarded to
+                ``TimedRotatingFileHandler``.
+        """
+        super().__init__(*args, **kwargs)
+        self.dedup_interval = dedup_interval
+        self._dedup_last_message = None
+        self._dedup_record = None
+        self._dedup_count = 0
+        self._dedup_started = None
+
+    def _flush_dedup(self):
+        """Write a summary line for any buffered repeats and reset the window."""
+        if self._dedup_count > 0 and self._dedup_record is not None:
+            times = self._dedup_count
+            summary = copy.copy(self._dedup_record)
+            summary.msg = (
+                f"{self._dedup_record.getMessage()} "
+                f"[previous message repeated {times} "
+                f"time{'s' if times != 1 else ''}]"
+            )
+            summary.args = None
+            super().emit(summary)
+        self._dedup_count = 0
+        self._dedup_started = None
+
+    def emit(self, record):
+        """Write ``record`` unless it is a suppressed consecutive duplicate."""
+        if not (self.dedup_interval and self.dedup_interval > 0):
+            super().emit(record)
+            return
+
+        message = record.getMessage()
+        now = time.monotonic()
+
+        if message != self._dedup_last_message:
+            # New, non-duplicate message: flush any pending repeats, then write.
+            self._flush_dedup()
+            super().emit(record)
+            self._dedup_last_message = message
+            self._dedup_record = record
+            return
+
+        if self._dedup_started is None:
+            # First immediate repeat: open the cooldown window and suppress.
+            self._dedup_started = now
+            self._dedup_count = 1
+            return
+
+        # Continued repeat within an open window.
+        self._dedup_count += 1
+        if now - self._dedup_started >= self.dedup_interval:
+            # Cooldown satisfied: summarise the run so far and reopen a window
+            # so sustained spam yields one summary line per interval.
+            self._flush_dedup()
+            self._dedup_started = now
 
 
 class HTTPPostHandler(logging.Handler):
@@ -276,6 +367,7 @@ def make_logger(
     log_level: int = 20,  # 10 (DEBUG), 20 (INFO), 30 (WARNING), 40 (ERROR), 50 (CRITICAL)
     email_config: dict = {},
     show_debug_console: bool = False,
+    dedup_interval: float = DEFAULT_DEDUP_INTERVAL,
 ) -> logging.Logger:
     """Build and configure the canonical per-server HELAO logger.
 
@@ -299,6 +391,10 @@ def make_logger(
             interval, defaulting to :data:`DEFAULT_EMAIL_INTERVAL`.
         show_debug_console: If ``True``, the console handler is set to
             ``DEBUG`` level.
+        dedup_interval: Seconds over which identical consecutive messages
+            written to the rotating file are collapsed into a single summary
+            line, defaulting to :data:`DEFAULT_DEDUP_INTERVAL`. ``0`` disables
+            de-duplication.
 
     Returns:
         The configured ``logging.Logger`` instance.
@@ -339,15 +435,23 @@ def make_logger(
     console = logging.StreamHandler()
     console.setFormatter(colored_formatter)
     try:
-        timed_rotation = TimedRotatingFileHandler(
-            filename=log_path, when="D", interval=1, backupCount=90
+        timed_rotation = DedupTimedRotatingFileHandler(
+            filename=log_path,
+            when="D",
+            interval=1,
+            backupCount=90,
+            dedup_interval=dedup_interval,
         )
         timed_rotation.rotator = GZipRotator()
     except OSError:
         temp_log_path = Path(os.path.join(temp_dir, f"{logger_name}.log"))
         print(f"Can't write to {log_path}. Redirecting to: {temp_log_path}")
-        timed_rotation = TimedRotatingFileHandler(
-            filename=temp_log_path, when="D", interval=1, backupCount=90
+        timed_rotation = DedupTimedRotatingFileHandler(
+            filename=temp_log_path,
+            when="D",
+            interval=1,
+            backupCount=90,
+            dedup_interval=dedup_interval,
         )
     timed_rotation.setFormatter(formatter)
 

--- a/helao/helpers/helao_logging.py
+++ b/helao/helpers/helao_logging.py
@@ -77,7 +77,14 @@ class TitledSMTPHandler(SMTPHandler):
     ``min_interval`` seconds. Records that arrive during the cooldown window
     are dropped rather than mailed, but are counted so the next email that
     does go out can report how many alerts were suppressed in the meantime.
+    The subject lines of dropped records are also buffered (up to
+    ``MAX_SUPPRESSED_SUBJECTS`` lines) and appended to the body of the next
+    email. Once the buffer is full further records are still counted but their
+    subject lines are no longer retained.
     """
+
+    #: Maximum number of suppressed subject lines buffered for the next email.
+    MAX_SUPPRESSED_SUBJECTS = 100
 
     def __init__(self, *args, min_interval: float = 0, **kwargs):
         """Build the handler.
@@ -92,6 +99,16 @@ class TitledSMTPHandler(SMTPHandler):
         self.min_interval = min_interval
         self._last_emit_monotonic = None
         self._suppressed_count = 0
+        self._suppressed_subjects = []
+
+    def _base_subject(self, record) -> str:
+        """Return ``"<LEVEL> - <title> on <HOST>"`` for ``record``."""
+        message = record.getMessage()
+        if "~" in message:
+            title = message.split("~")[0].strip()
+        else:
+            title = message.split()[0].strip()
+        return f"{record.levelname} - {title} on {HOST}"
 
     def getSubject(self, record) -> str:
         """Return ``"<LEVEL> - <title> on <HOST>"`` for ``record``.
@@ -99,14 +116,29 @@ class TitledSMTPHandler(SMTPHandler):
         When alerts were suppressed by throttling since the last email, a
         ``"(+N suppressed)"`` note is appended to the subject.
         """
-        if "~" in record.message:
-            title = record.message.split("~")[0].strip()
-        else:
-            title = record.message.split()[0].strip()
-        subject = f"{record.levelname} - {title} on {HOST}"
+        subject = self._base_subject(record)
         if self._suppressed_count:
             subject += f" (+{self._suppressed_count} suppressed)"
         return subject
+
+    def format(self, record) -> str:
+        """Format ``record`` and append any buffered suppressed subject lines."""
+        body = super().format(record)
+        if self._suppressed_subjects:
+            note_lines = [
+                "",
+                "",
+                f"--- {self._suppressed_count} alert(s) suppressed during cooldown ---",
+            ]
+            note_lines.extend(self._suppressed_subjects)
+            if self._suppressed_count > len(self._suppressed_subjects):
+                dropped = self._suppressed_count - len(self._suppressed_subjects)
+                note_lines.append(
+                    f"... (+{dropped} more not shown; buffer limit "
+                    f"{self.MAX_SUPPRESSED_SUBJECTS} reached)"
+                )
+            body = body + "\n".join(note_lines)
+        return body
 
     def emit(self, record):
         """Send ``record`` by email unless still within the cooldown window."""
@@ -117,10 +149,13 @@ class TitledSMTPHandler(SMTPHandler):
                 and now - self._last_emit_monotonic < self.min_interval
             ):
                 self._suppressed_count += 1
+                if len(self._suppressed_subjects) < self.MAX_SUPPRESSED_SUBJECTS:
+                    self._suppressed_subjects.append(self._base_subject(record))
                 return
             self._last_emit_monotonic = now
         super().emit(record)
         self._suppressed_count = 0
+        self._suppressed_subjects = []
 
 
 class HTTPPostHandler(logging.Handler):


### PR DESCRIPTION
Two independent log-spam guards in `helao/helpers/helao_logging.py`.

## 1. Buffer suppressed alert subjects into next email body

`TitledSMTPHandler` throttles alert emails to one per `min_interval` seconds. Records arriving during the cooldown were dropped, retaining only a `_suppressed_count` decorating the next subject with `(+N suppressed)`.

Now the **subject line of each dropped record is buffered** and appended to the body of the next email that sends.

- Buffer capped at `MAX_SUPPRESSED_SUBJECTS = 100`.
- Past the cap, further records still drop but keep incrementing the count.
- Next outgoing body gets a `--- N alert(s) suppressed during cooldown ---` block listing buffered subjects, plus a `... (+M more not shown)` overflow note.
- Count and buffer reset after a successful send.

## 2. Collapse duplicate consecutive file-log lines

New `DedupTimedRotatingFileHandler` (subclass of `TimedRotatingFileHandler`). When a message — compared by raw `record.getMessage()` content, ignoring formatting — is immediately repeated, a cooldown opens: further identical records are counted, not written. The running count is flushed as one summary line (`... [previous message repeated N times]`) when either:

- a different message arrives, or
- `dedup_interval` elapses (detected lazily on the next `emit`, since handlers only act on emit).

Wired into `make_logger` via a new `dedup_interval` argument (`DEFAULT_DEDUP_INTERVAL = 10.0s`; `0` disables and restores stock behaviour). All existing `make_logger` callers keep working (default kwarg; subclass still satisfies `isinstance(TimedRotatingFileHandler)`).

## Verification

`helao.core.tests.unit_test_logging.logging_unit_test` — all 24 checks pass, including 7 new dedup cases (flush-on-new-message, repeat-count summary, state reset, `dedup_interval=0` passthrough, elapsed-cooldown flush) and the SMTP throttle checks. Run under the `helao` conda env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)