### PR TITLE
fix: WindowsSelectorEventLoopPolicy in launchers for zmq.asyncio

### DIFF
--- a/bokeh_launcher.py
+++ b/bokeh_launcher.py
@@ -39,11 +39,21 @@ __all__ = []
 
 import sys
 import os
+import asyncio
 from glob import glob
 from functools import partial
 from importlib import import_module
 from bokeh.server.server import Server
 import colorama
+
+# pyzmq's zmq.asyncio (helao.core.rpc.zmq_rpc) requires the add_reader event-loop
+# family, which the Windows Proactor loop (the default on Windows) does not
+# provide. Select the WindowsSelectorEventLoopPolicy before Bokeh/tornado creates
+# its loop so any co-located ZMQ RPC socket works without the RuntimeWarning and
+# the extra selector thread. Safe here: helao uses no asyncio subprocesses, and
+# tornado prefers the selector loop on Windows.
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 from helao.helpers import helao_logging as logging
 from helao.helpers import config_loader
 from helao.helpers.yml_tools import yml_load

--- a/fast_launcher.py
+++ b/fast_launcher.py
@@ -158,10 +158,20 @@ if __name__ == "__main__":
     LOGGING_CONFIG["formatters"]["access"]["use_colors"] = False
 
     LOGGER.info(f" ---- starting  {server_key} ----")
-    fastapp = uvicorn.run(
+    # Run uvicorn's server coroutine under asyncio.run() rather than
+    # uvicorn.run(). uvicorn.run() -> Server.run() feeds its own loop factory to
+    # asyncio (asyncio.ProactorEventLoop on Windows), which is instantiated
+    # directly and therefore ignores the event-loop policy set above. asyncio.run
+    # calls asyncio.new_event_loop(), which honors the policy, so the co-located
+    # zmq.asyncio RPC server gets the add_reader-capable selector loop it needs.
+    # Behavior is unchanged off Windows (new_event_loop yields the same loop type
+    # uvicorn's auto factory would have).
+    config = uvicorn.Config(
         app,
         host=server_config["host"],
         port=server_config["port"],
         log_level="warning",
         timeout_graceful_shutdown=5,
     )
+    server = uvicorn.Server(config)
+    asyncio.run(server.serve())

--- a/fast_launcher.py
+++ b/fast_launcher.py
@@ -32,11 +32,20 @@ __all__ = []
 
 import sys
 import os
+import asyncio
 from glob import glob
 from importlib import import_module
 from uvicorn.config import LOGGING_CONFIG
 import uvicorn
 import colorama
+
+# pyzmq's zmq.asyncio (helao.core.rpc.zmq_rpc) requires the add_reader event-loop
+# family, which the Windows Proactor loop (the default on Windows) does not
+# provide. Select the WindowsSelectorEventLoopPolicy before uvicorn creates its
+# loop so the co-located ZMQ RPC server works without the RuntimeWarning and the
+# extra tornado selector thread. Safe here: helao uses no asyncio subprocesses.
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
 from helao.helpers import helao_logging as logging

--- a/helao/core/servers/base_api.py
+++ b/helao/core/servers/base_api.py
@@ -125,9 +125,24 @@ def _build_action_from_kwargs(
                     f"critical error: found another Action BaseModel under parameter '{name}', skipping it"
                 )
     if action is None:
-        LOGGER.error(
-            "critical error: no Action BaseModel was found by setup_action, using blank Action."
-        )
+        if "action" in kwargs:
+            # An 'action' value was supplied by the caller but is not an Action
+            # instance (e.g. a malformed envelope that failed to rehydrate) --
+            # this is a genuine problem worth flagging loudly.
+            LOGGER.error(
+                "critical error: 'action' kwarg present but is not an Action "
+                "BaseModel, using blank Action."
+            )
+        else:
+            # No action envelope was supplied at all. This is expected for a
+            # tags=["action"] query endpoint (e.g. PAL 'list_new_samples')
+            # invoked via async_private_dispatcher over the ZMQ-RPC fast path,
+            # which does not synthesize FastAPI's Body({}) default. Such
+            # endpoints do not use the action machinery, so a blank Action is
+            # the correct benign fallback -- log it at debug, not error.
+            LOGGER.debug(
+                "no Action supplied to action-tagged endpoint; using blank Action."
+            )
         action = Action()
     else:
         LOGGER.info(f"found Action BaseModel under parameter '{seen_action_param}'")

--- a/helao/deploy/hte/servers/action/pal_server.py
+++ b/helao/deploy/hte/servers/action/pal_server.py
@@ -1665,7 +1665,7 @@ def makeApp(server_key) -> BaseAPI:
         finished_action = await active.finish()
         return finished_action.as_dict()
 
-    @app.post(f"/list_new_samples", tags=["action"])
+    @app.post(f"/list_new_samples", tags=["private"])
     async def list_new_samples(num_smps: int = 10, give_only: str = "false") -> dict:
         """List the most recent global sample labels from each local DB table.
 


### PR DESCRIPTION
## Problem
Every server launch on Windows emitted:
```
zmq/_future.py:718: RuntimeWarning: Proactor event loop does not implement add_reader family of methods required for zmq. Registering an additional selector thread for add_reader support via tornado. Use `asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())` to avoid this warning.
```
`zmq.asyncio` (used by `helao/core/rpc/zmq_rpc.py`) requires the `add_reader` event-loop family, absent from the Windows **Proactor** loop (Python's default on Windows). pyzmq worked around it by spawning an extra tornado selector thread per process, and warned each time.

## Root cause (why the first attempt failed)
Setting `WindowsSelectorEventLoopPolicy` alone did **not** fix uvicorn. `uvicorn.run()` → `Server.run()` passes `config.get_loop_factory()` to its own `asyncio_run`, and on Windows that factory returns `asyncio.ProactorEventLoop`, which is **instantiated directly**. A loop built by a factory bypasses `set_event_loop_policy` entirely — so the Proactor loop was still used and the warning persisted.

## Fix
Two parts, both guarded to Windows / no behavior change elsewhere:

1. **Policy** — set `WindowsSelectorEventLoopPolicy` at the top of both launchers (`fast_launcher.py`, `bokeh_launcher.py`), under `sys.platform == "win32"`.
2. **uvicorn loop** — replace `uvicorn.run(app, ...)` with an explicit `uvicorn.Config` + `uvicorn.Server(...).serve()` driven by `asyncio.run()`. `asyncio.run()` builds its loop via `asyncio.new_event_loop()`, which **honors** the policy — so the server runs on a `WindowsSelectorEventLoop` and the co-located `zmq.asyncio` RPC server gets `add_reader`.

Bokeh already honored the policy (its tornado `IOLoop` is created via `new_event_loop`), so `bokeh_launcher` needs only the policy line.

### Safety
- Selector loop's only functional loss vs Proactor is asyncio subprocess support — grep confirms helao uses no `create_subprocess_exec/shell`.
- tornado (Bokeh) prefers the selector loop on Windows anyway.
- No behavior change off Windows.

### Verification
- `py_compile` clean on both files.
- Confirmed empirically that `asyncio.run()` honors a set event-loop policy (returns the policy-built loop) while uvicorn's loop factory does not.
- Windows-only warning; not reproducible on the Linux dev box, but the loop-selection mechanism is verified above.

---

## Also in this PR: spurious "critical error" from an action-tagged query endpoint

**Symptom:**
```
PAL :: _build_action_from_kwargs @ base_api.py:128 - critical error: no Action BaseModel was found by setup_action, using blank Action.
```
logged on every action-visualizer refresh.

**Cause:** PAL's `list_new_samples` is a read-only query endpoint (no `Action` param, returns a dict of recent sample labels) invoked only by `pal_vis` via `async_private_dispatcher`. It was tagged `tags=["action"]`, so `ActionAPIRoute` wrapped it and injected an `action` envelope. Over the ZMQ-RPC fast path the wrapper received only the caller's kwargs (no `action`, since RPC doesn't synthesize FastAPI's `Body({})` default), so `_build_action_from_kwargs` found no Action and logged a critical error. (Over HTTP, FastAPI always injects the envelope, so that path never triggered it.)

**Fix (two layers):**
1. **Root cause** — retag `list_new_samples` `action` → `private` (matching the 143 other private endpoints). Verified repo-wide that no experiment or sequence dispatches it as an action. POST routes are mirrored into the RPC dispatcher regardless of tag (`server_api.py`), so it stays reachable over RPC and HTTP; only the action wrapping is dropped.
2. **Defense-in-depth** — `base_api._build_action_from_kwargs` now distinguishes a supplied-but-malformed `action` (keeps the loud error) from a simply-absent one (blank Action at `debug`), so any other mis-tagged/no-action endpoint won't spam errors. Verified all three cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)