### PR TITLE
feat: opt-in orchestrator queue restore via config + launcher --restore flag

### DIFF
--- a/fast_launcher.py
+++ b/fast_launcher.py
@@ -134,6 +134,15 @@ if __name__ == "__main__":
             )
     CONFIG["deployment"] = deployment
 
+    # Launcher CLI override: `--restore` forces orchestrators to import their
+    # saved queues on startup regardless of the config default. server_config is
+    # the same dict HelaoFastAPI exposes as server_cfg (CONFIG["servers"][key]),
+    # so mutating it here — before makeApp constructs the app — is visible to
+    # Orch.myinit's restore gate.
+    if "--restore" in sys.argv[3:] and server_config.get("group") == "orchestrator":
+        server_config["restore_queues_on_startup"] = True
+        LOGGER.info("--restore flag set; orchestrator will import saved queues.")
+
     makeApp = import_module(
         f"helao.deploy.{deployment}.servers.{server_config['group']}.{server_config['fast']}"
     ).makeApp

--- a/helao/core/servers/orch.py
+++ b/helao/core/servers/orch.py
@@ -223,7 +223,16 @@ class Orch(Base):
         self.heartbeat_monitor = asyncio.create_task(self.active_action_monitor())
         self.driver_monitor = asyncio.create_task(self.action_server_monitor())
 
-        # self.import_queues()
+        # Restore previously exported queues only when opted in, either via the
+        # per-server config key `restore_queues_on_startup: true` or the launcher
+        # CLI switch `--restore` (which sets that key for orchestrators). Left off
+        # by default so a stale STATES/queues.pck is never silently replayed.
+        if self.server_cfg.get("restore_queues_on_startup", False):
+            LOGGER.info(
+                "restore_queues_on_startup is set; importing saved queues from "
+                "STATES/queues.pck."
+            )
+            self.import_queues()
 
     # def endpoint_queues_init(self):
     #     """

--- a/launch.py
+++ b/launch.py
@@ -13,9 +13,11 @@ Usage:
     keyboard input.
 Example:
     To run the launcher, use the following command:
-    python launch.py <config_file> [extra_option]
+    python launch.py <config_file> [extra_option] [--restore]
     Where <config_file> is the path to the configuration file and [extra_option] is an optional argument for additional
-    launch options.
+    launch options. The optional --restore flag makes launched orchestrators
+    import their previously exported queues (STATES/queues.pck) on startup;
+    flags may appear anywhere on the command line.
 Note:
     This script requires the 'click', 'termcolor', 'pyfiglet', 'colorama', 'psutil', and 'requests' libraries.
 """
@@ -435,7 +437,7 @@ def wait_key():
     return keypress
 
 
-def launcher(confArg, confDict, helao_repo_root, extraopt=""):
+def launcher(confArg, confDict, helao_repo_root, extraopt="", restore=False):
     """
     Launches the Helao servers based on the provided configuration.
     Args:
@@ -443,6 +445,9 @@ def launcher(confArg, confDict, helao_repo_root, extraopt=""):
         confDict (dict): Dictionary containing the configuration details.
         helao_repo_root (str): Root directory of the Helao project.
         extraopt (str, optional): Additional options for launching. Defaults to "".
+        restore (bool, optional): When True, pass ``--restore`` to launched
+            orchestrators so they import their saved queues on startup. Defaults
+            to False.
     Raises:
         Exception: If the configuration is invalid.
         Exception: If a server cannot be started due to port conflicts.
@@ -520,6 +525,11 @@ def launcher(confArg, confDict, helao_repo_root, extraopt=""):
                         if group == "orchestrator":
                             pidd.orchServs.append(server)
                         cmd = ["python", "fast_launcher.py", confArg, server]
+                        if restore and group == "orchestrator":
+                            cmd.append("--restore")
+                            LAUNCH_LOGGER.info(
+                                f"{server} launched with --restore; will import saved queues."
+                            )
                         p = subprocess.Popen(cmd, cwd=helao_repo_root)
                         ppid = p.pid
                     elif codeKey == "bokeh":
@@ -590,7 +600,12 @@ def main():
         }
         print(branches)
     helao_repo_root = os.path.dirname(os.path.realpath(__file__))
-    confArg = sys.argv[1]
+    # Separate flags (e.g. --restore) from positional args so confArg and the
+    # optional extraopt are not shifted by a flag's position on the command line.
+    positional = [a for a in sys.argv[1:] if not a.startswith("--")]
+    cli_flags = [a for a in sys.argv[1:] if a.startswith("--")]
+    restore = "--restore" in cli_flags
+    confArg = positional[0]
     config = read_config(confArg)
 
     # Run the full unit-test suite only when the config opts in.
@@ -604,8 +619,8 @@ def main():
     helaodirs = helao_dirs(config, "launcher")
     get_ntp_time("time.nist.gov", os.path.join(helaodirs.log_root, "ntpLastSync.txt"))
 
-    if len(sys.argv) > 2:
-        extraopt = sys.argv[2]
+    if len(positional) > 1:
+        extraopt = positional[1]
     else:
         extraopt = ""
 
@@ -694,6 +709,7 @@ def main():
         confDict=config,
         helao_repo_root=helao_repo_root,
         extraopt=extraopt,
+        restore=restore,
     )
 
     def hotkey_msg():


### PR DESCRIPTION
## Background

Orchestrator startup queue restore was hardcoded off — the `import_queues()` call in `Orch.myinit` was commented out (`orch.py`) by commit `ecfe202c` ("fix: don't automatically import queues on startup"), which has a **bare body** and landed **~9 minutes** after the feature that added it (`7af6bdd1`). No documented correctness reason, and no config knob.

Investigation confirmed the **serialization round-trip is sound**: `export_queues`/`import_queues` preserve the full deques plus `active_experiment`, `active_sequence`, their `last_*` counterparts, `active_seq_exp_counter`, the uuid fields, `globalstatusmodel`, and all three histories with **no attribute loss** (verified against the real `Sequence`/`Experiment`/`Action` premodels through the exact zdeque + pickle mechanics). The only real hazard was the lack of a knob: an unconditional startup import would silently replay any stale `STATES/queues.pck`.

## Change

Parameterize it instead of leaving it disabled:

- **`Orch.myinit`** calls `import_queues()` only when the per-server config key `restore_queues_on_startup: true` is set. Default stays off, so no stale queue is ever replayed without an explicit opt-in.
- **`launch.py`** gains a `--restore` CLI flag. Flags are parsed separately from positional args, so it may appear anywhere on the command line without shifting `confArg`/`extraopt`. When set, the launcher appends `--restore` to the `fast_launcher` command for **orchestrator servers only**.
- **`fast_launcher.py`** honors `--restore` by setting `restore_queues_on_startup` on the orchestrator's `server_config` before `makeApp`. Since `HelaoFastAPI` exposes that same `CONFIG["servers"][key]` dict as `server_cfg`, the override reaches the `Orch.myinit` gate.

The manual `/import_queues` HTTP endpoint is unchanged.

## Usage

```
python launch.py <config> --restore          # restore queues for all orchestrators this launch
python launch.py <config> nolive --restore   # flag order-independent
```
or per-instrument, persistently, in the orchestrator's server config:
```yaml
restore_queues_on_startup: true
```

## Verification

- `python -m py_compile launch.py fast_launcher.py helao/core/servers/orch.py` — OK
- Round-trip attribute-integrity test against real premodels — no loss (Seq 33 / Exp 57 / Act 95 fields, `active_*` included, nested params intact)
- CLI flag/positional parsing, launcher orchestrator-only `--restore` append, and fast_launcher config override — all unit-checked
- Project unit suite (`run_unit_tests.py`) — `overall: PASS`

## Notes / follow-ups (not in this PR)

Minor pre-existing smells in `import_queues` worth a later cleanup: a dead `active_run_id = gen_uuid()` in the seq loop (immediately overwritten), and `globalstatusmodel` restored wholesale (a hardened path should clear stale active/errored refs). Independent of PR #180 (Linux process-kill fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)