### PR TITLE
feat: expose loaded-module maps for hot-reload (endpoint + bokeh snapshot)

### DIFF
--- a/bokeh_launcher.py
+++ b/bokeh_launcher.py
@@ -158,6 +158,25 @@ if __name__ == "__main__":
         log_root = os.path.join(root, "LOGS")
     else:
         log_root = None
+
+    # Hot-reload support: snapshot the modules this bokeh process imported so the
+    # launcher's watcher can map a changed file to this server. Bokeh apps expose
+    # no HTTP route, so unlike FastAPI servers (which serve /loaded_modules live)
+    # we persist a startup snapshot here. Refreshed on every (re)launch.
+    if root is not None:
+        try:
+            import json
+            from helao.helpers.loaded_modules import loaded_repo_modules
+
+            states_dir = os.path.join(root, "STATES")
+            os.makedirs(states_dir, exist_ok=True)
+            snap_path = os.path.join(states_dir, f"loaded_modules_{server_key}.json")
+            with open(snap_path, "w") as f:
+                json.dump(loaded_repo_modules(), f)
+            LOGGER.info(f"wrote loaded-modules snapshot: {snap_path}")
+        except Exception:
+            LOGGER.warning("failed to write loaded-modules snapshot", exc_info=True)
+
     LOGGER.info(f" ---- starting  {server_key} ----")
 
     bokehapp = Server(

--- a/helao/core/servers/base_api.py
+++ b/helao/core/servers/base_api.py
@@ -24,6 +24,7 @@ from typing_extensions import Annotated
 from helao.core.drivers.helao_driver import HelaoDriver, DriverPoller, DriverStatus
 from helao.helpers.eval import eval_val
 from helao.helpers.time_utils import gen_uuid
+from helao.helpers.loaded_modules import loaded_repo_modules
 from helao.core.servers.base import Base
 from helao.helpers.server_api import HelaoFastAPI
 from helao.helpers.premodels import Action
@@ -714,6 +715,18 @@ class BaseAPI(HelaoFastAPI):
         def get_config():
             """Return the world configuration dictionary."""
             return self.base.world_cfg
+
+        @self.post("/loaded_modules", tags=["private"])
+        def loaded_modules():
+            """Return {repo_file_path: sha1} for every module this server process
+            has imported from the repository (transitive closure via sys.modules).
+
+            The hot-reload watcher intersects a pulled commit's changed files with
+            this set to decide whether this server must restart, and uses the
+            hashes to confirm the on-disk file actually differs from what was
+            loaded. Pure read; safe to call anytime.
+            """
+            return loaded_repo_modules()
 
         @self.post("/get_status", tags=["private"])
         def get_status():

--- a/helao/helpers/loaded_modules.py
+++ b/helao/helpers/loaded_modules.py
@@ -1,0 +1,66 @@
+"""Runtime introspection of a HELAO server process's loaded source files.
+
+The hot-reload watcher needs to know which repository files a given server
+process actually imported (transitively) so it can map a changed file to the
+set of servers that must restart. HELAO resolves most imports dynamically (by
+config string) — ``fast_launcher``/``bokeh_launcher`` ``import_module`` calls,
+orchestrator ``experiment_libraries``/``sequence_libraries`` via
+``import_autolibs``, config-named drivers — so a static import graph would miss
+exactly the deployment code we most care about. Instead this reads the truth
+that is already present in the live process: ``sys.modules``.
+
+Only files under the repository root are reported (this includes nested
+``helao/deploy/*`` deployments, which live in-tree). Each file is hashed so the
+watcher can confirm an on-disk change actually differs from what the server
+loaded.
+"""
+
+import os
+import sys
+import hashlib
+from typing import Optional
+
+import helao
+
+# Repository root = parent of the top-level ``helao`` package directory. Derived
+# from the package location rather than cwd so it is correct regardless of where
+# a server was launched from.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(helao.__file__)))
+
+
+def _hash_file(path: str):
+    """Return the SHA-1 hex digest of the file at ``path``, or None if unreadable."""
+    try:
+        with open(path, "rb") as f:
+            return hashlib.sha1(f.read()).hexdigest()
+    except OSError:
+        return None
+
+
+def loaded_repo_modules(repo_root: Optional[str] = None) -> dict:
+    """Map each loaded repository ``.py`` file to its current on-disk SHA-1.
+
+    Args:
+        repo_root: Root directory to scope the scan to. Defaults to the detected
+            HELAO repository root.
+
+    Returns:
+        ``{absolute_file_path: sha1_hexdigest}`` for every module in
+        ``sys.modules`` whose ``__file__`` resolves under ``repo_root``. Files
+        that cannot be read at query time are skipped.
+    """
+    root = os.path.abspath(repo_root or _REPO_ROOT)
+    prefix = root + os.sep
+    out = {}
+    # snapshot values() first; importing during iteration would mutate sys.modules
+    for mod in list(sys.modules.values()):
+        f = getattr(mod, "__file__", None)
+        if not f:
+            continue
+        af = os.path.abspath(f)
+        if not af.startswith(prefix) or not af.endswith(".py"):
+            continue
+        digest = _hash_file(af)
+        if digest is not None:
+            out[af] = digest
+    return out


### PR DESCRIPTION
## Phase 2 hot-reload — PR-A (foundation, no behavior change)

Gives the future launcher watcher a **runtime-accurate** map of which repository files each server process actually imported, so a pulled commit's changed files can be mapped to the servers that must restart. Pure introspection — **no restart behavior is added here**.

### Why runtime, not static

HELAO resolves most imports dynamically — `fast_launcher`/`bokeh_launcher` `import_module` by config string, orchestrator `experiment_libraries`/`sequence_libraries` via `import_autolibs`, config-named drivers. A static import graph (AST/`modulefinder`) would miss exactly the deployment code we most want to hot-reload. Instead this reads the truth already present in each process: `sys.modules`.

### Changes

- **`helao/helpers/loaded_modules.py`** (new): `loaded_repo_modules()` returns `{abs_repo_file: sha1}` for every `sys.modules` entry whose `__file__` resolves under the repo root. Nested `helao/deploy/*` deployments are included (they live in-tree). Repo root is derived from the `helao` package location, not cwd. The hash lets the watcher confirm an on-disk change actually differs from what the server loaded.
- **`base_api.py`**: FastAPI servers (action, orchestrator) expose a private `POST /loaded_modules` returning that map live. Safe to call anytime; same trust boundary as `/get_status` / `/shutdown`.
- **`bokeh_launcher.py`**: bokeh servers (visualizer, operator) have no HTTP route surface, so they write `STATES/loaded_modules_<server_key>.json` at startup instead. Refreshed on every (re)launch.

### Verification

- `python -m py_compile helao/helpers/loaded_modules.py helao/core/servers/base_api.py bokeh_launcher.py fast_launcher.py` — OK
- `loaded_repo_modules()` maps 20 repo modules; every path under the repo root; every value a valid SHA-1; `premodels.py` present with hash matching on-disk
- Project unit suite (`run_unit_tests.py`) — `overall: PASS` (base_api endpoint-registration path exercised)

### Follow-ups (separate PRs)

- **PR-B** — extract a shared `restart_server()` helper from the CTRL-r hotkey body in `launch.py` (refactor).
- **PR-C** — git-pull watcher thread (parent + nested deploy repos) → affected-set intersection → per-role idle gate → reuse restart path; opt-in via config / `--hot-reload`.

Full design: `.omc/specs/deep-dive-hotreload-phase2.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)