### PR TITLE
feat(hexagon): P3a spec+cam canary harness (spec both tiers, cam openapi-only)

### DIFF
--- a/helao/deploy/hte/configs/cam.yml
+++ b/helao/deploy/hte/configs/cam.yml
@@ -1,0 +1,40 @@
+# STANDALONE cam_server canary config (P3a special-split, CAM). Mirrors
+# galil.yml/sample.yml's 2-server shape (one action server + one
+# action_visualizer) so an at-station openapi diff can compare legacy vs
+# hexagon like-for-like without pulling in the full eche10 station. CAM param
+# (axis_ip) is copied verbatim from eche10.yml's CAM block. This is the Axis IP
+# webcam (AxisCam, HTTP JPEG fetch -- NO vendor DLL, NO COM/gclib).
+#
+# OPENAPI-CANARY ONLY: there is no runtime golden-diff tier for cam. Its
+# acquire_image action writes per-frame timestamped JPEG files
+# (cam_NNNNNN_<%y%m%d.%H%M%S>.jpg) whose filenames and binary content both vary
+# run-to-run; the parity harness has no manifest-only lever to normalize a
+# per-frame-timestamped filename in the tree member set (normalize_name only
+# collapses the §5.1 dir/meta timestamp grammar, not arbitrary aux filenames),
+# so a byte-parity runtime diff would need harness code changes. The openapi
+# surface diff fully proves the makeActionApp route/schema factory parity,
+# which is the cut-over gate; this matches the dbpack/analysis openapi-only
+# precedent. AxisCam.connect() opens no network connection (returns success
+# unconditionally), so this canary boots and serves /openapi.json even without
+# the camera reachable -- a reachable camera is only needed to actually acquire
+# an image, which this canary never does.
+dummy: true
+simulation: true
+run_type: cam_server
+root: C:\INST_hlo
+servers:
+  CAM:
+    host: 127.0.0.1
+    port: 8013
+    group: action
+    fast: cam_server
+    params:
+      axis_ip: 192.168.200.210
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'CAM Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/camhex.yml
+++ b/helao/deploy/hte/configs/camhex.yml
@@ -1,0 +1,29 @@
+# HEXAGON CANARY for the cam_server station (P3a special-split). Copy of
+# cam.yml with `deployment: hexagon` flipping CAM (cam_server) and ACTVIS
+# (action_visualizer) onto the hexagon factory. cam.yml stays legacy for
+# rollback; the cut-over is ONLY the two `deployment: hexagon` keys. Ports/root/
+# params match cam.yml so the openapi surface diff compares like-for-like.
+# OPENAPI-CANARY ONLY (no runtime golden-diff tier for cam -- see cam.yml's
+# header for the full rationale).
+dummy: true
+simulation: true
+run_type: cam_server
+root: C:\INST_hlo
+servers:
+  CAM:
+    host: 127.0.0.1
+    port: 8013
+    group: action
+    fast: cam_server
+    deployment: hexagon
+    params:
+      axis_ip: 192.168.200.210
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'CAM Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/spec.yml
+++ b/helao/deploy/hte/configs/spec.yml
@@ -1,0 +1,35 @@
+# STANDALONE spec_server canary config (P3a special-split, SPEC). Mirrors
+# galil.yml/gamry.yml's 2-server shape (one action server + one
+# action_visualizer) so an at-station openapi/runtime golden diff can compare
+# legacy vs hexagon like-for-like without pulling in the full eche10 station
+# (ORCH, MOTOR, PSTAT, IO, SAMPLE, DB, CAM, KMOTOR). SPEC params (dev_num,
+# lib_path, n_pixels, start_margin, allow_no_sample) are copied verbatim from
+# eche10.yml's SPEC_T block so acquire_spec registers identically. This is the
+# SM303 spectrometer (vendor SPdbUSBm.dll via ctypes) -- WINDOWS-ONLY hardware;
+# the runtime golden diff requires the spectrometer attached (see
+# golden_capture_spec.py's docstring). The openapi canary only needs the
+# server to boot and serve /openapi.json.
+dummy: true
+simulation: true
+run_type: spec_server
+root: C:\INST_hlo
+servers:
+  SPEC:
+    host: 127.0.0.1
+    port: 8011
+    group: action
+    fast: spec_server
+    params:
+      dev_num: 0
+      lib_path: C:\Spectral Products\SM32ProForUSB\SDK Examples\DLL\x64\stdcall\SPdbUSBm.dll
+      n_pixels: 1024
+      start_margin: 5
+      allow_no_sample: true
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'SPEC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/specgold.yml
+++ b/helao/deploy/hte/configs/specgold.yml
@@ -1,0 +1,33 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of spec.yml used solely
+# by helao.hexagon.tests.smoke.golden_capture_spec / spec_diff.bat to capture
+# a runtime golden-master acquire_spec tree. The ONLY change from spec.yml is
+# `root:`, pointed at a dedicated throwaway path so the capture rig's
+# assert_fresh() has a clean tree to start from and production C:\INST_hlo
+# (real run data, DATABASE, USER_CONFIG calibration) is never touched. This is
+# a REAL-HARDWARE capture (see golden_capture_spec.py docstring) -- acquire_spec
+# reads a single spectrum (non-perturbing) but the SM303 spectrometer must be
+# attached for connect() to succeed and the capture to produce data.
+dummy: true
+simulation: true
+run_type: spec_server
+root: C:\INST_hlo_golden
+servers:
+  SPEC:
+    host: 127.0.0.1
+    port: 8011
+    group: action
+    fast: spec_server
+    params:
+      dev_num: 0
+      lib_path: C:\Spectral Products\SM32ProForUSB\SDK Examples\DLL\x64\stdcall\SPdbUSBm.dll
+      n_pixels: 1024
+      start_margin: 5
+      allow_no_sample: true
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'SPEC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/specgoldhex.yml
+++ b/helao/deploy/hte/configs/specgoldhex.yml
@@ -1,0 +1,38 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of spechex.yml (keeps
+# `deployment: hexagon` on SPEC + ACTVIS -- the hexagon side of the runtime
+# golden diff) used solely by helao.hexagon.tests.smoke.golden_capture_spec /
+# spec_diff.bat to capture a runtime golden-master acquire_spec tree. The ONLY
+# change from spechex.yml is `root:`, pointed at a dedicated throwaway path so
+# the capture rig's assert_fresh() has a clean tree to start from and
+# production C:\INST_hlo (real run data, DATABASE, USER_CONFIG calibration) is
+# never touched. Ports and params match specgold.yml so the capture-vs-capture
+# parity diff compares like-for-like. This is a REAL-HARDWARE capture (see
+# golden_capture_spec.py docstring) -- acquire_spec reads a single spectrum
+# (non-perturbing) but the SM303 spectrometer must be attached for connect() to
+# succeed and the capture to produce data.
+dummy: true
+simulation: true
+run_type: spec_server
+root: C:\INST_hlo_golden
+servers:
+  SPEC:
+    host: 127.0.0.1
+    port: 8011
+    group: action
+    fast: spec_server
+    deployment: hexagon
+    params:
+      dev_num: 0
+      lib_path: C:\Spectral Products\SM32ProForUSB\SDK Examples\DLL\x64\stdcall\SPdbUSBm.dll
+      n_pixels: 1024
+      start_margin: 5
+      allow_no_sample: true
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'SPEC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/spechex.yml
+++ b/helao/deploy/hte/configs/spechex.yml
@@ -1,0 +1,32 @@
+# HEXAGON CANARY for the spec_server station (P3a special-split). Copy of
+# spec.yml with `deployment: hexagon` flipping SPEC (spec_server) and ACTVIS
+# (action_visualizer) onto the hexagon factory -- run AT-STATION
+# (Windows/SPdbUSBm.dll). spec.yml stays legacy for rollback; the cut-over is
+# ONLY the two `deployment: hexagon` keys. Ports/root/params match spec.yml so
+# an on-station openapi/golden diff compares like-for-like.
+dummy: true
+simulation: true
+run_type: spec_server
+root: C:\INST_hlo
+servers:
+  SPEC:
+    host: 127.0.0.1
+    port: 8011
+    group: action
+    fast: spec_server
+    deployment: hexagon
+    params:
+      dev_num: 0
+      lib_path: C:\Spectral Products\SM32ProForUSB\SDK Examples\DLL\x64\stdcall\SPdbUSBm.dll
+      n_pixels: 1024
+      start_margin: 5
+      allow_no_sample: true
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'SPEC Visualizer'
+      launch_browser: true

--- a/helao/hexagon/tests/smoke/cam_canary.bat
+++ b/helao/hexagon/tests/smoke/cam_canary.bat
@@ -156,6 +156,23 @@ REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
 REM through a shared conhost.exe and close the main canary window.
 REM The match includes " --no-hot-reload" so prefix "cam" cannot match "camhex".
 powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the CAM server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18013) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (cam vs camhex) starts while a stale listener
+REM still owns 127.0.0.1:18013, the next launch's "Address in use" fallback
+REM fires and a dispatch_action RPC-first call would reach the STALE binder.
+REM (cam is openapi-only so it never dispatches an action, but the wait keeps
+REM the kill path uniform and prevents a stale binder leaking into any later
+REM run on these ports.) Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8013) or c(18013)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :cam_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:cam_ports_free
+if not "!RELEASED!"=="1" echo [canary] WARNING %PREFIX% ports 8013/18013 still bound after wait -- next launch may hit a stale RPC binder
 goto :eof
 
 REM ---------------------------------------------------------------------------

--- a/helao/hexagon/tests/smoke/cam_canary.bat
+++ b/helao/hexagon/tests/smoke/cam_canary.bat
@@ -1,0 +1,167 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Windows canary for the camhex hexagon cut-over: runtime /openapi.json diff.
+REM
+REM Launches the LEGACY cam group and the HEXAGON camhex group in turn, dumps
+REM each CAM server's live /openapi.json, and diffs them. An identical
+REM route/schema surface proves the hexagon makeActionApp factory produces a
+REM byte-parity action server for the cam_server (Axis IP webcam) cut-over
+REM target.
+REM
+REM OPENAPI-CANARY ONLY: there is no spec_diff.bat-style runtime golden diff for
+REM cam. Its acquire_image action writes per-frame timestamped JPEG files
+REM (cam_NNNNNN_<%%y%%m%%d.%%H%%M%%S>.jpg) whose filenames AND binary content
+REM both vary run-to-run; the parity harness has no manifest-only lever to
+REM normalize a per-frame-timestamped filename in the tree member set
+REM (normalize_name collapses only the §5.1 dir/meta timestamp grammar, not
+REM arbitrary aux filenames), so a byte-parity runtime diff would need harness
+REM code changes. The openapi surface diff fully proves the makeActionApp
+REM route/schema factory parity, which is the cut-over gate -- matching the
+REM dbpack/analysis openapi-only precedent.
+REM
+REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
+REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
+REM sequences to an orchestrator. camhex is a 2-server group (CAM@8013 +
+REM ACTVIS@5001) with NO orchestrator (mirrors galil_canary.bat exactly).
+REM
+REM Both configs share root C:\INST_hlo and ports 8013/5001, so they MUST run
+REM sequentially (this script does that) -- never launch both at once.
+REM NOTE: AxisCam.connect() opens no network connection (returns success
+REM unconditionally), so this canary boots and serves /openapi.json even without
+REM the camera reachable at axis_ip -- a reachable camera is only needed to
+REM actually acquire an image, which this canary never does.
+REM
+REM Usage: cam_canary.bat [root] [outdir]
+REM   root   default C:\INST_hlo   (must match the configs' root: key)
+REM   outdir default %TEMP%\cam_canary
+REM ---------------------------------------------------------------------------
+
+set "ROOT=%~1"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\cam_canary"
+
+REM Guard: refuse an unsafe root (drive/fs anchor, or a root that contains the
+REM code repo) BEFORE anything touches it. safe_root.py is the single choke
+REM point; %ROOT% is only ever used read-only in this script, but the check is
+REM defense in depth against a mis-set root: key. See safe_root.py.
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` is
+REM exempt (it runs in a separate child shell).
+call conda run -n helao python "%~dp0safe_root.py" check "%ROOT%"
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT -- root %ROOT% failed the safety guard; see message above
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+set "LEGACY_JSON=%OUTDIR%\cam_openapi.json"
+set "HEX_JSON=%OUTDIR%\camhex_openapi.json"
+
+call :run_one cam     "%LEGACY_JSON%" || goto :fail
+call :run_one camhex  "%HEX_JSON%"    || goto :fail
+
+echo.
+echo [canary] diffing openapi surfaces
+REM Persist diff output to a file too, so the result survives the window closing.
+call conda run -n helao python "%~dp0openapi_diff.py" "%LEGACY_JSON%" "%HEX_JSON%" > "%OUTDIR%\openapi_diff.txt" 2>&1
+set "DIFF_RC=!errorlevel!"
+type "%OUTDIR%\openapi_diff.txt"
+popd
+echo.
+if "%DIFF_RC%"=="0" (
+  echo [canary] PASS -- camhex openapi surface matches legacy cam> "%OUTDIR%\canary_result.txt"
+) else (
+  echo [canary] DIFFS FOUND rc=%DIFF_RC% -- see openapi_diff.txt> "%OUTDIR%\canary_result.txt"
+)
+type "%OUTDIR%\canary_result.txt"
+echo [canary] artifacts + result saved in: %OUTDIR%
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\canary_result.txt regardless.
+pause
+exit /b %DIFF_RC%
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = output json path
+set "PREFIX=%~1"
+set "OUTJSON=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_CANARY_%PREFIX%"
+
+echo.
+echo [canary] === %PREFIX% ===
+REM NEVER wipe %ROOT%. An openapi diff reads the live server's /openapi.json and
+REM produces no output tree, so no "fresh root" is needed. On a station %ROOT%
+REM (e.g. C:\INST_hlo) holds production RUN data, calibration matrices, and may
+REM contain the code repo itself -- deleting it is catastrophic and unrecoverable
+REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
+REM to locate the pid pickle for kill_group.py.
+
+echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [canary] waiting for CAM port 8013
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8013))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [canary] FAIL %PREFIX% port 8013 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [canary] fetching /openapi.json -> %OUTJSON%
+call conda run -n helao python -c "import urllib.request,sys; open(sys.argv[2],'wb').write(urllib.request.urlopen('http://127.0.0.1:8013/openapi.json',timeout=30).read())" x "%OUTJSON%"
+set "FETCH_RC=!errorlevel!"
+
+echo [canary] killing %PREFIX%
+call :kill_one
+
+if not "%FETCH_RC%"=="0" (
+  echo [canary] FAIL %PREFIX% openapi fetch rc=%FETCH_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the cam driver's shutdown() runs cleanly.
+REM AxisCam holds no persistent hardware handle (HTTP-per-frame), but this
+REM matches every other canary's kill sequence -- best-effort (server dies
+REM mid-response); then wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8013
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit the canary console.
+REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main canary window.
+REM The match includes " --no-hot-reload" so prefix "cam" cannot match "camhex".
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [canary] ABORTED -- a launch/fetch step failed; see logs in %OUTDIR%
+echo [canary] ABORTED -- see %PREFIX%.launch.log in %OUTDIR%> "%OUTDIR%\canary_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/golden_capture.py
+++ b/helao/hexagon/tests/smoke/golden_capture.py
@@ -262,7 +262,12 @@ def settle(
     poll_s: float = 2.0,
     timeout_s: float = 300.0,
 ) -> None:
-    """Wait for the run_OCV action to WRITE its -act.yml and FINISH, then settle.
+    """Wait for the dispatched action to WRITE its -act.yml and FINISH, then settle.
+
+    Shared by every golden_capture module (gamry run_OCV, galil query_positions,
+    sample get_loaded_positions, spec acquire_spec, ...) -- it is action-agnostic
+    (gates purely on -act.yml terminal status under ``root``), so messages here
+    name "the action" generically, not any one scenario's endpoint.
 
     NO orch/DB in this topology, AND a manual direct-POST action writes to
     RUNS_DIAG (base.py:1016) and never touches RUNS_ACTIVE -- so polling
@@ -305,9 +310,9 @@ def settle(
         time.sleep(poll_s)
     statuses = _act_status_map(root)
     raise TimeoutError(
-        f"{root}: run_OCV did not reach a terminal action_status after "
-        f"{timeout_s}s (statuses={statuses}). The action is stuck active or "
-        "never wrote -- check the launch/capture logs. Refusing to snapshot a "
+        f"{root}: the dispatched action did not reach a terminal action_status "
+        f"after {timeout_s}s (statuses={statuses}). The action is stuck active "
+        "or never wrote -- check the launch/capture logs. Refusing to snapshot a "
         "mid-flight tree."
     )
 

--- a/helao/hexagon/tests/smoke/golden_capture_spec.py
+++ b/helao/hexagon/tests/smoke/golden_capture_spec.py
@@ -1,0 +1,265 @@
+"""Runtime golden-diff capture for the spec_server hexagon canary (P3a
+special-split).
+
+*** DRIVES THE REAL SM303 SPECTROMETER. THIS IS NOT A SIMULATION. ***
+
+Like gamry/galil (and unlike sample), spec_server has NO sim/dummy data path:
+``SM303.__init__``/``connect`` (helao/deploy/hte/drivers/spec/
+spectral_products_driver.py) unconditionally loads the vendor ``SPdbUSBm.dll``
+via ctypes and configures the physical device, and ``spec_server.py``
+instantiates ``driver_classes=[SM303]`` unconditionally -- the config's
+``dummy``/``simulation`` YAML keys are cosmetic (banner color) for this canary
+only. So this capture rig is an AT-STATION, REAL-HARDWARE gate: the SM303
+spectrometer must be attached (Windows, vendor DLL present) for ``acquire_spec``
+to produce any data.
+
+``acquire_spec`` (``POST /SPEC/acquire_spec``) with ``duration_sec <= 0``
+acquires ONE spectrum (single-shot, non-perturbing -- it only reads the
+detector; it drives nothing) and enqueues it to the default data sink as a
+``.hlo``. That .hlo's body columns are ``epoch_s`` (wall clock), ``ch_0000``..
+``ch_<n_pixels-1>`` (per-pixel detector intensities), ``error_code`` and
+``peak_intensity`` -- ALL live/hardware-derived, none deterministic run-to-run.
+Their VALUES are therefore masked via the manifest's ``masked_hlo_columns``
+(structure, column presence, and the single-row count are still asserted). The
+``.hlo`` HEADER carries ``wl`` (the pixel->wavelength table, ``app.driver.pxwl``)
+which IS config/calibration-deterministic and is compared unmasked -- a real
+diff there is a genuine regression.
+
+Unlike gamry's ``run_OCV``, the ``acquire_spec`` endpoint writes NO data-derived
+summary value back into ``action_params`` (only ``acquire_spec_adv`` stashes
+``peak_intensity`` into params; ``acquire_spec`` does not), so ``-act.yml`` is
+fully deterministic (params = ``int_time_ms``/``duration_sec``) and NO
+``masked_meta_keys`` are needed. The only masking is the .hlo body columns.
+
+Standalone counterpart to ``harness.capture.snapshot_capture`` for the
+orch-less, db-less spec/spechex 2-server topology (SPEC@8011 + ACTVIS@5001 only
+-- no ORCH, no DB), mirroring galil/gamry's ``golden_capture[_galil].py`` (see
+those modules' docstrings for the full topology-gap rationale). The
+hardware-agnostic settle / anti-vacuous-guard logic (``settle``,
+``_run_artifacts``, ``_act_status_map``) and the production dispatch path
+(``dispatch_action``) are IMPORTED from ``golden_capture.py`` rather than
+re-implemented here; only the scenario-specific pieces (endpoint, masking,
+manifest notes) are new. ``golden_capture.py`` itself is NOT modified.
+
+Usage (AT-STATION, Windows, conda env ``helao``) -- ATTACH THE SPECTROMETER
+FIRST:
+
+    rmdir /s /q C:\\INST_hlo_golden               (or pick a fresh --root)
+    conda run -n helao python launch.py specgold --no-hot-reload
+    conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_spec ^
+        --config-prefix specgold --root C:\\INST_hlo_golden ^
+        --out C:\\golden\\spec
+
+then terminate the launch, point ``--root``/``--config-prefix`` at a FRESH
+throwaway root and ``specgoldhex``, capture again, and diff the two capture
+directories with ``harness.parity``. ``spec_diff.bat`` automates exactly this
+sequence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from harness import HARNESS_VERSION
+from harness.capture import assert_fresh, wait_for_server
+from harness.manifest import ProvenanceManifest
+from harness.treepass import PARITY_TOPS
+
+from helao.hexagon.tests.smoke.golden_capture import (
+    _act_status_map,
+    _run_artifacts,
+    dispatch_action,
+    settle,
+)
+
+SPEC_HOST, SPEC_PORT = "127.0.0.1", 8011
+
+SCENARIO = "GM-SPEC"
+
+# helao/hexagon/tests/smoke/golden_capture_spec.py -> repo root is 4 parents up
+# (matches safe_root.py's own _repo_root()).
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFIG_DIR = REPO_ROOT / "helao" / "deploy" / "hte" / "configs"
+
+# n_pixels from the SPEC config block (eche10.yml / spec*.yml). SM303.
+# acquire_spec_adv builds the data dict as {"epoch_s": ..., "ch_0000": ...,
+# ..., "ch_<N-1>": ..., "error_code": ..., "peak_intensity": ...}
+# (spectral_products_driver.py ~L307: retdict.update({f"ch_{i:04}": x ...})).
+N_PIXELS = 1024
+
+# ALL acquire_spec .hlo body columns are live/hardware-derived (raw detector
+# intensities + wall-clock epoch + data-derived peak/error), none seeded or
+# deterministic -- so their VALUES are masked for parity. Column presence and
+# the single-shot row count are still compared. The .hlo HEADER's `wl`
+# (pixel->wavelength table) is config/calibration-deterministic and is NOT
+# masked (a diff there is a real regression). Pattern "*.hlo" is safe: the only
+# .hlo any acquire_spec capture emits is this spectrum file.
+SPEC_HLO_COLUMNS = ["epoch_s", "error_code", "peak_intensity"] + [
+    f"ch_{i:04}" for i in range(N_PIXELS)
+]
+SPEC_MASKED_HLO_COLUMNS = {
+    "*.hlo": SPEC_HLO_COLUMNS,
+    "*.hlo.json*": SPEC_HLO_COLUMNS,
+}
+# Single-shot acquire (duration_sec <= 0) writes exactly ONE row on both sides
+# -- exact row-count match required (empty tolerance dict == 0).
+SPEC_HLO_ROW_COUNT_TOLERANCE: dict = {}
+# acquire_spec writes no data-derived value back into action_params (only
+# acquire_spec_adv does); -act.yml is fully deterministic -> nothing to mask.
+SPEC_ACT_YML_MASKED_META_KEYS: dict = {}
+
+
+def acquire_spec_action(
+    config_prefix: str, int_time_ms: int = 35, duration_sec: float = -1
+) -> dict:
+    """Run /SPEC/acquire_spec via ``async_action_dispatcher`` (production
+    action-dispatch path -- RPC then HTTP, full action envelope).
+
+    ``duration_sec <= 0`` acquires a single spectrum (non-perturbing: reads the
+    detector only, drives nothing). ``allow_no_sample: true`` in the SPEC config
+    means no ``fast_samples_in`` is required (the endpoint's ``Body([])``
+    default applies).
+    """
+    return dispatch_action(
+        config_prefix,
+        "SPEC",
+        "acquire_spec",
+        {"int_time_ms": int_time_ms, "duration_sec": duration_sec},
+        # single acquisition is quick, but leave headroom for the endpoint's
+        # trailing 1s dangling-data drain + finish().
+        timeout=60,
+    )
+
+
+def snapshot(
+    root: Path,
+    out_dir: Path,
+    config_prefix: str,
+    int_time_ms: int,
+    duration_sec: float,
+    notes: str = "",
+) -> Path:
+    """Copy PARITY_TOPS from ``root`` and write a provenance manifest.
+
+    Refuses to overwrite an existing ``out_dir``, matching
+    ``harness.capture.snapshot_capture`` / gamry's ``golden_capture.snapshot``.
+    """
+    root, out_dir = Path(root), Path(out_dir)
+    if out_dir.exists():
+        raise FileExistsError(
+            f"{out_dir} already exists; refusing to overwrite a capture"
+        )
+    # Anti-vacuous-pass guard (shared convention with gamry/galil/sample): an
+    # empty capture (no action output) compares to nothing and passes parity
+    # trivially. Require at least one -act.yml before writing anything.
+    acts, hlos = _run_artifacts(root)
+    if not acts:
+        raise RuntimeError(
+            f"{root} has no -act.yml to capture; refusing a vacuous capture "
+            "that would pass parity with 0 diffs. Check the launch/capture "
+            "logs -- the action may have errored or produced no output."
+        )
+    errored = [p for p, st in _act_status_map(root).items() if "errored" in st]
+    if errored:
+        print(
+            f"[golden_capture_spec] WARNING: {len(errored)} action(s) ERRORED "
+            f"and were still captured: {errored}. An errored run is NOT a valid "
+            "parity baseline. Check the -act.yml error fields and the SPEC log "
+            "before trusting a PASS."
+        )
+    if not hlos:
+        print(
+            f"[golden_capture_spec] WARNING: no .hlo captured under {root} -- "
+            "acquire_spec produced no spectrum data file. Parity will compare "
+            "-act.yml metadata only, NOT the hlo data-write path. Verify the "
+            "SM303 is attached and read_data returned a spectrum."
+        )
+    out_root = out_dir / "root"
+    out_root.mkdir(parents=True)
+    for top in PARITY_TOPS:
+        src = root / top
+        if src.is_dir():
+            shutil.copytree(src, out_root / top)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    config_path = CONFIG_DIR / f"{config_prefix}.yml"
+    combined_notes = (
+        "REAL-HARDWARE acquire_spec capture (SM303 spectrometer attached); NOT "
+        "a simulation -- SM303 has no sim/dummy data path. The .hlo body columns "
+        "epoch_s/ch_NNNN/error_code/peak_intensity are live detector data and "
+        "are masked via masked_hlo_columns so parity is a clean PASS when only "
+        "they differ; the .hlo header `wl` (pixel->wavelength table) is "
+        "config-deterministic and compared unmasked."
+    )
+    if notes:
+        combined_notes = f"{combined_notes} {notes}"
+    ProvenanceManifest(
+        scenario=SCENARIO,
+        config_prefix=config_prefix,
+        config_path=str(config_path),
+        legacy_git_sha=sha,
+        launch_cmd=f"conda run -n helao python launch.py {config_prefix} --no-hot-reload",
+        sequence_name="manual_acquire_spec",
+        sequence_params={
+            "manual": True,
+            "endpoint": "POST /SPEC/acquire_spec",
+            "int_time_ms": int_time_ms,
+            "duration_sec": duration_sec,
+            "fast_samples_in": [],
+        },
+        capture_timestamp=datetime.datetime.now().isoformat(timespec="seconds"),
+        harness_version=HARNESS_VERSION,
+        masked_hlo_columns=SPEC_MASKED_HLO_COLUMNS,
+        hlo_row_count_tolerance=SPEC_HLO_ROW_COUNT_TOLERANCE,
+        masked_meta_keys=SPEC_ACT_YML_MASKED_META_KEYS,
+        notes=combined_notes,
+    ).save(out_dir)
+    return out_dir
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m helao.hexagon.tests.smoke.golden_capture_spec",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--config-prefix", required=True)
+    parser.add_argument(
+        "--int-time-ms", type=int, default=35, help="int_time_ms (default 35)"
+    )
+    parser.add_argument(
+        "--duration-sec",
+        type=float,
+        default=-1,
+        help="duration_sec; <=0 acquires a single spectrum (default -1)",
+    )
+    parser.add_argument("--settle-polls", type=int, default=3)
+    parser.add_argument("--notes", default="")
+    args = parser.parse_args(argv)
+
+    assert_fresh(args.root)
+    wait_for_server(SPEC_HOST, SPEC_PORT)
+    acquire_spec_action(args.config_prefix, args.int_time_ms, args.duration_sec)
+    settle(args.root, settle_polls=args.settle_polls)
+    out = snapshot(
+        root=args.root,
+        out_dir=args.out,
+        config_prefix=args.config_prefix,
+        int_time_ms=args.int_time_ms,
+        duration_sec=args.duration_sec,
+        notes=args.notes,
+    )
+    print(f"captured {SCENARIO} -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/spec_canary.bat
+++ b/helao/hexagon/tests/smoke/spec_canary.bat
@@ -1,0 +1,161 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Windows canary for the spechex hexagon cut-over: runtime /openapi.json diff.
+REM
+REM Launches the LEGACY spec group and the HEXAGON spechex group in turn, dumps
+REM each SPEC server's live /openapi.json, and diffs them. An identical
+REM route/schema surface proves the hexagon makeActionApp factory produces a
+REM byte-parity action server for the spec_server (SM303 spectrometer) cut-over
+REM target.
+REM
+REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
+REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
+REM sequences to an orchestrator. spechex is a 2-server group (SPEC@8011 +
+REM ACTVIS@5001) with NO orchestrator, so the GM-* scenarios cannot drive it.
+REM The openapi diff is the topology-appropriate parity check (mirrors
+REM galil_canary.bat / gamryhex_canary.bat exactly). See spec_diff.bat for the
+REM runtime acquire_spec golden diff, the topology-appropriate DATA check.
+REM
+REM Both configs share root C:\INST_hlo and ports 8011/5001, so they MUST run
+REM sequentially (this script does that) -- never launch both at once.
+REM NOTE: spec.yml's simulation:true is cosmetic (banner color) -- SM303 has no
+REM sim/dummy data path (see golden_capture_spec.py). SM303.connect() loads the
+REM vendor SPdbUSBm.dll and configures the physical device at startup; the
+REM spectrometer should be attached so the server boots and serves
+REM /openapi.json (a data-producing action additionally requires it, see
+REM spec_diff.bat).
+REM
+REM Usage: spec_canary.bat [root] [outdir]
+REM   root   default C:\INST_hlo   (must match the configs' root: key)
+REM   outdir default %TEMP%\spec_canary
+REM ---------------------------------------------------------------------------
+
+set "ROOT=%~1"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\spec_canary"
+
+REM Guard: refuse an unsafe root (drive/fs anchor, or a root that contains the
+REM code repo) BEFORE anything touches it. safe_root.py is the single choke
+REM point; %ROOT% is only ever used read-only in this script, but the check is
+REM defense in depth against a mis-set root: key. See safe_root.py.
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` is
+REM exempt (it runs in a separate child shell).
+call conda run -n helao python "%~dp0safe_root.py" check "%ROOT%"
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT -- root %ROOT% failed the safety guard; see message above
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+set "LEGACY_JSON=%OUTDIR%\spec_openapi.json"
+set "HEX_JSON=%OUTDIR%\spechex_openapi.json"
+
+call :run_one spec     "%LEGACY_JSON%" || goto :fail
+call :run_one spechex  "%HEX_JSON%"    || goto :fail
+
+echo.
+echo [canary] diffing openapi surfaces
+REM Persist diff output to a file too, so the result survives the window closing.
+call conda run -n helao python "%~dp0openapi_diff.py" "%LEGACY_JSON%" "%HEX_JSON%" > "%OUTDIR%\openapi_diff.txt" 2>&1
+set "DIFF_RC=!errorlevel!"
+type "%OUTDIR%\openapi_diff.txt"
+popd
+echo.
+if "%DIFF_RC%"=="0" (
+  echo [canary] PASS -- spechex openapi surface matches legacy spec> "%OUTDIR%\canary_result.txt"
+) else (
+  echo [canary] DIFFS FOUND rc=%DIFF_RC% -- see openapi_diff.txt> "%OUTDIR%\canary_result.txt"
+)
+type "%OUTDIR%\canary_result.txt"
+echo [canary] artifacts + result saved in: %OUTDIR%
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\canary_result.txt regardless.
+pause
+exit /b %DIFF_RC%
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = output json path
+set "PREFIX=%~1"
+set "OUTJSON=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_CANARY_%PREFIX%"
+
+echo.
+echo [canary] === %PREFIX% ===
+REM NEVER wipe %ROOT%. An openapi diff reads the live server's /openapi.json and
+REM produces no output tree, so no "fresh root" is needed. On a station %ROOT%
+REM (e.g. C:\INST_hlo) holds production RUN data, calibration matrices, and may
+REM contain the code repo itself -- deleting it is catastrophic and unrecoverable
+REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
+REM to locate the pid pickle for kill_group.py.
+
+echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [canary] waiting for SPEC port 8011
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8011))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [canary] FAIL %PREFIX% port 8011 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [canary] fetching /openapi.json -> %OUTJSON%
+call conda run -n helao python -c "import urllib.request,sys; open(sys.argv[2],'wb').write(urllib.request.urlopen('http://127.0.0.1:8011/openapi.json',timeout=30).read())" x "%OUTJSON%"
+set "FETCH_RC=!errorlevel!"
+
+echo [canary] killing %PREFIX%
+call :kill_one
+
+if not "%FETCH_RC%"=="0" (
+  echo [canary] FAIL %PREFIX% openapi fetch rc=%FETCH_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the SM303 driver's shutdown() runs:
+REM SM303.shutdown() releases the vendor SPdbUSBm.dll device handle. A hard kill
+REM skips this and may leave the device claimed for the next launch --
+REM best-effort (server dies mid-response); then wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8011
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit the canary console.
+REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main canary window.
+REM The match includes " --no-hot-reload" so prefix "spec" cannot match "spechex".
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [canary] ABORTED -- a launch/fetch step failed; see logs in %OUTDIR%
+echo [canary] ABORTED -- see %PREFIX%.launch.log in %OUTDIR%> "%OUTDIR%\canary_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/spec_canary.bat
+++ b/helao/hexagon/tests/smoke/spec_canary.bat
@@ -150,6 +150,22 @@ REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
 REM through a shared conhost.exe and close the main canary window.
 REM The match includes " --no-hot-reload" so prefix "spec" cannot match "spechex".
 powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the SPEC server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18011) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (spec vs spechex) starts while a stale listener
+REM still owns 127.0.0.1:18011, the SPEC "Address in use" fallback fires AND a
+REM dispatch_action RPC-first call would reach the STALE binder -- the action is
+REM ACK'd but never runs on the live server, yielding an empty capture
+REM (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8011) or c(18011)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :spec_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:spec_ports_free
+if not "!RELEASED!"=="1" echo [canary] WARNING %PREFIX% ports 8011/18011 still bound after wait -- next launch may hit a stale RPC binder
 goto :eof
 
 REM ---------------------------------------------------------------------------

--- a/helao/hexagon/tests/smoke/spec_diff.bat
+++ b/helao/hexagon/tests/smoke/spec_diff.bat
@@ -193,6 +193,22 @@ REM cascade through a shared conhost.exe and close the main window.
 REM The match includes " --no-hot-reload" so "specgold" cannot match
 REM "specgoldhex" (no space follows "specgold" in that cmdline).
 powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the SPEC server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18011) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (specgold vs specgoldhex) -- or a preceding
+REM spec_canary run on the same ports -- leaves a stale listener owning
+REM 127.0.0.1:18011, a dispatch_action RPC-first call reaches the STALE binder:
+REM the action is ACK'd but never runs on the live server, yielding an empty
+REM capture (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8011) or c(18011)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :spec_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:spec_ports_free
+if not "!RELEASED!"=="1" echo [golden] WARNING %PREFIX% ports 8011/18011 still bound after wait -- next launch may hit a stale RPC binder
 goto :eof
 
 REM ---------------------------------------------------------------------------

--- a/helao/hexagon/tests/smoke/spec_diff.bat
+++ b/helao/hexagon/tests/smoke/spec_diff.bat
@@ -1,0 +1,204 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Runtime golden-diff driver for the spec_server hexagon canary (P3a
+REM special-split).
+REM
+REM *** DRIVES THE REAL SM303 SPECTROMETER (SINGLE READ, NON-PERTURBING). ***
+REM The SM303 spectrometer must be ATTACHED (Windows, vendor SPdbUSBm.dll
+REM present) before running this script. acquire_spec reads ONE spectrum off the
+REM detector -- it drives nothing -- but SM303.connect() still needs the live
+REM device to produce any data; see
+REM helao\hexagon\tests\smoke\golden_capture_spec.py's docstring.
+REM
+REM Launches specgold (legacy) then specgoldhex (hexagon), each against a FRESH
+REM throwaway root, drives one POST /SPEC/acquire_spec per launch via
+REM golden_capture_spec.py, snapshots the resulting RUNS tree, and diffs the two
+REM captures with harness.parity. Mirrors the conventions already proven in
+REM galil_diff.bat/golden_diff.bat (call conda / ping sleeps / cmdline-scoped
+REM Stop-Process / persisted results + pause) -- see those scripts for why
+REM harness.capture/parity_run.sh cannot drive this orch-less, db-less 2-server
+REM topology.
+REM
+REM Usage: spec_diff.bat [caproot] [outdir]
+REM   caproot default C:\INST_hlo_golden -- a DEDICATED THROWAWAY capture root,
+REM            fully wiped before EACH capture (see :wipe_caproot). NEVER point
+REM            this at C:\INST_hlo or any root holding real data.
+REM   outdir  default %TEMP%\spec_golden -- capture sets + parity report land
+REM            here (outdir\spec, outdir\spechex, outdir\parity-report.json,
+REM            outdir\golden_result.txt).
+REM ---------------------------------------------------------------------------
+
+set "CAPROOT=%~1"
+if "%CAPROOT%"=="" set "CAPROOT=C:\INST_hlo_golden"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\spec_golden"
+set "PROD_ROOT=C:\INST_hlo"
+
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates
+REM when conda.bat returns (silent exit). Only the conda inside
+REM `start ... cmd /c` (in :run_one below) is exempt -- it runs in a separate
+REM child shell.
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard; see message above
+  exit /b 2
+)
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- caproot equals production root %PROD_ROOT%; refusing to run
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+
+call :wipe_caproot || goto :fail
+call :run_one specgold    "%OUTDIR%\spec"    || goto :fail
+call :wipe_caproot || goto :fail
+call :run_one specgoldhex "%OUTDIR%\spechex" || goto :fail
+
+echo.
+echo [golden] running parity diff
+call conda run -n helao python -m harness.parity --golden "%OUTDIR%\spec" --candidate "%OUTDIR%\spechex" --report "%OUTDIR%\parity-report.json" > "%OUTDIR%\parity_stdout.txt" 2>&1
+set "PARITY_RC=!errorlevel!"
+type "%OUTDIR%\parity_stdout.txt"
+
+echo.
+echo [golden] full parity report (also saved to %OUTDIR%\parity-report.json):
+type "%OUTDIR%\parity-report.json"
+
+popd
+echo.
+REM The acquire_spec .hlo body columns (epoch_s / ch_NNNN / error_code /
+REM peak_intensity) are masked via the capture manifest's masked_hlo_columns
+REM (see golden_capture_spec.py) since they are live detector readings, not
+REM deterministic sim data -- so parity rc=0 is a genuine PASS and rc!=0 means a
+REM REAL hexagon-vs-legacy diff. The .hlo header `wl` (pixel->wavelength table)
+REM is config-deterministic and compared unmasked. The full report is printed
+REM and persisted above either way for inspection.
+if "%PARITY_RC%"=="0" (
+  (
+    echo [golden] PASS -- specgoldhex RUNS-tree matches legacy specgold ^(acquire_spec, masked^)
+    echo [golden] artifacts: %OUTDIR%\spec, %OUTDIR%\spechex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+) else (
+  (
+    echo [golden] DIFFS FOUND rc=%PARITY_RC% -- REAL regression, inspect the report
+    echo [golden] open %OUTDIR%\parity-report.json: tree_diffs / file_diffs list
+    echo [golden]   every differing member and key. The acquire_spec .hlo data
+    echo [golden]   columns are masked, so anything shown here is a genuine
+    echo [golden]   hexagon-vs-legacy difference.
+    echo [golden] artifacts: %OUTDIR%\spec, %OUTDIR%\spechex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+)
+type "%OUTDIR%\golden_result.txt"
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\golden_result.txt regardless.
+pause
+exit /b %PARITY_RC%
+
+REM ---------------------------------------------------------------------------
+:wipe_caproot
+REM Full-wipe the throwaway capture root before each capture -- required
+REM because golden_capture_spec.py's assert_fresh() refuses a root that already
+REM contains run artifacts. This rmdir is safe ONLY because %CAPROOT% just
+REM passed safe_root.py's check (repo not underneath it, not a drive/fs anchor)
+REM AND the equality guard below proves it is not production C:\INST_hlo -- it
+REM must NEVER run against a root that could hold real station data (run output,
+REM DATABASE, USER_CONFIG calibration matrices).
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- refusing to wipe production root %PROD_ROOT%
+  exit /b 2
+)
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard before wipe
+  exit /b 2
+)
+if exist "%CAPROOT%" (
+  echo [golden] wiping throwaway caproot %CAPROOT%
+  rmdir /s /q "%CAPROOT%"
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = capture out dir
+set "PREFIX=%~1"
+set "CAPOUT=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
+
+echo.
+echo [golden] === %PREFIX% ===
+echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [golden] waiting for SPEC port 8011
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8011))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [golden] FAIL %PREFIX% port 8011 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [golden] capturing acquire_spec -^> %CAPOUT%
+call conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_spec --config-prefix %PREFIX% --root "%CAPROOT%" --out "%CAPOUT%" > "%OUTDIR%\%PREFIX%.capture.log" 2>&1
+set "CAPTURE_RC=!errorlevel!"
+type "%OUTDIR%\%PREFIX%.capture.log"
+
+echo [golden] killing %PREFIX%
+call :kill_one
+REM Let the SM303 device handle release before the next launch reopens it --
+REM killing the python server does not instantly guarantee the vendor DLL
+REM released the device. ~5s margin between our two sequential captures.
+ping -n 6 -w 1000 127.0.0.1 >nul
+
+if not "%CAPTURE_RC%"=="0" (
+  echo [golden] FAIL %PREFIX% capture rc=%CAPTURE_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the SM303 driver's shutdown() runs:
+REM SM303.shutdown() releases the vendor SPdbUSBm.dll device handle. A hard kill
+REM skips this and may leave the device claimed for the next launch.
+REM Best-effort (server dies mid-response); then wait for release.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8011
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit this console.
+REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can
+REM cascade through a shared conhost.exe and close the main window.
+REM The match includes " --no-hot-reload" so "specgold" cannot match
+REM "specgoldhex" (no space follows "specgold" in that cmdline).
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [golden] ABORTED -- a launch/capture step failed; see logs in %OUTDIR%
+echo [golden] ABORTED -- see %OUTDIR%\*.launch.log / *.capture.log> "%OUTDIR%\golden_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/test_golden_capture_spec.py
+++ b/helao/hexagon/tests/smoke/test_golden_capture_spec.py
@@ -1,0 +1,218 @@
+"""Linux unit tests for golden_capture_spec.py's PURE logic (no server, no HTTP).
+
+Exercises only:
+  - the PARITY_TOPS snapshot copy + provenance.yml round-trip (``snapshot``)
+  - the masked-column set (epoch_s / ch_NNNN / error_code / peak_intensity are
+    masked; the deterministic header `wl` is NOT)
+  - the shared (gamry-authored, imported here) ``settle`` helper, applied to a
+    spec-shaped RUNS_DIAG tree
+
+The real-hardware POST to ``/SPEC/acquire_spec`` is NOT exercised here -- that
+only runs at-station with the SM303 attached (see golden_capture_spec.py /
+spec_diff.bat docstrings).
+
+Written as plain assert-based ``test_*`` functions with no ``import pytest``
+(mirrors test_golden_capture_galil.py -- this repo's conda ``helao`` env does
+not currently have the pytest package installed), so this module is runnable
+two ways:
+
+    conda run -n helao python -m pytest helao/hexagon/tests/smoke/test_golden_capture_spec.py -q
+    conda run -n helao python -m helao.hexagon.tests.smoke.test_golden_capture_spec
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from harness.manifest import ProvenanceManifest
+
+from helao.hexagon.tests.smoke.golden_capture import settle
+from helao.hexagon.tests.smoke.golden_capture_spec import (
+    N_PIXELS,
+    SCENARIO,
+    SPEC_HLO_COLUMNS,
+    SPEC_MASKED_HLO_COLUMNS,
+    snapshot,
+)
+
+
+def test_masked_columns_cover_all_live_channels_but_not_header_wl():
+    cols = set(SPEC_MASKED_HLO_COLUMNS["*.hlo"])
+    # every live/hardware-derived column is masked...
+    assert "epoch_s" in cols
+    assert "error_code" in cols
+    assert "peak_intensity" in cols
+    assert "ch_0000" in cols
+    assert f"ch_{N_PIXELS - 1:04}" in cols
+    # ...one per pixel, plus the three scalars
+    assert len(SPEC_HLO_COLUMNS) == N_PIXELS + 3
+    # the deterministic pixel->wavelength header key is NOT a masked body column
+    # (it lives in the .hlo HEADER and is compared unmasked -- a diff there is a
+    # real regression).
+    assert "wl" not in cols
+
+
+def test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_FINISHED" / "x").mkdir(parents=True)
+        (root / "RUNS_FINISHED" / "x" / "a-act.yml").write_text("file_type: action\n")
+        # include a .hlo too (the full happy path: metadata + spectrum file)
+        (root / "RUNS_FINISHED" / "x" / "acquire_spec-0.hlo").write_text(
+            "hlo_version: x\n%%\n"
+        )
+        (root / "LOGS").mkdir(parents=True)
+        (root / "LOGS" / "SPEC.log").write_text("not captured")
+
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="specgold",
+            int_time_ms=35,
+            duration_sec=-1,
+        )
+
+        assert (out / "root" / "RUNS_FINISHED" / "x" / "a-act.yml").exists()
+        assert not (out / "root" / "LOGS").exists()  # non-parity top excluded
+        assert (out / "provenance.yml").exists()
+
+        manifest = ProvenanceManifest.load(out)
+        assert manifest.scenario == SCENARIO
+        assert manifest.config_prefix == "specgold"
+        assert manifest.config_path.replace("\\", "/").endswith(
+            "helao/deploy/hte/configs/specgold.yml"
+        )
+        assert manifest.masked_hlo_columns == SPEC_MASKED_HLO_COLUMNS
+        # no data-derived summary lands in -act.yml for acquire_spec -> no
+        # meta-key masking
+        assert manifest.masked_meta_keys == {}
+
+
+def _write_action(root: Path, status: str = "finished", with_hlo: bool = True) -> Path:
+    """A RUNS_DIAG tree with one manual action -act.yml at ``status`` (+ .hlo)."""
+    d = root / "RUNS_DIAG" / "25.28" / "0716" / "0__0__SPEC__acquire_spec"
+    d.mkdir(parents=True)
+    (d / "250716.131421-act.yml").write_text(
+        f"file_type: action\naction_status:\n  - {status}\n"
+    )
+    if with_hlo:
+        (d / "acquire_spec-0.hlo").write_text("hlo_version: x\n%%\n")
+    return d
+
+
+def test_snapshot_refuses_to_overwrite_existing_out_dir():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="specgold",
+            int_time_ms=35,
+            duration_sec=-1,
+        )
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="specgold",
+                int_time_ms=35,
+                duration_sec=-1,
+            )
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError(
+                "snapshot() should refuse to overwrite an existing out_dir"
+            )
+
+
+def test_snapshot_refuses_empty_capture():
+    """The false-PASS guard: a root with no -act.yml/.hlo must NOT be captured
+    (an empty golden set compares to nothing and passes parity vacuously)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_DIAG").mkdir(parents=True)  # present but empty (no data)
+        out = Path(td) / "golden" / "run1"
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="specgold",
+                int_time_ms=35,
+                duration_sec=-1,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("snapshot() must refuse an empty (no-output) capture")
+        assert not out.exists()  # nothing written on refusal
+
+
+def test_settle_returns_once_action_artifacts_are_complete_and_stable():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        settle(root, settle_polls=2, poll_s=0.01, timeout_s=5.0)
+
+
+def test_settle_times_out_when_no_artifacts_are_written():
+    """The action never wrote output (errored / no data): settle must raise,
+    not silently return -- this is what prevents the empty-capture false PASS."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        root.mkdir()  # empty root, nothing ever written
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() should time out when no artifacts appear")
+
+
+def test_settle_does_not_return_while_action_active():
+    """-act.yml exists at init with status 'active' (base.py:1029). settle must
+    NOT return on file existence -- else it snapshots + kills the server
+    mid-acquisition."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="active", with_hlo=False)  # still running
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() must not return while status is 'active'")
+
+
+ALL_TESTS = [
+    test_masked_columns_cover_all_live_channels_but_not_header_wl,
+    test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance,
+    test_snapshot_refuses_to_overwrite_existing_out_dir,
+    test_snapshot_refuses_empty_capture,
+    test_settle_returns_once_action_artifacts_are_complete_and_stable,
+    test_settle_times_out_when_no_artifacts_are_written,
+    test_settle_does_not_return_while_action_active,
+]
+
+
+def main() -> int:
+    failures = 0
+    for fn in ALL_TESTS:
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 -- report every failure, keep going
+            failures += 1
+            print(f"FAIL {fn.__name__}: {exc}")
+        else:
+            print(f"PASS {fn.__name__}")
+    print(f"{len(ALL_TESTS) - failures}/{len(ALL_TESTS)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds the at-station hexagon cut-over canary harness for the **SPEC** (SM303 spectrometer) and **CAM** (Axis IP webcam) hte families — the two hardware families the current station covers. Continues the P3 hte hexagon migration (PR #188) on a fresh branch off `unstable`.

## Validated at-station (2026-07-19)
- `spec_canary.bat` ✅ — openapi surface parity (legacy `spec` vs hexagon `spechex`)
- `spec_diff.bat` ✅ — runtime `acquire_spec` golden diff on the real SM303
- `cam_canary.bat` ✅ — openapi surface parity (legacy `cam` vs hexagon `camhex`)

Plus Linux pre-checks: 7 spec unit tests green, all 6 configs pass offline preflight (hex variants confirm the spec/cam hexagon shims are complete).

## spec — both tiers (Windows / `SPdbUSBm.dll`, no sim path like gamry/galil)
- Configs: `spec.yml`/`spechex.yml` (SPEC@8011 + ACTVIS@5001) + `specgold.yml`/`specgoldhex.yml` (throwaway-root capture)
- `golden_capture_spec.py`: scenario `GM-SPEC` = single-shot `acquire_spec`. The `.hlo` body columns (`epoch_s` / `ch_0000..ch_1023` / `error_code` / `peak_intensity`) are live detector data and are masked via the manifest's `masked_hlo_columns`; the `.hlo` header `wl` (pixel→wavelength table) is config-deterministic and compared **unmasked**. `acquire_spec` writes no data-derived summary into `-act.yml`, so no `masked_meta_keys` needed.
- `test_golden_capture_spec.py`: 7 Linux unit tests (snapshot/provenance/settle + masked-column coverage).

## cam — openapi-only (Axis webcam / HTTP JPEG)
- Configs: `cam.yml`/`camhex.yml` (CAM@8013 + ACTVIS@5001)
- No runtime golden-diff tier: `acquire_image` writes per-frame timestamped JPEGs (`cam_NNNNNN_<%y%m%d.%H%M%S>.jpg`) whose filenames **and** bytes both vary run-to-run. The parity harness has no manifest-only lever to normalize a per-frame-timestamped filename in the tree member set, so a byte-parity runtime diff would need harness code changes (deferred follow-up). The openapi surface diff fully proves the `makeActionApp` route/schema factory parity — matching the dbpack/analysis openapi-only precedent.

## Stale-RPC-binder fix (found + fixed at-station)
First `spec_diff` run gave a false empty capture (`statuses={}`): a leftover SPEC process from the preceding `spec_canary` run still owned the co-located ZMQ RPC port 18011 (= HTTP 8011 + 10000), so `dispatch_action`'s RPC-first path hit the stale binder — it ACK'd while `acquire_spec` never ran on the live server. The three `.bat` kill paths now poll the action server's HTTP + RPC ports until released (~30s cap) before returning, so a canary→diff sequence can't leak a stale RPC listener. Also genericized the shared `settle()` "run_OCV" text (misleading for non-gamry callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)