### PR TITLE
feat(hexagon): cam runtime golden-diff tier + RE_CAM_IMG harness rule

### DIFF
--- a/harness/classify.py
+++ b/harness/classify.py
@@ -46,6 +46,14 @@ RE_SEQ_ZIPDIR = re.compile(r"^\d{6}(__.+)\.zipdir$")  # explode_zips target
 # treatment as the ``.zip``/``.zipdir`` pair above.
 RE_SEQ_ORIG = re.compile(r"^\d{6}(__.+)\.orig$")
 RE_SEQ_ORIGDIR = re.compile(r"^\d{6}(__.+)\.origdir$")  # explode_zips target
+# AxisCamExec.write_image (helao/deploy/hte/drivers/sensor/axiscam_driver.py)
+# names each frame ``cam_{counter:06}_{%y%m%d.%H%M%S}.jpg`` — the counter is
+# deterministic (0 for a one-shot) but the wall-clock ymdhms suffix is volatile
+# (§5.5), so two independent captures of the same acquire_image scenario would
+# otherwise land the JPEG at different tree paths (a spurious member-set diff
+# that content-masking cannot fix). Collapse ONLY the timestamp, keeping the
+# counter, so the frame identity is still compared: cam_000000_TS.jpg.
+RE_CAM_IMG = re.compile(r"^(cam_\d{6,})_\d{6}\.\d{6}\.jpg$")  # cam_N_%y%m%d.%H%M%S.jpg
 
 TOP_IGNORED = {"LOGS", "STATES", "DATABASE", "USER_CONFIG"}
 
@@ -79,6 +87,9 @@ def normalize_name(part: str) -> str:
     m = RE_SEQ_ORIGDIR.match(part)
     if m:
         return f"TS{m.group(1)}.origdir"
+    m = RE_CAM_IMG.match(part)
+    if m:
+        return f"{m.group(1)}_TS.jpg"
     m = RE_EXP_DIR.match(part)
     if m:
         return f"TS{m.group(1)}"

--- a/harness/tests/test_classify.py
+++ b/harness/tests/test_classify.py
@@ -63,3 +63,24 @@ def test_classify_rows():
     assert classify_file("RUNS_FINISHED/a/extra_output.csv") is ArtifactRow.AUX_FILE
     assert classify_file("LOGS/ORCH.log") is ArtifactRow.IGNORE
     assert classify_file("STATES/pids_golden_.pck") is ArtifactRow.IGNORE
+
+
+def test_normalize_cam_image_strips_only_the_wall_clock_suffix():
+    # AxisCamExec frame: cam_{counter:06}_{%y%m%d.%H%M%S}.jpg. The counter is
+    # kept (real frame identity, deterministic across captures); only the
+    # volatile ymdhms suffix collapses to TS.
+    assert normalize_name("cam_000000_260719.220107.jpg") == "cam_000000_TS.jpg"
+    assert normalize_name("cam_000005_251231.000000.jpg") == "cam_000005_TS.jpg"
+    # a longer counter (>=1e6 frames) still normalizes (the {:06} pad is a floor)
+    assert normalize_name("cam_1000000_260719.220107.jpg") == "cam_1000000_TS.jpg"
+    # a .jpg that is NOT the cam-frame grammar is left untouched (AUX_FILE stays
+    # compared by name) -- the rule is anchored, not a blanket "*.jpg" strip.
+    assert normalize_name("snapshot.jpg") == "snapshot.jpg"
+    assert normalize_name("cam_result.jpg") == "cam_result.jpg"
+    # it participates in the full relpath walk like any other element
+    assert (
+        normalize_relpath(
+            "RUNS_DIAG/25.28/0716/0__0__CAM__acquire_image/cam_000000_260719.220107.jpg"
+        )
+        == "RUNS_DIAG/YY.WW/MMDD/0__0__CAM__acquire_image/cam_000000_TS.jpg"
+    )

--- a/harness/tests/test_yaml_pass.py
+++ b/harness/tests/test_yaml_pass.py
@@ -211,3 +211,32 @@ def test_apply_meta_key_mask_absent_is_noop_presence_still_diffs():
     g2 = {"other": 1}
     apply_meta_key_mask(g2, ["action_params.has_bubble"])
     assert g2 == {"other": 1}
+
+
+def test_file_name_values_get_the_name_grammar_treatment():
+    # A FileInfo.file_name inside an -act.yml `files` entry is a bare basename
+    # (os.path.basename). A timestamped cam frame normalizes identically on both
+    # sides so the -act.yml diff is clean; the volatile ymdhms is collapsed but
+    # the deterministic frame counter is kept.
+    m = UuidMapper()
+    out = normalize_meta(
+        {
+            "files": [
+                {"file_name": "cam_000000_260719.220107.jpg", "file_type": "webcam"}
+            ]
+        },
+        m,
+    )
+    assert out == {"files": [{"file_name": "cam_000000_TS.jpg", "file_type": "webcam"}]}
+    # two independent captures (different wall clock) normalize to the SAME thing
+    a = normalize_meta({"file_name": "cam_000000_260719.220107.jpg"}, UuidMapper())
+    b = normalize_meta({"file_name": "cam_000000_991231.010203.jpg"}, UuidMapper())
+    assert a == b == {"file_name": "cam_000000_TS.jpg"}
+
+
+def test_deterministic_file_names_pass_through_unchanged():
+    # No-regression guard: an ordinary <label>-<idx>.hlo file_name matches no
+    # §5.1 grammar rule, so it is untouched (only the cam-frame grammar is new).
+    m = UuidMapper()
+    out = normalize_meta({"file_name": "WsSim-0.0.0.0__0.hlo"}, m)
+    assert out == {"file_name": "WsSim-0.0.0.0__0.hlo"}

--- a/harness/yaml_pass.py
+++ b/harness/yaml_pass.py
@@ -35,7 +35,7 @@ from typing import Any, List, Optional, Union
 
 from helao.helpers.yml_tools import yml_load
 
-from harness.classify import normalize_relpath
+from harness.classify import normalize_name, normalize_relpath
 from harness.uuidmap import UuidMapper
 
 # --- §5.5 volatile lists (exhaustive; keep in lockstep with the spec) ------
@@ -55,6 +55,14 @@ DROP_EXACT_KEYS = {
 }
 HOST_EXACT_KEYS = {"orch_key", "orch_host", "orch_port", "machine_name"}
 OUTPUT_DIR_KEY_SUFFIX = "_output_dir"
+# §5.5: FileInfo.file_name (in an -act.yml `files` entry) is
+# os.path.basename(file_path) — a single path element that may carry a volatile
+# wall-clock component (e.g. AxisCamExec's cam_NNNNNN_<%y%m%d.%H%M%S>.jpg).
+# Route it through the §5.1 name grammar (normalize_name) so timestamped frame
+# filenames normalize identically on both sides; deterministic basenames (the
+# common case: <label>-<idx>.hlo) match no grammar rule and pass through
+# unchanged, so this is a no-op for every existing scenario.
+FILENAME_KEYS = {"file_name"}
 # §5.5 ordering hazards: sort by a stable key before diffing.
 SORT_LIST_KEYS = {
     "dispatched_actions_abbr",
@@ -146,6 +154,8 @@ def normalize_meta(
         s = mapper.sub(obj)
         if key is not None and key.endswith(OUTPUT_DIR_KEY_SUFFIX):
             s = normalize_relpath(s)
+        elif key in FILENAME_KEYS:
+            s = normalize_name(s)
         return s
     return obj
 

--- a/helao/deploy/hte/configs/cam.yml
+++ b/helao/deploy/hte/configs/cam.yml
@@ -1,23 +1,20 @@
 # STANDALONE cam_server canary config (P3a special-split, CAM). Mirrors
 # galil.yml/sample.yml's 2-server shape (one action server + one
-# action_visualizer) so an at-station openapi diff can compare legacy vs
-# hexagon like-for-like without pulling in the full eche10 station. CAM param
-# (axis_ip) is copied verbatim from eche10.yml's CAM block. This is the Axis IP
-# webcam (AxisCam, HTTP JPEG fetch -- NO vendor DLL, NO COM/gclib).
+# action_visualizer) so an at-station openapi/runtime golden diff can compare
+# legacy vs hexagon like-for-like without pulling in the full eche10 station.
+# CAM param (axis_ip) is copied verbatim from eche10.yml's CAM block. This is
+# the Axis IP webcam (AxisCam, HTTP JPEG fetch -- NO vendor DLL, NO COM/gclib).
 #
-# OPENAPI-CANARY ONLY: there is no runtime golden-diff tier for cam. Its
-# acquire_image action writes per-frame timestamped JPEG files
-# (cam_NNNNNN_<%y%m%d.%H%M%S>.jpg) whose filenames and binary content both vary
-# run-to-run; the parity harness has no manifest-only lever to normalize a
-# per-frame-timestamped filename in the tree member set (normalize_name only
-# collapses the §5.1 dir/meta timestamp grammar, not arbitrary aux filenames),
-# so a byte-parity runtime diff would need harness code changes. The openapi
-# surface diff fully proves the makeActionApp route/schema factory parity,
-# which is the cut-over gate; this matches the dbpack/analysis openapi-only
-# precedent. AxisCam.connect() opens no network connection (returns success
-# unconditionally), so this canary boots and serves /openapi.json even without
-# the camera reachable -- a reachable camera is only needed to actually acquire
-# an image, which this canary never does.
+# TWO TIERS (as of the RE_CAM_IMG harness rule): cam_canary.bat does the
+# /openapi.json surface diff (this config + camhex.yml); cam_diff.bat does the
+# runtime acquire_image golden diff (camgold.yml/camgoldhex.yml).
+# AxisCam.connect() opens no network connection (returns success
+# unconditionally), so the openapi canary boots and serves /openapi.json even
+# without the camera reachable; the runtime diff DOES need the camera reachable
+# at axis_ip (it fetches one frame). The runtime diff is possible because
+# harness.classify.normalize_name collapses the volatile
+# cam_NNNNNN_<%y%m%d.%H%M%S>.jpg frame timestamp to cam_NNNNNN_TS.jpg on both
+# sides; see golden_capture_cam.py for the full masking rationale.
 dummy: true
 simulation: true
 run_type: cam_server

--- a/helao/deploy/hte/configs/camgold.yml
+++ b/helao/deploy/hte/configs/camgold.yml
@@ -1,0 +1,28 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of cam.yml used solely by
+# helao.hexagon.tests.smoke.golden_capture_cam / cam_diff.bat to capture a
+# runtime golden-master acquire_image tree. The ONLY change from cam.yml is
+# `root:`, pointed at a dedicated throwaway path so the capture rig's
+# assert_fresh() has a clean tree to start from and production C:\INST_hlo (real
+# run data, DATABASE, USER_CONFIG calibration) is never touched. This is a
+# REAL-HARDWARE capture (see golden_capture_cam.py docstring) -- acquire_image
+# fetches one live JPEG frame, so the Axis webcam must be reachable at axis_ip.
+dummy: true
+simulation: true
+run_type: cam_server
+root: C:\INST_hlo_golden
+servers:
+  CAM:
+    host: 127.0.0.1
+    port: 8013
+    group: action
+    fast: cam_server
+    params:
+      axis_ip: 192.168.200.210
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'CAM Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/camgoldhex.yml
+++ b/helao/deploy/hte/configs/camgoldhex.yml
@@ -1,0 +1,33 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of camhex.yml (keeps
+# `deployment: hexagon` on CAM + ACTVIS -- the hexagon side of the runtime
+# golden diff) used solely by helao.hexagon.tests.smoke.golden_capture_cam /
+# cam_diff.bat to capture a runtime golden-master acquire_image tree. The ONLY
+# change from camhex.yml is `root:`, pointed at a dedicated throwaway path so
+# the capture rig's assert_fresh() has a clean tree to start from and production
+# C:\INST_hlo (real run data, DATABASE, USER_CONFIG calibration) is never
+# touched. Ports and params match camgold.yml so the capture-vs-capture parity
+# diff compares like-for-like. This is a REAL-HARDWARE capture (see
+# golden_capture_cam.py docstring) -- acquire_image fetches one live JPEG frame,
+# so the Axis webcam must be reachable at axis_ip.
+dummy: true
+simulation: true
+run_type: cam_server
+root: C:\INST_hlo_golden
+servers:
+  CAM:
+    host: 127.0.0.1
+    port: 8013
+    group: action
+    fast: cam_server
+    deployment: hexagon
+    params:
+      axis_ip: 192.168.200.210
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'CAM Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/camhex.yml
+++ b/helao/deploy/hte/configs/camhex.yml
@@ -3,8 +3,8 @@
 # (action_visualizer) onto the hexagon factory. cam.yml stays legacy for
 # rollback; the cut-over is ONLY the two `deployment: hexagon` keys. Ports/root/
 # params match cam.yml so the openapi surface diff compares like-for-like.
-# OPENAPI-CANARY ONLY (no runtime golden-diff tier for cam -- see cam.yml's
-# header for the full rationale).
+# TWO TIERS -- see cam.yml's header (openapi via cam_canary.bat, runtime
+# acquire_image golden diff via cam_diff.bat + camgold/camgoldhex).
 dummy: true
 simulation: true
 run_type: cam_server

--- a/helao/hexagon/tests/smoke/cam_canary.bat
+++ b/helao/hexagon/tests/smoke/cam_canary.bat
@@ -9,16 +9,13 @@ REM route/schema surface proves the hexagon makeActionApp factory produces a
 REM byte-parity action server for the cam_server (Axis IP webcam) cut-over
 REM target.
 REM
-REM OPENAPI-CANARY ONLY: there is no spec_diff.bat-style runtime golden diff for
-REM cam. Its acquire_image action writes per-frame timestamped JPEG files
-REM (cam_NNNNNN_<%%y%%m%%d.%%H%%M%%S>.jpg) whose filenames AND binary content
-REM both vary run-to-run; the parity harness has no manifest-only lever to
-REM normalize a per-frame-timestamped filename in the tree member set
-REM (normalize_name collapses only the §5.1 dir/meta timestamp grammar, not
-REM arbitrary aux filenames), so a byte-parity runtime diff would need harness
-REM code changes. The openapi surface diff fully proves the makeActionApp
-REM route/schema factory parity, which is the cut-over gate -- matching the
-REM dbpack/analysis openapi-only precedent.
+REM TWO TIERS: this script does the /openapi.json surface diff; cam_diff.bat does
+REM the runtime acquire_image golden diff (camgold/camgoldhex). The runtime tier
+REM became possible with harness.classify.normalize_name's cam-frame grammar rule
+REM (RE_CAM_IMG): it collapses the volatile cam_NNNNNN_<%%y%%m%%d.%%H%%M%%S>.jpg
+REM frame timestamp to cam_NNNNNN_TS.jpg so two captures' JPEGs land at the same
+REM normalized tree member; the .jpg bytes are content-masked and the .hlo
+REM epoch_s/filename columns value-masked (see golden_capture_cam.py).
 REM
 REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
 REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
@@ -30,7 +27,8 @@ REM sequentially (this script does that) -- never launch both at once.
 REM NOTE: AxisCam.connect() opens no network connection (returns success
 REM unconditionally), so this canary boots and serves /openapi.json even without
 REM the camera reachable at axis_ip -- a reachable camera is only needed to
-REM actually acquire an image, which this canary never does.
+REM actually acquire an image, which this openapi canary never does (cam_diff.bat
+REM does, and needs the camera).
 REM
 REM Usage: cam_canary.bat [root] [outdir]
 REM   root   default C:\INST_hlo   (must match the configs' root: key)
@@ -159,12 +157,11 @@ powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $
 REM 3) WAIT for the CAM server's HTTP + co-located ZMQ RPC ports (RPC =
 REM HTTP+10000 = 18013) to actually RELEASE before returning. The RPC listener
 REM is a thread inside the server process and lives as long as the process does;
-REM if the next sequential launch (cam vs camhex) starts while a stale listener
-REM still owns 127.0.0.1:18013, the next launch's "Address in use" fallback
-REM fires and a dispatch_action RPC-first call would reach the STALE binder.
-REM (cam is openapi-only so it never dispatches an action, but the wait keeps
-REM the kill path uniform and prevents a stale binder leaking into any later
-REM run on these ports.) Poll both ports until free (~30s cap).
+REM if the next sequential launch (cam vs camhex, or a following cam_diff.bat run
+REM on the same ports) starts while a stale listener still owns 127.0.0.1:18013,
+REM the next launch's "Address in use" fallback fires and a dispatch_action
+REM RPC-first call would reach the STALE binder -- yielding an empty capture
+REM (the at-station spec failure mode). Poll both ports until free (~30s cap).
 set "RELEASED=0"
 for /l %%i in (1,1,30) do (
   call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8013) or c(18013)) else 0)" 2>nul

--- a/helao/hexagon/tests/smoke/cam_diff.bat
+++ b/helao/hexagon/tests/smoke/cam_diff.bat
@@ -1,0 +1,217 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Runtime golden-diff driver for the cam_server hexagon canary (P3a
+REM special-split).
+REM
+REM *** DRIVES THE REAL AXIS WEBCAM (fetches one live JPEG frame). ***
+REM The Axis webcam must be REACHABLE at axis_ip before running this script.
+REM acquire_image (duration=0) fetches ONE frame; see
+REM helao\hexagon\tests\smoke\golden_capture_cam.py's docstring.
+REM
+REM Launches camgold (legacy) then camgoldhex (hexagon), each against a FRESH
+REM throwaway root, drives one POST /CAM/acquire_image per launch via
+REM golden_capture_cam.py, snapshots the resulting RUNS tree, and diffs the two
+REM captures with harness.parity. Mirrors spec_diff.bat/galil_diff.bat exactly
+REM (call conda / ping sleeps / cmdline-scoped Stop-Process / RPC-port-release
+REM wait / persisted results + pause).
+REM
+REM cam's runtime diff is possible because harness.classify.normalize_name has a
+REM cam-frame grammar rule (RE_CAM_IMG) that collapses the volatile
+REM cam_NNNNNN_<%%y%%m%%d.%%H%%M%%S>.jpg timestamp to cam_NNNNNN_TS.jpg on both
+REM sides; the .jpg bytes are content-masked "skip" and the .hlo epoch_s/filename
+REM columns are value-masked (see golden_capture_cam.py). Without that rule the
+REM two captures' JPEGs would land at different tree members (spurious fail).
+REM
+REM Usage: cam_diff.bat [caproot] [outdir]
+REM   caproot default C:\INST_hlo_golden -- a DEDICATED THROWAWAY capture root,
+REM            fully wiped before EACH capture (see :wipe_caproot). NEVER point
+REM            this at C:\INST_hlo or any root holding real data.
+REM   outdir  default %TEMP%\cam_golden -- capture sets + parity report land
+REM            here (outdir\cam, outdir\camhex, outdir\parity-report.json,
+REM            outdir\golden_result.txt).
+REM ---------------------------------------------------------------------------
+
+set "CAPROOT=%~1"
+if "%CAPROOT%"=="" set "CAPROOT=C:\INST_hlo_golden"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\cam_golden"
+set "PROD_ROOT=C:\INST_hlo"
+
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` (in
+REM :run_one below) is exempt -- it runs in a separate child shell.
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard; see message above
+  exit /b 2
+)
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- caproot equals production root %PROD_ROOT%; refusing to run
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+
+call :wipe_caproot || goto :fail
+call :run_one camgold    "%OUTDIR%\cam"    || goto :fail
+call :wipe_caproot || goto :fail
+call :run_one camgoldhex "%OUTDIR%\camhex" || goto :fail
+
+echo.
+echo [golden] running parity diff
+call conda run -n helao python -m harness.parity --golden "%OUTDIR%\cam" --candidate "%OUTDIR%\camhex" --report "%OUTDIR%\parity-report.json" > "%OUTDIR%\parity_stdout.txt" 2>&1
+set "PARITY_RC=!errorlevel!"
+type "%OUTDIR%\parity_stdout.txt"
+
+echo.
+echo [golden] full parity report (also saved to %OUTDIR%\parity-report.json):
+type "%OUTDIR%\parity-report.json"
+
+popd
+echo.
+REM The .jpg frame bytes are content-masked "skip" and the .hlo epoch_s/filename
+REM columns are value-masked via the capture manifest (see golden_capture_cam.py);
+REM the .jpg tree path + -act.yml file_name normalize via the RE_CAM_IMG grammar
+REM rule -- so parity rc=0 is a genuine PASS and rc!=0 means a REAL
+REM hexagon-vs-legacy diff. The full report is printed and persisted above either
+REM way for inspection.
+if "%PARITY_RC%"=="0" (
+  (
+    echo [golden] PASS -- camgoldhex RUNS-tree matches legacy camgold ^(acquire_image, masked^)
+    echo [golden] artifacts: %OUTDIR%\cam, %OUTDIR%\camhex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+) else (
+  (
+    echo [golden] DIFFS FOUND rc=%PARITY_RC% -- REAL regression, inspect the report
+    echo [golden] open %OUTDIR%\parity-report.json: tree_diffs / file_diffs list
+    echo [golden]   every differing member and key. The .jpg bytes + .hlo data
+    echo [golden]   columns are masked and the frame filename is grammar-
+    echo [golden]   normalized, so anything shown here is a genuine
+    echo [golden]   hexagon-vs-legacy difference.
+    echo [golden] artifacts: %OUTDIR%\cam, %OUTDIR%\camhex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+)
+type "%OUTDIR%\golden_result.txt"
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\golden_result.txt regardless.
+pause
+exit /b %PARITY_RC%
+
+REM ---------------------------------------------------------------------------
+:wipe_caproot
+REM Full-wipe the throwaway capture root before each capture -- required because
+REM golden_capture_cam.py's assert_fresh() refuses a root that already contains
+REM run artifacts. This rmdir is safe ONLY because %CAPROOT% just passed
+REM safe_root.py's check (repo not underneath it, not a drive/fs anchor) AND the
+REM equality guard below proves it is not production C:\INST_hlo -- it must NEVER
+REM run against a root that could hold real station data (run output, DATABASE,
+REM USER_CONFIG calibration matrices).
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- refusing to wipe production root %PROD_ROOT%
+  exit /b 2
+)
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard before wipe
+  exit /b 2
+)
+if exist "%CAPROOT%" (
+  echo [golden] wiping throwaway caproot %CAPROOT%
+  rmdir /s /q "%CAPROOT%"
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = capture out dir
+set "PREFIX=%~1"
+set "CAPOUT=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
+
+echo.
+echo [golden] === %PREFIX% ===
+echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [golden] waiting for CAM port 8013
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8013))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [golden] FAIL %PREFIX% port 8013 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [golden] capturing acquire_image -^> %CAPOUT%
+call conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_cam --config-prefix %PREFIX% --root "%CAPROOT%" --out "%CAPOUT%" > "%OUTDIR%\%PREFIX%.capture.log" 2>&1
+set "CAPTURE_RC=!errorlevel!"
+type "%OUTDIR%\%PREFIX%.capture.log"
+
+echo [golden] killing %PREFIX%
+call :kill_one
+
+if not "%CAPTURE_RC%"=="0" (
+  echo [golden] FAIL %PREFIX% capture rc=%CAPTURE_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the cam driver's shutdown() runs cleanly.
+REM AxisCam holds no persistent hardware handle (HTTP-per-frame), but this
+REM matches every other canary's kill sequence -- best-effort (server dies
+REM mid-response); then wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8013
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit this console.
+REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main window.
+REM The match includes " --no-hot-reload" so "camgold" cannot match "camgoldhex".
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the CAM server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18013) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (camgold vs camgoldhex) -- or a preceding
+REM cam_canary run on the same ports -- leaves a stale listener owning
+REM 127.0.0.1:18013, a dispatch_action RPC-first call reaches the STALE binder:
+REM the action is ACK'd but never runs on the live server, yielding an empty
+REM capture (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8013) or c(18013)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :cam_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:cam_ports_free
+if not "!RELEASED!"=="1" echo [golden] WARNING %PREFIX% ports 8013/18013 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [golden] ABORTED -- a launch/capture step failed; see logs in %OUTDIR%
+echo [golden] ABORTED -- see %OUTDIR%\*.launch.log / *.capture.log> "%OUTDIR%\golden_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/golden_capture_cam.py
+++ b/helao/hexagon/tests/smoke/golden_capture_cam.py
@@ -1,0 +1,253 @@
+"""Runtime golden-diff capture for the cam_server hexagon canary (P3a
+special-split).
+
+*** DRIVES THE REAL AXIS WEBCAM (fetches one live JPEG frame). ***
+
+cam_server wraps ``AxisCam`` (helao/deploy/hte/drivers/sensor/axiscam_driver.py),
+which pulls a JPEG over HTTP from the camera's ``/jpg/1/image.jpg`` endpoint.
+``AxisCam.connect()`` opens no persistent connection, but ``acquire_image``
+actually fetches a frame, so the camera must be REACHABLE at ``axis_ip`` for the
+capture to produce data (the openapi canary needs no camera; this runtime diff
+does).
+
+``acquire_image`` (``POST /CAM/acquire_image``) with ``duration == 0`` runs a
+ONE-SHOT executor (``AxisCamExec`` oneoff): it acquires exactly one frame,
+writes it to disk as ``cam_000000_<%y%m%d.%H%M%S>.jpg``, ``track_file``-registers
+it into ``-act.yml``'s ``files`` list, and streams a one-row ``.hlo`` whose body
+columns are ``epoch_s`` (wall clock) and ``filename`` (the timestamped JPEG name).
+
+This scenario has THREE run-to-run-volatile surfaces, ALL neutralized without
+changing what the hexagon graft controls:
+  1. the ``.jpg`` TREE PATH -- ``cam_NNNNNN_<ts>.jpg`` -- is normalized to
+     ``cam_NNNNNN_TS.jpg`` by ``harness.classify.normalize_name``'s cam-frame
+     grammar rule (RE_CAM_IMG), so both captures land the frame at the same
+     normalized member (the counter is kept; only the wall clock collapses);
+  2. the ``.jpg`` BYTES (a live frame) are content-masked ``"skip"`` (presence
+     only) via the manifest's ``content_masked_files``;
+  3. the ``.hlo`` body columns ``epoch_s``/``filename`` are value-masked via
+     ``masked_hlo_columns`` (structure + the single-row count still asserted).
+The ``-act.yml`` ``files[].file_name`` (the same ``cam_NNNNNN_<ts>.jpg``) is
+handled structurally: ``harness.yaml_pass.normalize_meta`` routes ``file_name``
+values through the same ``normalize_name`` grammar, so it matches on both sides
+with NO masking (a real difference in any other -act.yml field still surfaces).
+
+Standalone counterpart to ``harness.capture.snapshot_capture`` for the
+orch-less, db-less cam/camhex 2-server topology (CAM@8013 + ACTVIS@5001 only),
+mirroring spec/galil/gamry's golden_capture modules. The hardware-agnostic
+settle / anti-vacuous-guard logic (``settle``, ``_run_artifacts``,
+``_act_status_map``) and the production dispatch path (``dispatch_action``) are
+IMPORTED from ``golden_capture.py``; only the scenario-specific pieces are new.
+
+Usage (AT-STATION, Windows, conda env ``helao``) -- CAMERA REACHABLE AT axis_ip:
+
+    rmdir /s /q C:\\INST_hlo_golden               (or pick a fresh --root)
+    conda run -n helao python launch.py camgold --no-hot-reload
+    conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_cam ^
+        --config-prefix camgold --root C:\\INST_hlo_golden ^
+        --out C:\\golden\\cam
+
+then terminate the launch, point ``--root``/``--config-prefix`` at a FRESH
+throwaway root and ``camgoldhex``, capture again, and diff the two capture
+directories with ``harness.parity``. ``cam_diff.bat`` automates exactly this
+sequence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from harness import HARNESS_VERSION
+from harness.capture import assert_fresh, wait_for_server
+from harness.manifest import ProvenanceManifest
+from harness.treepass import PARITY_TOPS
+
+from helao.hexagon.tests.smoke.golden_capture import (
+    _act_status_map,
+    _run_artifacts,
+    dispatch_action,
+    settle,
+)
+
+CAM_HOST, CAM_PORT = "127.0.0.1", 8013
+
+SCENARIO = "GM-CAM"
+
+# helao/hexagon/tests/smoke/golden_capture_cam.py -> repo root is 4 parents up
+# (matches safe_root.py's own _repo_root()).
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFIG_DIR = REPO_ROOT / "helao" / "deploy" / "hte" / "configs"
+
+# AxisCamExec.write_image streams live_dict {"epoch_s": ..., "filename": ...} as
+# the .hlo body: epoch_s is wall-clock, filename is the timestamped JPEG name --
+# both volatile, so their VALUES are masked (column presence + the single-row
+# count are still asserted). The .jpg TREE PATH + the -act.yml files[].file_name
+# are handled structurally by normalize_name/normalize_meta (see module
+# docstring), not here.
+CAM_HLO_COLUMNS = ["epoch_s", "filename"]
+CAM_MASKED_HLO_COLUMNS = {
+    "*.hlo": CAM_HLO_COLUMNS,
+    "*.hlo.json*": CAM_HLO_COLUMNS,
+}
+# One-shot (duration == 0) writes exactly ONE frame/row on both sides -- exact
+# row-count match required (empty tolerance dict == 0).
+CAM_HLO_ROW_COUNT_TOLERANCE: dict = {}
+# The live JPEG frame differs every capture; compare PRESENCE only (its
+# normalized path already matches via the RE_CAM_IMG grammar rule).
+CAM_CONTENT_MASKED_FILES = {"*.jpg": "skip"}
+# acquire_image writes no data-derived value into action_params; the only
+# volatile -act.yml field (files[].file_name) is normalized structurally, not
+# masked -> nothing to mask here.
+CAM_ACT_YML_MASKED_META_KEYS: dict = {}
+
+
+def acquire_image_action(
+    config_prefix: str, duration: float = 0, acquisition_rate: float = 1
+) -> dict:
+    """Run /CAM/acquire_image via ``async_action_dispatcher`` (production
+    action-dispatch path -- RPC then HTTP, full action envelope).
+
+    ``duration == 0`` runs a ONE-SHOT executor: exactly one frame is fetched and
+    written, then the action finishes. ``dispatch_action`` returns as soon as the
+    executor is started (fire-and-forget); ``settle`` then waits for the -act.yml
+    to reach a terminal status.
+    """
+    return dispatch_action(
+        config_prefix,
+        "CAM",
+        "acquire_image",
+        {"duration": duration, "acquisition_rate": acquisition_rate},
+        timeout=60,
+    )
+
+
+def snapshot(
+    root: Path,
+    out_dir: Path,
+    config_prefix: str,
+    duration: float,
+    acquisition_rate: float,
+    notes: str = "",
+) -> Path:
+    """Copy PARITY_TOPS from ``root`` and write a provenance manifest.
+
+    Refuses to overwrite an existing ``out_dir``, matching
+    ``harness.capture.snapshot_capture`` / the other golden_capture modules.
+    """
+    root, out_dir = Path(root), Path(out_dir)
+    if out_dir.exists():
+        raise FileExistsError(
+            f"{out_dir} already exists; refusing to overwrite a capture"
+        )
+    # Anti-vacuous-pass guard (shared convention with gamry/galil/spec/sample):
+    # an empty capture (no action output) compares to nothing and passes parity
+    # trivially. Require at least one -act.yml before writing anything.
+    acts, hlos = _run_artifacts(root)
+    if not acts:
+        raise RuntimeError(
+            f"{root} has no -act.yml to capture; refusing a vacuous capture "
+            "that would pass parity with 0 diffs. Check the launch/capture "
+            "logs -- the action may have errored or produced no output."
+        )
+    errored = [p for p, st in _act_status_map(root).items() if "errored" in st]
+    if errored:
+        print(
+            f"[golden_capture_cam] WARNING: {len(errored)} action(s) ERRORED "
+            f"and were still captured: {errored}. An errored run is NOT a valid "
+            "parity baseline. Check the -act.yml error fields and the CAM log "
+            "before trusting a PASS."
+        )
+    if not hlos:
+        print(
+            f"[golden_capture_cam] WARNING: no .hlo captured under {root} -- "
+            "acquire_image streamed no frame data. Parity will compare -act.yml "
+            "metadata only, NOT the hlo/jpg write path. Verify the camera is "
+            "reachable at axis_ip and returned a frame."
+        )
+    out_root = out_dir / "root"
+    out_root.mkdir(parents=True)
+    for top in PARITY_TOPS:
+        src = root / top
+        if src.is_dir():
+            shutil.copytree(src, out_root / top)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    config_path = CONFIG_DIR / f"{config_prefix}.yml"
+    combined_notes = (
+        "REAL-HARDWARE acquire_image capture (Axis webcam reachable at axis_ip). "
+        "Three volatile surfaces neutralized: the .jpg tree path is normalized by "
+        "the RE_CAM_IMG grammar rule (cam_NNNNNN_TS.jpg); the .jpg bytes are "
+        "content-masked 'skip'; the .hlo epoch_s/filename columns are "
+        "value-masked. The -act.yml files[].file_name normalizes structurally via "
+        "normalize_meta's file_name grammar (unmasked, so any other diff shows)."
+    )
+    if notes:
+        combined_notes = f"{combined_notes} {notes}"
+    ProvenanceManifest(
+        scenario=SCENARIO,
+        config_prefix=config_prefix,
+        config_path=str(config_path),
+        legacy_git_sha=sha,
+        launch_cmd=f"conda run -n helao python launch.py {config_prefix} --no-hot-reload",
+        sequence_name="manual_acquire_image",
+        sequence_params={
+            "manual": True,
+            "endpoint": "POST /CAM/acquire_image",
+            "duration": duration,
+            "acquisition_rate": acquisition_rate,
+            "fast_samples_in": [],
+        },
+        capture_timestamp=datetime.datetime.now().isoformat(timespec="seconds"),
+        harness_version=HARNESS_VERSION,
+        masked_hlo_columns=CAM_MASKED_HLO_COLUMNS,
+        hlo_row_count_tolerance=CAM_HLO_ROW_COUNT_TOLERANCE,
+        content_masked_files=CAM_CONTENT_MASKED_FILES,
+        masked_meta_keys=CAM_ACT_YML_MASKED_META_KEYS,
+        notes=combined_notes,
+    ).save(out_dir)
+    return out_dir
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m helao.hexagon.tests.smoke.golden_capture_cam",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--config-prefix", required=True)
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=0,
+        help="duration; 0 acquires a single frame (default 0)",
+    )
+    parser.add_argument("--acquisition-rate", type=float, default=1)
+    parser.add_argument("--settle-polls", type=int, default=3)
+    parser.add_argument("--notes", default="")
+    args = parser.parse_args(argv)
+
+    assert_fresh(args.root)
+    wait_for_server(CAM_HOST, CAM_PORT)
+    acquire_image_action(args.config_prefix, args.duration, args.acquisition_rate)
+    settle(args.root, settle_polls=args.settle_polls)
+    out = snapshot(
+        root=args.root,
+        out_dir=args.out,
+        config_prefix=args.config_prefix,
+        duration=args.duration,
+        acquisition_rate=args.acquisition_rate,
+        notes=args.notes,
+    )
+    print(f"captured {SCENARIO} -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/test_golden_capture_cam.py
+++ b/helao/hexagon/tests/smoke/test_golden_capture_cam.py
@@ -1,0 +1,177 @@
+"""Linux unit tests for golden_capture_cam.py's PURE logic (no server, no HTTP).
+
+Exercises only:
+  - the PARITY_TOPS snapshot copy + provenance.yml round-trip (``snapshot``)
+  - the masking config (epoch_s / filename .hlo columns masked; .jpg content
+    "skip"; no meta-key masking -- the frame filename normalizes structurally)
+  - the shared (gamry-authored, imported here) ``settle`` helper on a
+    cam-shaped RUNS_DIAG tree
+  - the end-to-end tree normalization of a cam frame: two captures whose JPEGs
+    differ ONLY by wall clock collapse to the SAME normalized member (this is
+    what makes the cam runtime golden diff possible)
+
+The real-hardware POST to ``/CAM/acquire_image`` is NOT exercised here -- that
+only runs at-station with the camera reachable (see golden_capture_cam.py /
+cam_diff.bat docstrings).
+
+Runnable two ways (no ``import pytest`` -- mirrors the other capture tests):
+
+    conda run -n helao python -m pytest helao/hexagon/tests/smoke/test_golden_capture_cam.py -q
+    conda run -n helao python -m helao.hexagon.tests.smoke.test_golden_capture_cam
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from harness.manifest import ProvenanceManifest
+from harness.treepass import snapshot as tree_snapshot
+from harness.uuidmap import UuidMapper
+
+from helao.hexagon.tests.smoke.golden_capture import settle
+from helao.hexagon.tests.smoke.golden_capture_cam import (
+    CAM_CONTENT_MASKED_FILES,
+    CAM_MASKED_HLO_COLUMNS,
+    SCENARIO,
+    snapshot,
+)
+
+
+def test_masking_config_covers_the_volatile_surfaces():
+    cols = set(CAM_MASKED_HLO_COLUMNS["*.hlo"])
+    assert cols == {"epoch_s", "filename"}  # both live: wall clock + frame name
+    assert CAM_CONTENT_MASKED_FILES == {"*.jpg": "skip"}  # bytes: presence only
+
+
+def test_two_cam_captures_normalize_the_frame_to_one_member():
+    """The crux: JPEG frames that differ ONLY by wall clock must land at the
+    SAME normalized tree member (else diff_member_sets fails). Proves the
+    RE_CAM_IMG grammar rule is wired end-to-end through treepass.snapshot."""
+    with tempfile.TemporaryDirectory() as td:
+        a = Path(td) / "a"
+        b = Path(td) / "b"
+        rel = "RUNS_DIAG/25.28/0716/0__0__CAM__acquire_image"
+        for root, ts in ((a, "260719.220107"), (b, "991231.010203")):
+            d = root / rel
+            d.mkdir(parents=True)
+            (d / f"cam_000000_{ts}.jpg").write_bytes(b"\xff\xd8\xff")  # differ
+        sa = tree_snapshot(a, UuidMapper())
+        sb = tree_snapshot(b, UuidMapper())
+        assert set(sa.files) == set(sb.files)
+        assert any(k.endswith("cam_000000_TS.jpg") for k in sa.files)
+
+
+def _write_action(root: Path, status: str = "finished", with_hlo: bool = True) -> Path:
+    """A RUNS_DIAG tree with one manual acquire_image -act.yml (+ .hlo + .jpg)."""
+    d = root / "RUNS_DIAG" / "25.28" / "0716" / "0__0__CAM__acquire_image"
+    d.mkdir(parents=True)
+    (d / "250716.131421-act.yml").write_text(
+        f"file_type: action\naction_status:\n  - {status}\n"
+    )
+    if with_hlo:
+        (d / "acquire_image-0.hlo").write_text("hlo_version: x\n%%\n")
+        (d / "cam_000000_250716.131421.jpg").write_bytes(b"\xff\xd8\xff")
+    return d
+
+
+def test_snapshot_writes_roundtrippable_provenance_with_cam_masking():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        (root / "LOGS").mkdir(parents=True)
+        (root / "LOGS" / "CAM.log").write_text("not captured")
+
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="camgold",
+            duration=0,
+            acquisition_rate=1,
+        )
+        assert not (out / "root" / "LOGS").exists()  # non-parity top excluded
+        assert (
+            out
+            / "root"
+            / "RUNS_DIAG"
+            / "25.28"
+            / "0716"
+            / "0__0__CAM__acquire_image"
+            / "cam_000000_250716.131421.jpg"
+        ).exists()
+
+        manifest = ProvenanceManifest.load(out)
+        assert manifest.scenario == SCENARIO
+        assert manifest.config_prefix == "camgold"
+        assert manifest.masked_hlo_columns == CAM_MASKED_HLO_COLUMNS
+        assert manifest.content_masked_files == CAM_CONTENT_MASKED_FILES
+        assert manifest.masked_meta_keys == {}
+
+
+def test_snapshot_refuses_empty_capture():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_DIAG").mkdir(parents=True)  # present but empty
+        out = Path(td) / "golden" / "run1"
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="camgold",
+                duration=0,
+                acquisition_rate=1,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("snapshot() must refuse an empty (no-output) capture")
+        assert not out.exists()
+
+
+def test_settle_returns_once_action_complete_and_stable():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        settle(root, settle_polls=2, poll_s=0.01, timeout_s=5.0)
+
+
+def test_settle_does_not_return_while_action_active():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="active", with_hlo=False)
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() must not return while status is 'active'")
+
+
+ALL_TESTS = [
+    test_masking_config_covers_the_volatile_surfaces,
+    test_two_cam_captures_normalize_the_frame_to_one_member,
+    test_snapshot_writes_roundtrippable_provenance_with_cam_masking,
+    test_snapshot_refuses_empty_capture,
+    test_settle_returns_once_action_complete_and_stable,
+    test_settle_does_not_return_while_action_active,
+]
+
+
+def main() -> int:
+    failures = 0
+    for fn in ALL_TESTS:
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 -- report every failure, keep going
+            failures += 1
+            print(f"FAIL {fn.__name__}: {exc}")
+        else:
+            print(f"PASS {fn.__name__}")
+    print(f"{len(ALL_TESTS) - failures}/{len(ALL_TESTS)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Promotes **cam** from openapi-only to **both tiers**. Follow-up to PR #189 (spec+cam), which deferred cam's runtime golden-diff because of its timestamped-binary-frame output.

## The blocker, and the fix
`acquire_image` writes `cam_NNNNNN_<%y%m%d.%H%M%S>.jpg` whose **filename** varies run-to-run — a tree member-set divergence that content-masking can't fix. Fixed with two principled, self-contained §5.5 wall-clock-filename additions to the harness, **both no-ops on every existing scenario** (deterministic `<label>-<idx>` names match no grammar rule):

- `harness/classify.py`: `RE_CAM_IMG` in `normalize_name` collapses the frame timestamp → `cam_NNNNNN_TS.jpg` (counter kept, so frame identity is still compared) — fixes the `.jpg` tree member-set.
- `harness/yaml_pass.py`: `normalize_meta` now routes `file_name` string values through `normalize_name`, so `-act.yml` `files[].file_name` (a basename) normalizes identically on both sides — **unmasked**, so any other `-act.yml` diff still surfaces.

Tests: `test_classify` (cam-frame grammar + non-cam `.jpg` pass-through), `test_yaml_pass` (file_name normalization + deterministic-name no-regression). **Full harness suite: 102 passed.**

## Per-scenario cam capture rig (mirrors spec's; `GM-CAM` = one-shot `acquire_image`)
- `golden_capture_cam.py`: masks `.hlo` cols `epoch_s`/`filename`; content-masks `*.jpg` `"skip"` (bytes = live frame, presence only). No `masked_meta_keys`.
- `camgold.yml`/`camgoldhex.yml` throwaway-root configs; `cam_diff.bat` runtime runner (includes the RPC-port-release wait from #189); `test_golden_capture_cam.py` (6 tests, incl. an end-to-end "two frames normalize to one member" check).
- `cam.yml`/`camhex.yml`/`cam_canary.bat` headers updated to two-tier.

## Validation status
- ✅ Linux: 102 harness tests + 6 cam capture tests, all cam configs preflight-green.
- ⏳ **At-station `cam_diff.bat` runtime diff PENDING** — needs the Axis webcam reachable at `axis_ip`. **Do not merge until this passes at-station** (the spec runtime tier surfaced a real stale-RPC-binder bug that only an at-station run caught).

🤖 Generated with [Claude Code](https://claude.com/claude-code)