### PR TITLE
feat(hexagon): P3a hardware-family canary harness + dispatch fixes

### DIFF
--- a/helao/core/rpc/zmq_rpc.py
+++ b/helao/core/rpc/zmq_rpc.py
@@ -438,6 +438,7 @@ class RPCClient:
         self,
         method: str,
         timeout: Optional[float] = None,
+        args: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> Any:
         """Invoke ``method`` on the remote dispatcher and return its result.
@@ -445,7 +446,13 @@ class RPCClient:
         Args:
             method: Remote method name.
             timeout: Override for the per-call wait, in seconds.
-            **kwargs: Forwarded to the remote method.
+            args: Payload dict forwarded to the remote method. Use this rather
+                than ``**kwargs`` when a forwarded parameter name could shadow
+                one of this method's own parameters (``method``/``timeout``/
+                ``args``) -- e.g. an action whose params include a key literally
+                named ``timeout``. Keys here are collision-proof; ``**kwargs``
+                are merged on top for convenience.
+            **kwargs: Forwarded to the remote method (merged over ``args``).
 
         Returns:
             The server's ``result`` payload.
@@ -461,7 +468,9 @@ class RPCClient:
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         self._pending[req_id] = fut
         try:
-            req = RPCRequest(id=req_id, method=method, args=kwargs)
+            payload = dict(args or {})
+            payload.update(kwargs)
+            req = RPCRequest(id=req_id, method=method, args=payload)
             await self._socket.send(_REQ_ENCODER.encode(req))
             wait = timeout if timeout is not None else self.default_timeout
             resp: RPCResponse = await asyncio.wait_for(fut, timeout=wait)
@@ -541,6 +550,7 @@ class RPCSyncClient:
         self,
         method: str,
         timeout: Optional[float] = None,
+        args: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> Any:
         """Send a single request and block for the reply.
@@ -548,7 +558,13 @@ class RPCSyncClient:
         Args:
             method: Remote method name.
             timeout: Override for the per-call wait, in seconds.
-            **kwargs: Forwarded to the remote method.
+            args: Payload dict forwarded to the remote method. Use this rather
+                than ``**kwargs`` when a forwarded parameter name could shadow
+                one of this method's own parameters (``method``/``timeout``/
+                ``args``) -- e.g. an action whose params include a key literally
+                named ``timeout``. Keys here are collision-proof; ``**kwargs``
+                are merged on top for convenience.
+            **kwargs: Forwarded to the remote method (merged over ``args``).
 
         Returns:
             The server's ``result`` payload.
@@ -558,7 +574,9 @@ class RPCSyncClient:
             TimeoutError: If no reply arrives within ``timeout``.
         """
         sock = self._ensure_socket()
-        req = RPCRequest(id=next(self._ids), method=method, args=kwargs)
+        payload = dict(args or {})
+        payload.update(kwargs)
+        req = RPCRequest(id=next(self._ids), method=method, args=payload)
         try:
             sock.send(_REQ_ENCODER.encode(req))
         except zmq.ZMQError:

--- a/helao/core/runners/micro_orch.py
+++ b/helao/core/runners/micro_orch.py
@@ -442,7 +442,9 @@ class MicroOrch:
         rpc_args["action"] = action.as_dict()
         method = f"{server_name}/{action_name}"
         try:
-            result = await client.call(method, timeout=timeout, **rpc_args)
+            # `args=` (not `**rpc_args`) so an action param named `timeout`
+            # cannot collide with call()'s own `timeout` kwarg.
+            result = await client.call(method, timeout=timeout, args=rpc_args)
         except Exception:
             async with self._cond:
                 self._pending_meta.pop(action_uuid, None)

--- a/helao/core/tests/unit_test_dispatcher.py
+++ b/helao/core/tests/unit_test_dispatcher.py
@@ -65,10 +65,18 @@ async def _exercise_rpc(reporter: TestReporter) -> None:
     def boom() -> None:
         raise RuntimeError("boom")
 
+    def echo_timeout(timeout: int = 0, message: str = "") -> dict:
+        # A remote method whose parameter name shadows RPCClient.call's own
+        # `timeout` control kwarg. It must be forwarded via `args=` without a
+        # "got multiple values for keyword argument 'timeout'" collision
+        # (regression: ANDOR/acquire has a `timeout` param).
+        return {"timeout": timeout, "message": message}
+
     dispatcher.register("echo", echo)
     dispatcher.register("aecho", aecho)
     dispatcher.register("needs_machine", needs_machine)
     dispatcher.register("boom", boom)
+    dispatcher.register("echo_timeout", echo_timeout)
 
     await dispatcher.serve("127.0.0.1", port)
     try:
@@ -94,15 +102,27 @@ async def _exercise_rpc(reporter: TestReporter) -> None:
                 lambda: disp == "S@M",
             )
 
+            # A forwarded param named `timeout` must not collide with the
+            # control `timeout` kwarg: the control timeout (2.0s) governs the
+            # wait, while args={"timeout": 999} is forwarded to the remote fn.
+            shadow = await client.call(
+                "echo_timeout",
+                timeout=2.0,
+                args={"timeout": 999, "message": "z"},
+            )
+            reporter.check(
+                "RPCClient forwards a param named 'timeout' via args= "
+                "without colliding with the control timeout",
+                lambda: shadow == {"timeout": 999, "message": "z"},
+            )
+
             # Expect RPCError when the handler raises
             try:
                 await client.call("boom")
                 raised = False
             except RPCError:
                 raised = True
-            reporter.check(
-                "RPCError raised when remote handler errors", lambda: raised
-            )
+            reporter.check("RPCError raised when remote handler errors", lambda: raised)
 
             # Unknown method should also raise RPCError
             try:
@@ -123,15 +143,24 @@ async def _exercise_rpc(reporter: TestReporter) -> None:
         def _drive_sync():
             sync = RPCSyncClient(endpoint=endpoint, default_timeout=5.0)
             try:
-                return sync.call("echo", message="sync", count=3)
+                echoed = sync.call("echo", message="sync", count=3)
+                shadowed = sync.call(
+                    "echo_timeout", timeout=5.0, args={"timeout": 42, "message": "s"}
+                )
+                return echoed, shadowed
             finally:
                 sync.close()
 
         loop = asyncio.get_running_loop()
-        sync_result = await loop.run_in_executor(None, _drive_sync)
+        sync_result, sync_shadow = await loop.run_in_executor(None, _drive_sync)
         reporter.check(
             "RPCSyncClient round-trip preserves args",
             lambda: sync_result == {"message": "sync", "count": 3},
+        )
+        reporter.check(
+            "RPCSyncClient forwards a param named 'timeout' via args= "
+            "without colliding with the control timeout",
+            lambda: sync_shadow == {"timeout": 42, "message": "s"},
         )
     finally:
         await dispatcher.close()

--- a/helao/core/tests/unit_test_dispatcher.py
+++ b/helao/core/tests/unit_test_dispatcher.py
@@ -12,12 +12,22 @@ covers HTTP fallback behaviour from :mod:`helao.helpers.dispatcher`:
   reported as unavailable with a sensible state string.
 * :func:`RPCDispatcher.serve` + :class:`RPCClient` round-trip including
   pydantic model rehydration via ``_coerce_args``.
+* :func:`async_action_dispatcher` end-to-end over the RPC fast path,
+  driving a real ``wrap_action_endpoint``-wrapped handler (mirrors what
+  ``server_api._rpc_startup`` registers for a ``tags=["action"]`` route) so
+  ``ACTION_CTX``/``action_params`` are asserted to be populated server-side
+  -- not the generic echo handlers used by ``_exercise_rpc``. Covers the
+  regression where an action param literally named ``timeout`` (e.g.
+  ANDOR/acquire's ``timeout: float = 5000``) collided with
+  ``RPCClient.call``'s own ``timeout`` kwarg (fixed in 4d11afe3); plus a
+  down-peer case proving the fallback still returns promptly.
 """
 
 __all__ = ["dispatcher_unit_test"]
 
 import asyncio
 import socket
+import time
 import traceback
 
 from helao.core.error import ErrorCodes
@@ -28,13 +38,17 @@ from helao.core.rpc import (
     RPCSyncClient,
     derive_rpc_port,
 )
+from helao.core.rpc.zmq_rpc import RPC_PORT_OFFSET
+from helao.core.servers.base_api import ACTION_CTX, wrap_action_endpoint
 from helao.helpers.dispatcher import (
     _query_safe,
     aclose_all_rpc_clients,
+    async_action_dispatcher,
     async_private_dispatcher,
     close_all_sync_rpc_clients,
     endpoints_available,
 )
+from helao.helpers.premodels import Action
 from helao.core.models.machine import MachineModel
 from helao.core.tests._test_utils import TestReporter
 
@@ -167,6 +181,162 @@ async def _exercise_rpc(reporter: TestReporter) -> None:
         await dispatcher.close()
 
 
+def _free_http_port() -> int:
+    """Return an HTTP port whose derived RPC port is free and <= 65535.
+
+    Binds the *RPC* socket first (so we know it's free) then derives the
+    HTTP port downward, mirroring how a real server's ``host``/``port``
+    config entry relates to its co-located RPC ROUTER (mirrors
+    ``server_api.HelaoFastAPI``'s ``derive_rpc_port(server_cfg["port"])``).
+    A tiny TOCTOU window exists but is acceptable for a test fixture.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    rpc_port = s.getsockname()[1]
+    s.close()
+    http_port = rpc_port - RPC_PORT_OFFSET
+    assert 1024 < http_port <= 65535, f"derived http_port {http_port} out of range"
+    assert derive_rpc_port(http_port) <= 65535
+    return http_port
+
+
+async def _exercise_action_dispatcher_rpc(reporter: TestReporter) -> None:
+    """Drive ``async_action_dispatcher`` end-to-end over the real RPC fast path.
+
+    Registers a ``wrap_action_endpoint``-wrapped handler -- the exact
+    callable ``server_api._rpc_startup`` mirrors into the co-located
+    ``RPCDispatcher`` for a ``tags=["action"]`` route -- under
+    ``f"{server_name}/{action_name}"`` on a real bound ``RPCDispatcher``, then
+    dispatches a real :class:`Action` through :func:`async_action_dispatcher`
+    exactly as the orchestrator does. Asserts:
+
+    * The call succeeds via RPC alone -- no HTTP server is listening on the
+      paired HTTP port at all, so any HTTP fallback would fail outright;
+      ``ErrorCodes.none`` therefore proves the RPC leg (not a fallback)
+      produced the result.
+    * ``ACTION_CTX`` was populated with the REAL action (not a blank
+      ``Action()``) and ``action.action_params`` reached the handler --
+      the mechanism ``_build_action_from_kwargs`` implements.
+    * An action param literally named ``timeout`` (mirroring ANDOR/acquire's
+      ``timeout: float = 5000``) round-trips correctly instead of colliding
+      with ``RPCClient.call``'s own ``timeout`` control kwarg (4d11afe3).
+    """
+    server_name = "ACTIONRPC"
+    action_name = "acquire"
+    captured: dict = {}
+
+    async def acquire_like(
+        external_trigger: bool = True,
+        duration: float = 10.0,
+        timeout: float = 5000,
+    ) -> dict:
+        ctx = ACTION_CTX.get()
+        captured["ctx_is_none"] = ctx is None
+        if ctx is not None:
+            captured["action_params"] = dict(ctx.action.action_params)
+        captured["external_trigger"] = external_trigger
+        captured["duration"] = duration
+        captured["timeout"] = timeout
+        return {"ok": True}
+
+    # Mirrors ActionAPIRoute.__init__: a tags=["action"] endpoint is wrapped
+    # with wrap_action_endpoint before it is ever registered anywhere --
+    # including into the RPC dispatcher's method table.
+    wrapped = wrap_action_endpoint(acquire_like)
+
+    dispatcher = RPCDispatcher(server_key=server_name)
+    http_port = _free_http_port()
+    rpc_port = derive_rpc_port(http_port)
+    dispatcher.register(f"{server_name}/{action_name}", wrapped)
+    await dispatcher.serve("127.0.0.1", rpc_port)
+    try:
+        world_cfg = {
+            "servers": {
+                server_name: {"host": "127.0.0.1", "port": http_port},
+            }
+        }
+        action_params = {
+            "external_trigger": False,
+            "duration": 2.5,
+            "timeout": 5000,  # shadows RPCClient.call(timeout=...) by name
+        }
+        action = Action(
+            action_name=action_name,
+            action_server=MachineModel(
+                server_name=server_name, machine_name="testhost"
+            ),
+            action_params=action_params,
+        )
+
+        t0 = time.monotonic()
+        response, error_code = await async_action_dispatcher(
+            world_cfg, action, params=action_params, timeout=10
+        )
+        elapsed = time.monotonic() - t0
+
+        reporter.check(
+            "async_action_dispatcher succeeds via RPC alone "
+            "(no HTTP server is listening, so a fallback would fail)",
+            lambda: error_code == ErrorCodes.none and response == {"ok": True},
+        )
+        reporter.check(
+            "async_action_dispatcher took the RPC fast path (fast, no HTTP retry backoff)",
+            lambda: elapsed < 3.0,
+        )
+        reporter.check(
+            "ACTION_CTX was populated with the real Action, not left as None",
+            lambda: captured.get("ctx_is_none") is False,
+        )
+        reporter.check(
+            "server-side action.action_params carries the dispatched params",
+            lambda: captured.get("action_params", {}).get("duration") == 2.5
+            and captured.get("action_params", {}).get("external_trigger") is False,
+        )
+        reporter.check(
+            "an action param literally named 'timeout' reaches the handler "
+            "instead of colliding with RPCClient.call's own timeout kwarg",
+            lambda: captured.get("timeout") == 5000,
+        )
+        reporter.check(
+            "external_trigger (bool) round-trips through msgpack + _coerce_args",
+            lambda: captured.get("external_trigger") is False,
+        )
+    finally:
+        await dispatcher.close()
+
+    # --- down-peer case: neither RPC nor HTTP is up; must fall back promptly ---
+    down_http_port = _free_http_port()
+    world_cfg_down = {
+        "servers": {
+            server_name: {"host": "127.0.0.1", "port": down_http_port},
+        }
+    }
+    down_action = Action(
+        action_name=action_name,
+        action_server=MachineModel(server_name=server_name, machine_name="testhost"),
+        action_params={"duration": 0.1},
+    )
+    t0 = time.monotonic()
+    response, error_code = await async_action_dispatcher(
+        world_cfg_down,
+        down_action,
+        params=down_action.action_params,
+        timeout=1,
+        retries=1,
+    )
+    elapsed = time.monotonic() - t0
+    reporter.check(
+        "async_action_dispatcher against a down peer returns a non-success "
+        "ErrorCodes value instead of raising",
+        lambda: error_code != ErrorCodes.none and response is None,
+    )
+    reporter.check(
+        "async_action_dispatcher against a down peer returns promptly "
+        "(RPC probe capped at _RPC_PROBE_TIMEOUT, then one short HTTP retry)",
+        lambda: elapsed < 15.0,
+    )
+
+
 async def _exercise_http_fallback(reporter: TestReporter) -> None:
     """Drive ``async_private_dispatcher`` against an unreachable peer."""
     # Pick a port nothing is listening on. The RPC fast path will fail
@@ -260,6 +430,9 @@ def dispatcher_unit_test() -> bool:
 
         reporter.section("RPCDispatcher <-> RPCClient round-trip")
         asyncio.run(_exercise_rpc(reporter))
+
+        reporter.section("async_action_dispatcher over the real RPC fast path")
+        asyncio.run(_exercise_action_dispatcher_rpc(reporter))
 
         reporter.section("async_private_dispatcher HTTP fallback returns gracefully")
         asyncio.run(_exercise_http_fallback(reporter))

--- a/helao/core/tests/unit_test_dispatcher.py
+++ b/helao/core/tests/unit_test_dispatcher.py
@@ -29,6 +29,7 @@ from helao.core.rpc import (
     derive_rpc_port,
 )
 from helao.helpers.dispatcher import (
+    _query_safe,
     aclose_all_rpc_clients,
     async_private_dispatcher,
     close_all_sync_rpc_clients,
@@ -223,6 +224,38 @@ def dispatcher_unit_test() -> bool:
         reporter.check(
             "ErrorCodes.http is the dispatcher's failure flag",
             lambda: ErrorCodes.http.value == "http",
+        )
+
+        reporter.section("_query_safe coerces HTTP query params (yarl-safe)")
+        # yarl rejects bool query values ("Invalid variable type") -- an action
+        # param named external_trigger=False crashed the HTTP fallback POST and
+        # got swallowed as an escalating-sleep hang. bool -> "true"/"false"
+        # (FastAPI parses back to bool), None dropped, scalars passed through.
+        safe = _query_safe(
+            {
+                "external_trigger": False,
+                "flag": True,
+                "n": 3,
+                "x": 1.5,
+                "s": "a",
+                "z": None,
+            }
+        )
+        reporter.check(
+            "_query_safe maps bool -> 'true'/'false'",
+            lambda: safe.get("external_trigger") == "false"
+            and safe.get("flag") == "true",
+        )
+        reporter.check(
+            "_query_safe drops None and passes str/int/float through",
+            lambda: safe
+            == {
+                "external_trigger": "false",
+                "flag": "true",
+                "n": 3,
+                "x": 1.5,
+                "s": "a",
+            },
         )
 
         reporter.section("RPCDispatcher <-> RPCClient round-trip")

--- a/helao/deploy/hte/configs/andor.yml
+++ b/helao/deploy/hte/configs/andor.yml
@@ -1,0 +1,39 @@
+# STANDALONE andor_server canary config (P3a special-split, ANDOR). Mirrors
+# spec.yml/cam.yml's 2-server shape (one action server + one action_visualizer)
+# so an at-station openapi/runtime golden diff can compare legacy vs hexagon
+# like-for-like without pulling in the full hispec station (ORCH, VIS, DB, CALC,
+# CAM...). The ANDOR params: (dev_id) is copied VERBATIM from hispec.yml's ANDOR
+# block so `acquire` registers identically. This is the Andor Zyla camera +
+# ATSpectrograph (vendor pyAndorSDK3 / pyAndorSpectrograph runtimes) --
+# WINDOWS-ONLY hardware; the runtime golden diff requires the camera +
+# spectrograph attached (see golden_capture_andor.py's docstring). The openapi
+# canary only needs the server to boot and serve /openapi.json.
+#
+# TWO TIERS: andor_canary.bat does the /openapi.json surface diff (this config +
+# andorhex.yml); andor_diff.bat does the runtime `acquire` golden diff
+# (andorgold.yml/andorgoldhex.yml). `acquire` streams a .hlo of live per-pixel
+# intensities (ch_0000..ch_NNNN) + tick timestamps with a config-deterministic
+# `wl` (pixel->wavelength) header -- like spec_server's acquire_spec, NOT cam's
+# timestamped JPEG sidecars: the driver writes NO image files, so no new
+# filename grammar is involved (see golden_capture_andor.py for the masking
+# rationale).
+dummy: true
+simulation: true
+run_type: andor_server
+root: C:\INST_hlo
+servers:
+  ANDOR:
+    host: 127.0.0.1
+    port: 8011
+    group: action
+    fast: andor_server
+    params:
+      dev_id: 0
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'ANDOR Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/andorgold.yml
+++ b/helao/deploy/hte/configs/andorgold.yml
@@ -1,0 +1,30 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of andor.yml used solely
+# by helao.hexagon.tests.smoke.golden_capture_andor / andor_diff.bat to capture
+# a runtime golden-master `acquire` tree. The ONLY change from andor.yml is
+# `root:`, pointed at a dedicated throwaway path so the capture rig's
+# assert_fresh() has a clean tree to start from and production C:\INST_hlo (real
+# run data, DATABASE, USER_CONFIG) is never touched. This is a REAL-HARDWARE
+# capture (see golden_capture_andor.py docstring) -- `acquire` streams live
+# spectra (non-perturbing, software-triggered) but the Andor Zyla camera +
+# ATSpectrograph must be attached for connect() to succeed and the capture to
+# produce data.
+dummy: true
+simulation: true
+run_type: andor_server
+root: C:\INST_hlo_golden
+servers:
+  ANDOR:
+    host: 127.0.0.1
+    port: 8011
+    group: action
+    fast: andor_server
+    params:
+      dev_id: 0
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'ANDOR Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/andorgoldhex.yml
+++ b/helao/deploy/hte/configs/andorgoldhex.yml
@@ -1,0 +1,34 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of andorhex.yml (keeps
+# `deployment: hexagon` on ANDOR + ACTVIS -- the hexagon side of the runtime
+# golden diff) used solely by helao.hexagon.tests.smoke.golden_capture_andor /
+# andor_diff.bat to capture a runtime golden-master `acquire` tree. The ONLY
+# change from andorhex.yml is `root:`, pointed at a dedicated throwaway path so
+# the capture rig's assert_fresh() has a clean tree to start from and production
+# C:\INST_hlo (real run data, DATABASE, USER_CONFIG) is never touched. Ports and
+# params match andorgold.yml so the capture-vs-capture parity diff compares
+# like-for-like. This is a REAL-HARDWARE capture (see golden_capture_andor.py
+# docstring) -- `acquire` streams live spectra (non-perturbing,
+# software-triggered) but the Andor Zyla camera + ATSpectrograph must be
+# attached for connect() to succeed and the capture to produce data.
+dummy: true
+simulation: true
+run_type: andor_server
+root: C:\INST_hlo_golden
+servers:
+  ANDOR:
+    host: 127.0.0.1
+    port: 8011
+    group: action
+    fast: andor_server
+    deployment: hexagon
+    params:
+      dev_id: 0
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'ANDOR Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/andorhex.yml
+++ b/helao/deploy/hte/configs/andorhex.yml
@@ -1,0 +1,31 @@
+# HEXAGON CANARY for the andor_server station (P3a special-split). Copy of
+# andor.yml with `deployment: hexagon` flipping ANDOR (andor_server) and ACTVIS
+# (action_visualizer) onto the hexagon factory -- run AT-STATION
+# (Windows/pyAndorSDK3 + pyAndorSpectrograph). andor.yml stays legacy for
+# rollback; the cut-over is ONLY the two `deployment: hexagon` keys.
+# Ports/root/params match andor.yml so an on-station openapi/golden diff
+# compares like-for-like. TWO TIERS -- see andor.yml's header (openapi via
+# andor_canary.bat, runtime `acquire` golden diff via andor_diff.bat +
+# andorgold/andorgoldhex).
+dummy: true
+simulation: true
+run_type: andor_server
+root: C:\INST_hlo
+servers:
+  ANDOR:
+    host: 127.0.0.1
+    port: 8011
+    group: action
+    fast: andor_server
+    deployment: hexagon
+    params:
+      dev_id: 0
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'ANDOR Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/biologic.yml
+++ b/helao/deploy/hte/configs/biologic.yml
@@ -2,14 +2,20 @@
 # Mirrors spec.yml/galil.yml/gamry.yml's 2-server shape (one action server + one
 # action_visualizer) so an at-station openapi/runtime golden diff can compare
 # legacy vs hexagon like-for-like without pulling in the full eche4 station
-# (ORCH, OPERATOR, and the rest). The BIOLOGIC params block (max_channels) is
-# copied VERBATIM from eche4.yml's BIOLOGIC block, and the server key is kept
-# exactly `BIOLOGIC`, so run_OCV (and the other technique endpoints) register
-# identically. This is the Biologic potentiostat (easy_biologic / EC-lib over
-# TCP) -- WINDOWS-ONLY hardware; the runtime golden diff requires the
-# instrument attached with a dummy cell / calibration resistor (see
-# golden_capture_biologic.py's docstring). The openapi canary only needs the
-# server to boot and serve /openapi.json.
+# (ORCH, OPERATOR, and the rest). The BIOLOGIC params block MUST carry the
+# REAL hardware params of the station under test (device `address`,
+# `num_channels`, ...), ported from that station's legacy config -- here the
+# hispec station's PSTAT block (address 192.168.200.100, num_channels 1).
+# BiologicDriver.connect() reads only `address` (default 192.168.200.240) and
+# `num_channels` (default 12); a wrong/absent address fails connect() at
+# startup (_driver_status='error'). The OPENAPI canary passes regardless (the
+# route table builds without a live device), so ONLY the runtime golden diff
+# exercises connect() -- a runtime canary is inherently station-specific in its
+# hardware params. The server key is kept exactly `BIOLOGIC`, so run_OCV (and
+# the other technique endpoints) register identically. Biologic potentiostat
+# (easy_biologic / EC-lib over TCP) -- WINDOWS-ONLY hardware; the runtime golden
+# diff requires the instrument attached with a dummy cell / calibration
+# resistor (see golden_capture_biologic.py's docstring).
 dummy: true
 simulation: true
 run_type: biologic_server
@@ -21,7 +27,10 @@ servers:
     group: action
     fast: biologic_server
     params:
-      max_channels: 12
+      allow_no_sample: true
+      address: 192.168.200.100
+      num_channels: 1
+      grounded: true
   ACTVIS:
     host: 127.0.0.1
     port: 5001

--- a/helao/deploy/hte/configs/biologic.yml
+++ b/helao/deploy/hte/configs/biologic.yml
@@ -1,0 +1,32 @@
+# STANDALONE biologic_server canary config (P3a special-split, BIOLOGIC).
+# Mirrors spec.yml/galil.yml/gamry.yml's 2-server shape (one action server + one
+# action_visualizer) so an at-station openapi/runtime golden diff can compare
+# legacy vs hexagon like-for-like without pulling in the full eche4 station
+# (ORCH, OPERATOR, and the rest). The BIOLOGIC params block (max_channels) is
+# copied VERBATIM from eche4.yml's BIOLOGIC block, and the server key is kept
+# exactly `BIOLOGIC`, so run_OCV (and the other technique endpoints) register
+# identically. This is the Biologic potentiostat (easy_biologic / EC-lib over
+# TCP) -- WINDOWS-ONLY hardware; the runtime golden diff requires the
+# instrument attached with a dummy cell / calibration resistor (see
+# golden_capture_biologic.py's docstring). The openapi canary only needs the
+# server to boot and serve /openapi.json.
+dummy: true
+simulation: true
+run_type: biologic_server
+root: C:\INST_hlo
+servers:
+  BIOLOGIC:
+    host: 127.0.0.1
+    port: 8016
+    group: action
+    fast: biologic_server
+    params:
+      max_channels: 12
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'BIOLOGIC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/biologicgold.yml
+++ b/helao/deploy/hte/configs/biologicgold.yml
@@ -1,0 +1,30 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of biologic.yml used
+# solely by helao.hexagon.tests.smoke.golden_capture_biologic / biologic_diff.bat
+# to capture a runtime golden-master run_OCV tree. The ONLY change from
+# biologic.yml is `root:`, pointed at a dedicated throwaway path so the capture
+# rig's assert_fresh() has a clean tree to start from and production C:\INST_hlo
+# (real run data, DATABASE, USER_CONFIG calibration) is never touched. This is a
+# REAL-HARDWARE capture (see golden_capture_biologic.py docstring) -- run_OCV
+# reads open-circuit voltage (non-perturbing, drives nothing) but the Biologic
+# instrument must be attached with a dummy cell / calibration resistor for
+# connect() to succeed and the capture to produce data.
+dummy: true
+simulation: true
+run_type: biologic_server
+root: C:\INST_hlo_golden
+servers:
+  BIOLOGIC:
+    host: 127.0.0.1
+    port: 8016
+    group: action
+    fast: biologic_server
+    params:
+      max_channels: 12
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'BIOLOGIC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/biologicgold.yml
+++ b/helao/deploy/hte/configs/biologicgold.yml
@@ -19,7 +19,10 @@ servers:
     group: action
     fast: biologic_server
     params:
-      max_channels: 12
+      allow_no_sample: true
+      address: 192.168.200.100
+      num_channels: 1
+      grounded: true
   ACTVIS:
     host: 127.0.0.1
     port: 5001

--- a/helao/deploy/hte/configs/biologicgoldhex.yml
+++ b/helao/deploy/hte/configs/biologicgoldhex.yml
@@ -23,7 +23,10 @@ servers:
     fast: biologic_server
     deployment: hexagon
     params:
-      max_channels: 12
+      allow_no_sample: true
+      address: 192.168.200.100
+      num_channels: 1
+      grounded: true
   ACTVIS:
     host: 127.0.0.1
     port: 5001

--- a/helao/deploy/hte/configs/biologicgoldhex.yml
+++ b/helao/deploy/hte/configs/biologicgoldhex.yml
@@ -1,0 +1,35 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of biologichex.yml (keeps
+# `deployment: hexagon` on BIOLOGIC + ACTVIS -- the hexagon side of the runtime
+# golden diff) used solely by helao.hexagon.tests.smoke.golden_capture_biologic /
+# biologic_diff.bat to capture a runtime golden-master run_OCV tree. The ONLY
+# change from biologichex.yml is `root:`, pointed at a dedicated throwaway path
+# so the capture rig's assert_fresh() has a clean tree to start from and
+# production C:\INST_hlo (real run data, DATABASE, USER_CONFIG calibration) is
+# never touched. Ports and params match biologicgold.yml so the capture-vs-capture
+# parity diff compares like-for-like. This is a REAL-HARDWARE capture (see
+# golden_capture_biologic.py docstring) -- run_OCV reads open-circuit voltage
+# (non-perturbing, drives nothing) but the Biologic instrument must be attached
+# with a dummy cell / calibration resistor for connect() to succeed and the
+# capture to produce data.
+dummy: true
+simulation: true
+run_type: biologic_server
+root: C:\INST_hlo_golden
+servers:
+  BIOLOGIC:
+    host: 127.0.0.1
+    port: 8016
+    group: action
+    fast: biologic_server
+    deployment: hexagon
+    params:
+      max_channels: 12
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'BIOLOGIC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/biologichex.yml
+++ b/helao/deploy/hte/configs/biologichex.yml
@@ -1,0 +1,28 @@
+# HEXAGON CANARY for the biologic_server station (P3a special-split). Copy of
+# biologic.yml with `deployment: hexagon` flipping BIOLOGIC (biologic_server)
+# and ACTVIS (action_visualizer) onto the hexagon factory -- run AT-STATION
+# (Windows/easy_biologic). biologic.yml stays legacy for rollback; the cut-over
+# is ONLY the two `deployment: hexagon` keys. Ports/root/params match
+# biologic.yml so an on-station openapi/golden diff compares like-for-like.
+dummy: true
+simulation: true
+run_type: biologic_server
+root: C:\INST_hlo
+servers:
+  BIOLOGIC:
+    host: 127.0.0.1
+    port: 8016
+    group: action
+    fast: biologic_server
+    deployment: hexagon
+    params:
+      max_channels: 12
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'BIOLOGIC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/biologichex.yml
+++ b/helao/deploy/hte/configs/biologichex.yml
@@ -16,7 +16,10 @@ servers:
     fast: biologic_server
     deployment: hexagon
     params:
-      max_channels: 12
+      allow_no_sample: true
+      address: 192.168.200.100
+      num_channels: 1
+      grounded: true
   ACTVIS:
     host: 127.0.0.1
     port: 5001

--- a/helao/deploy/hte/configs/co2.yml
+++ b/helao/deploy/hte/configs/co2.yml
@@ -1,0 +1,31 @@
+# STANDALONE co2sensor_server canary config (P3a special-split, CO2). Mirrors
+# spec.yml/galil.yml/gamry.yml's 2-server shape (one action server + one
+# action_visualizer) so an at-station openapi/runtime golden diff can compare
+# legacy vs hexagon like-for-like without pulling in the full ccsi1 station
+# (ORCH, the syringe/MFC/valve servers, DB, ...). CO2SENSOR params (port,
+# start_margin) are copied VERBATIM from ccsi1.yml's CO2SENSOR block so
+# acquire_co2 registers identically. This is the SprintIR-6S NDIR CO2 sensor
+# (serial COM12 via pyserial) -- WINDOWS-STATION hardware; the runtime golden
+# diff requires the sensor attached (see golden_capture_co2.py's docstring).
+# The openapi canary only needs the server to boot and serve /openapi.json.
+dummy: true
+simulation: true
+run_type: co2sensor_server
+root: C:\INST_hlo
+servers:
+  CO2SENSOR:
+    host: 127.0.0.1
+    port: 8012
+    group: action
+    fast: co2sensor_server
+    params:
+      port: COM12
+      start_margin: 0
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'CO2 Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/co2gold.yml
+++ b/helao/deploy/hte/configs/co2gold.yml
@@ -1,0 +1,30 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of co2.yml used solely
+# by helao.hexagon.tests.smoke.golden_capture_co2 / co2_diff.bat to capture a
+# runtime golden-master acquire_co2 tree. The ONLY change from co2.yml is
+# `root:`, pointed at a dedicated throwaway path so the capture rig's
+# assert_fresh() has a clean tree to start from and production C:\INST_hlo
+# (real run data, DATABASE, USER_CONFIG) is never touched. This is a
+# REAL-HARDWARE capture (see golden_capture_co2.py docstring) -- acquire_co2
+# reads live CO2 ppm (non-perturbing) but the SprintIR sensor must be attached
+# on COM12 for connect() to succeed and the capture to produce data.
+dummy: true
+simulation: true
+run_type: co2sensor_server
+root: C:\INST_hlo_golden
+servers:
+  CO2SENSOR:
+    host: 127.0.0.1
+    port: 8012
+    group: action
+    fast: co2sensor_server
+    params:
+      port: COM12
+      start_margin: 0
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'CO2 Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/co2goldhex.yml
+++ b/helao/deploy/hte/configs/co2goldhex.yml
@@ -1,0 +1,36 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of co2hex.yml (keeps
+# `deployment: hexagon` on CO2SENSOR + ACTVIS -- the hexagon side of the
+# runtime golden diff) used solely by
+# helao.hexagon.tests.smoke.golden_capture_co2 / co2_diff.bat to capture a
+# runtime golden-master acquire_co2 tree. The ONLY change from co2hex.yml is
+# `root:`, pointed at a dedicated throwaway path so the capture rig's
+# assert_fresh() has a clean tree to start from and production C:\INST_hlo
+# (real run data, DATABASE, USER_CONFIG) is never touched. Ports and params
+# match co2gold.yml so the capture-vs-capture parity diff compares like-for-
+# like. This is a REAL-HARDWARE capture (see golden_capture_co2.py docstring)
+# -- acquire_co2 reads live CO2 ppm (non-perturbing) but the SprintIR sensor
+# must be attached on COM12 for connect() to succeed and the capture to
+# produce data.
+dummy: true
+simulation: true
+run_type: co2sensor_server
+root: C:\INST_hlo_golden
+servers:
+  CO2SENSOR:
+    host: 127.0.0.1
+    port: 8012
+    group: action
+    fast: co2sensor_server
+    deployment: hexagon
+    params:
+      port: COM12
+      start_margin: 0
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'CO2 Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/co2hex.yml
+++ b/helao/deploy/hte/configs/co2hex.yml
@@ -1,0 +1,29 @@
+# HEXAGON CANARY for the co2sensor_server station (P3a special-split). Copy of
+# co2.yml with `deployment: hexagon` flipping CO2SENSOR (co2sensor_server) and
+# ACTVIS (action_visualizer) onto the hexagon factory -- run AT-STATION
+# (Windows, SprintIR sensor on COM12). co2.yml stays legacy for rollback; the
+# cut-over is ONLY the two `deployment: hexagon` keys. Ports/root/params match
+# co2.yml so an on-station openapi/golden diff compares like-for-like.
+dummy: true
+simulation: true
+run_type: co2sensor_server
+root: C:\INST_hlo
+servers:
+  CO2SENSOR:
+    host: 127.0.0.1
+    port: 8012
+    group: action
+    fast: co2sensor_server
+    deployment: hexagon
+    params:
+      port: COM12
+      start_margin: 0
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'CO2 Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/diapump.yml
+++ b/helao/deploy/hte/configs/diapump.yml
@@ -1,0 +1,35 @@
+# STANDALONE diapump_server canary config (P3a special-split, DIAPUMP). Mirrors
+# cam.yml's 2-server shape (one action server + one action_visualizer) so an
+# at-station openapi surface diff can compare legacy vs hexagon like-for-like
+# without pulling in the full ccsi2 station. The DOSEPUMP params (port/address)
+# are copied VERBATIM from ccsi2.yml's DOSEPUMP block. This is the diaphragm
+# dosing pump (serial COM, no vendor DLL, no COM/gclib).
+#
+# OPENAPI-CANARY ONLY (single tier, NO runtime golden-diff tier). Every diapump
+# action -- run_continuous, dispense_byvolume, dispense_byrate -- actively DRIVES
+# fluid; none is a safe non-perturbing read, so there is no valid runtime golden
+# scenario the way cam's acquire_image is. The /openapi.json surface diff
+# (diapump_canary.bat: this config + diapumphex.yml) fully proves the hexagon
+# makeActionApp route/schema factory parity. Same openapi-only precedent as the
+# dbpack and analysis canaries.
+dummy: true
+simulation: true
+run_type: diapump_server
+root: C:\INST_hlo
+servers:
+  DOSEPUMP:
+    host: 127.0.0.1
+    port: 8016
+    group: action
+    fast: diapump_server
+    params:
+      port: COM7
+      address: 0
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'DIAPUMP Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/diapumphex.yml
+++ b/helao/deploy/hte/configs/diapumphex.yml
@@ -1,0 +1,35 @@
+# HEXAGON CANARY for the diapump_server station (P3a special-split). Copy of
+# diapump.yml with `deployment: hexagon` flipping DOSEPUMP (diapump_server) and
+# ACTVIS (action_visualizer) onto the hexagon factory. diapump.yml stays legacy
+# for rollback; the cut-over is ONLY the two `deployment: hexagon` keys.
+# Ports/root/params match diapump.yml so the openapi surface diff compares
+# like-for-like.
+#
+# OPENAPI-CANARY ONLY (single tier, NO runtime golden-diff tier) -- see
+# diapump.yml's header: every diapump action drives fluid, so there is no safe
+# non-perturbing read and thus no runtime golden scenario. The /openapi.json
+# surface diff via diapump_canary.bat is the whole harness (dbpack/analysis
+# precedent).
+dummy: true
+simulation: true
+run_type: diapump_server
+root: C:\INST_hlo
+servers:
+  DOSEPUMP:
+    host: 127.0.0.1
+    port: 8016
+    group: action
+    fast: diapump_server
+    deployment: hexagon
+    params:
+      port: COM7
+      address: 0
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'DIAPUMP Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/kmotor.yml
+++ b/helao/deploy/hte/configs/kmotor.yml
@@ -1,0 +1,58 @@
+# STANDALONE kinesis_server canary config (P3a special-split, KMOTOR). Mirrors
+# galil.yml / spec.yml's 2-server shape (one action server + one
+# action_visualizer) so an at-station openapi golden diff can compare legacy
+# vs hexagon like-for-like without pulling in the full hispec station (ORCH,
+# MOTOR, PSTAT, IO, SAMPLE, SPEC_T, DB, CAM). The `axes.z` block (serial_no /
+# pos_scale / vel_scale / acc_scale / move_limit_mm) is copied VERBATIM from
+# hispec.yml's KMOTOR block so kinesis_dyn_endpoints registers the identical
+# kmove/cancel_kmove/set_velocity route surface AND so KinesisMotor.connect()
+# can actually open the real Thorlabs device at station -- a wrong/absent
+# serial_no makes connect() raise mid-loop, which leaves `self.dev_kinesis`
+# unset on the driver; kinesis_dyn_endpoints's endpoint signatures type-hint
+# their `axis` param as `app.driver.dev_kinesis`, so a missing attribute
+# raises AttributeError at endpoint-registration time and the app never
+# boots (no /openapi.json at all) -- this exact failure mode is what bit the
+# biologic canary. Real params are therefore load-bearing here even for the
+# openapi-only canary, not just for a runtime capture.
+#
+# OPENAPI-ONLY canary (no runtime golden-diff counterpart): every action
+# route kinesis_server.py registers under a configured axis --
+# `kmove` (commands motion, even a 0.0mm relative move still issues a real
+# move command to the stage), `cancel_kmove` (stops/cancels a move
+# executor), and `set_velocity` (writes velocity/acceleration parameters to
+# the live device) -- either drives the stage or mutates its hardware state.
+# There is no position/status QUERY action analogous to galil_motion's
+# `query_positions` (the poller samples position internally via
+# `get_lbuf`/live_dict, but that is not exposed as a callable action route).
+# So there is no SAFE, non-perturbing read action to dispatch for a runtime
+# golden diff -- the openapi-surface diff (see kmotor_canary.bat) is the
+# safety-appropriate parity check (mirrors ni_canary.bat's rationale exactly).
+# KinesisMotor.connect() opens a real pylablib Thorlabs.KinesisMotor handle
+# per axis -- WINDOWS-ONLY hardware; simulation:true is cosmetic (banner
+# color only), there is no Kinesis sim/dummy data path.
+dummy: true
+simulation: true
+run_type: kinesis_server
+root: C:\INST_hlo
+servers:
+  KMOTOR:
+    host: 127.0.0.1
+    port: 8015
+    group: action
+    fast: kinesis_server
+    params:
+      axes:
+        z:
+          serial_no: "49437454"
+          pos_scale: 1228800.0 # device to mm
+          vel_scale: 65970697.6 # device to mm/s
+          acc_scale: 13518.2 # device to mm/s2
+          move_limit_mm: 5.0
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'KMOTOR Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/kmotorhex.yml
+++ b/helao/deploy/hte/configs/kmotorhex.yml
@@ -1,0 +1,43 @@
+# HEXAGON CANARY for the kinesis_server station (P3a special-split). Copy of
+# kmotor.yml with `deployment: hexagon` flipping KMOTOR (kinesis_server) and
+# ACTVIS (action_visualizer) onto the hexagon factory (makeActionApp shim at
+# helao/deploy/hexagon/servers/action/kinesis_server.py) -- run AT-STATION
+# (Windows / Thorlabs Kinesis). kmotor.yml stays legacy for rollback; the
+# cut-over is ONLY the two `deployment: hexagon` keys. Ports/root/params
+# match kmotor.yml so an on-station openapi diff compares like-for-like.
+#
+# OPENAPI-ONLY (see kmotor.yml's header): every action route registered
+# under the verbatim `axes.z` block (kmove / cancel_kmove / set_velocity)
+# either drives the stage or writes live velocity/acceleration parameters to
+# the device; there is no position/status QUERY action to dispatch safely.
+# There is therefore no runtime golden-diff config pair for KMOTOR -- only
+# this openapi-surface canary (mirrors ni_canary.bat's rationale). The RPC
+# port is HTTP+10000 = 18015.
+dummy: true
+simulation: true
+run_type: kinesis_server
+root: C:\INST_hlo
+servers:
+  KMOTOR:
+    host: 127.0.0.1
+    port: 8015
+    group: action
+    fast: kinesis_server
+    deployment: hexagon
+    params:
+      axes:
+        z:
+          serial_no: "49437454"
+          pos_scale: 1228800.0 # device to mm
+          vel_scale: 65970697.6 # device to mm/s
+          acc_scale: 13518.2 # device to mm/s2
+          move_limit_mm: 5.0
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'KMOTOR Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/mfc.yml
+++ b/helao/deploy/hte/configs/mfc.yml
@@ -1,0 +1,41 @@
+# STANDALONE mfc_server canary config (P3a special-split, MFC). Mirrors
+# galil.yml/gamry.yml/spec.yml's 2-server shape (one action server + one
+# action_visualizer) so an at-station openapi/runtime golden diff can compare
+# legacy vs hexagon like-for-like without pulling in the full ccsi1 station
+# (ORCH, IO, NI, SAMPLE, DB, syringes, CO2SENSOR, N2MFC, ...). The MFC params
+# (devices CO2 -> COM9/unit_id A, co2_server_name) are copied VERBATIM from
+# ccsi1.yml's MFC block so acquire_flowrate registers identically. This is an
+# Alicat mass flow controller (pyserial over COM9) -- WINDOWS-ONLY hardware.
+# NOTE: co2_server_name points at CO2SENSOR, which is NOT in this 2-server
+# canary, so the maintain_concentration endpoints are (deterministically, on
+# BOTH legacy and hexagon) not registered -- acquire_flowrate/acquire_pressure/
+# set_*/hold_* still register whenever a device is declared. Unlike gamry,
+# AliCatMFC.__init__ does NO device I/O (dev_mfcs is built from config alone)
+# and connect() failures are caught, so the server BOOTS and serves
+# /openapi.json even with no Alicat attached; a data-producing action
+# (acquire_flowrate) additionally requires the real MFC on COM9 (see
+# mfc_diff.bat / golden_capture_mfc.py).
+dummy: true
+simulation: true
+run_type: mfc_server
+root: C:\INST_hlo
+servers:
+  MFC:
+    host: 127.0.0.1
+    port: 8009
+    group: action
+    fast: mfc_server
+    params:
+      devices:
+        CO2:
+          port: COM9
+          unit_id: A
+      co2_server_name: CO2SENSOR
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'MFC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/mfcgold.yml
+++ b/helao/deploy/hte/configs/mfcgold.yml
@@ -1,0 +1,35 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of mfc.yml used solely
+# by helao.hexagon.tests.smoke.golden_capture_mfc / mfc_diff.bat to capture a
+# runtime golden-master acquire_flowrate tree. The ONLY change from mfc.yml is
+# `root:`, pointed at a dedicated throwaway path so the capture rig's
+# assert_fresh() has a clean tree to start from and production C:\INST_hlo
+# (real run data, DATABASE, USER_CONFIG) is never touched. This is a
+# REAL-HARDWARE capture (see golden_capture_mfc.py docstring) -- acquire_flowrate
+# with flowrate_sccm=None only READS live telemetry (it never opens the valve
+# or commands flow; it ends by holding the valve CLOSED), but the Alicat MFC
+# must be attached on COM9 for the poller to buffer data and the capture to
+# produce a .hlo.
+dummy: true
+simulation: true
+run_type: mfc_server
+root: C:\INST_hlo_golden
+servers:
+  MFC:
+    host: 127.0.0.1
+    port: 8009
+    group: action
+    fast: mfc_server
+    params:
+      devices:
+        CO2:
+          port: COM9
+          unit_id: A
+      co2_server_name: CO2SENSOR
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'MFC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/mfcgoldhex.yml
+++ b/helao/deploy/hte/configs/mfcgoldhex.yml
@@ -1,0 +1,39 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of mfchex.yml (keeps
+# `deployment: hexagon` on MFC + ACTVIS -- the hexagon side of the runtime
+# golden diff) used solely by helao.hexagon.tests.smoke.golden_capture_mfc /
+# mfc_diff.bat to capture a runtime golden-master acquire_flowrate tree. The
+# ONLY change from mfchex.yml is `root:`, pointed at a dedicated throwaway path
+# so the capture rig's assert_fresh() has a clean tree to start from and
+# production C:\INST_hlo (real run data, DATABASE, USER_CONFIG) is never
+# touched. Ports and params match mfcgold.yml so the capture-vs-capture parity
+# diff compares like-for-like. This is a REAL-HARDWARE capture (see
+# golden_capture_mfc.py docstring) -- acquire_flowrate with flowrate_sccm=None
+# only READS live telemetry (never opens the valve or commands flow; ends by
+# holding the valve CLOSED), but the Alicat MFC must be attached on COM9 for
+# the poller to buffer data and the capture to produce a .hlo.
+dummy: true
+simulation: true
+run_type: mfc_server
+root: C:\INST_hlo_golden
+servers:
+  MFC:
+    host: 127.0.0.1
+    port: 8009
+    group: action
+    fast: mfc_server
+    deployment: hexagon
+    params:
+      devices:
+        CO2:
+          port: COM9
+          unit_id: A
+      co2_server_name: CO2SENSOR
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'MFC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/mfchex.yml
+++ b/helao/deploy/hte/configs/mfchex.yml
@@ -1,0 +1,32 @@
+# HEXAGON CANARY for the mfc_server station (P3a special-split). Copy of
+# mfc.yml with `deployment: hexagon` flipping MFC (mfc_server) and ACTVIS
+# (action_visualizer) onto the hexagon factory -- run AT-STATION (Windows,
+# Alicat MFC on COM9). mfc.yml stays legacy for rollback; the cut-over is ONLY
+# the two `deployment: hexagon` keys. Ports/root/params match mfc.yml so an
+# on-station openapi/golden diff compares like-for-like.
+dummy: true
+simulation: true
+run_type: mfc_server
+root: C:\INST_hlo
+servers:
+  MFC:
+    host: 127.0.0.1
+    port: 8009
+    group: action
+    fast: mfc_server
+    deployment: hexagon
+    params:
+      devices:
+        CO2:
+          port: COM9
+          unit_id: A
+      co2_server_name: CO2SENSOR
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'MFC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/ni.yml
+++ b/helao/deploy/hte/configs/ni.yml
@@ -1,0 +1,66 @@
+# STANDALONE nidaqmx_server canary config (P3a special-split, NI). Mirrors
+# spec.yml / galil.yml / gamry.yml's 2-server shape (one action server + one
+# action_visualizer) so an at-station openapi golden diff can compare legacy vs
+# hexagon like-for-like without pulling in the full ccsi1 station (ORCH, SAMPLE,
+# DB, CO2SENSOR, MFC, syringes, ...). The NI `params:` (dev_gasvalve /
+# dev_multivalve / dev_liquidvalve / dev_pump device maps) are copied VERBATIM
+# from ccsi1.yml's NI block so nidaqmx_dyn_endpoints registers exactly the same
+# route surface -- these dev_* maps GATE which action endpoints exist, so an
+# incomplete params block would change the registered routes and break the
+# openapi diff.
+#
+# OPENAPI-ONLY canary (no runtime golden-diff counterpart): ccsi1's NI block
+# declares NO `dev_monitor` (nor dev_heat / dev_cellcurrent+dev_cellvoltage),
+# so the only SAFE, non-perturbing read action (`acquire_monitors`, gated on
+# `if dev_monitor:` in nidaqmx_server.py) is NOT registered here. Every action
+# route this config DOES expose (pump / gasvalve / liquidvalve / multivalve /
+# stop) drives real hardware and must never be dispatched as a canary. So there
+# is no runtime data-capture scenario for NI under the verbatim ccsi1 params;
+# the openapi-surface diff (see ni_canary.bat) is the topology- and
+# safety-appropriate parity check. cNIMAX.connect() opens NI-DAQmx tasks against
+# the cDAQ chassis -- WINDOWS-ONLY hardware; simulation:true is cosmetic (banner
+# color), there is no NI sim/dummy data path. The openapi canary only needs the
+# server to boot and serve /openapi.json.
+dummy: true
+simulation: true
+run_type: nidaqmx_server
+root: C:\INST_hlo
+servers:
+  NI:
+    host: 127.0.0.1
+    port: 8006
+    group: action
+    fast: nidaqmx_server
+    params:
+      dev_gasvalve:
+        1A: cDAQ1Mod1/port0/line0
+        1B: cDAQ1Mod1/port0/line1
+        7A: cDAQ1Mod1/port0/line9
+        7B: cDAQ1Mod1/port0/line10
+        10-co2supply: cDAQ1Mod1/port0/line13
+        11-n2supply: cDAQ1Mod1/port0/line16
+      dev_multivalve:
+        multi_CMD0: cDAQ1Mod1/port0/line28
+        multi_CMD1: cDAQ1Mod1/port0/line29
+        multi_CMD2: cDAQ1Mod1/port0/line30
+        multi_CMD3: cDAQ1Mod1/port0/line31
+      dev_liquidvalve:
+        '2': cDAQ1Mod1/port0/line2
+        '3': cDAQ1Mod1/port0/line3
+        '4': cDAQ1Mod1/port0/line4
+        5A-cell: cDAQ1Mod1/port0/line5
+        5B-waste: cDAQ1Mod1/port0/line6
+        6A-waste: cDAQ1Mod1/port0/line7
+        6B: cDAQ1Mod1/port0/line8
+        '8': cDAQ1Mod1/port0/line11
+        '9': cDAQ1Mod1/port0/line12
+      dev_pump:
+        RecirculatingPeriPump1: cDAQ1Mod1/port0/line12
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'NI Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/nihex.yml
+++ b/helao/deploy/hte/configs/nihex.yml
@@ -1,0 +1,58 @@
+# HEXAGON CANARY for the nidaqmx_server station (P3a special-split). Copy of
+# ni.yml with `deployment: hexagon` flipping NI (nidaqmx_server) and ACTVIS
+# (action_visualizer) onto the hexagon factory (makeActionApp shim) -- run
+# AT-STATION (Windows / NI-DAQmx cDAQ chassis). ni.yml stays legacy for
+# rollback; the cut-over is ONLY the two `deployment: hexagon` keys.
+# Ports/root/params match ni.yml so an on-station openapi diff compares
+# like-for-like.
+#
+# OPENAPI-ONLY (see ni.yml's header): the verbatim ccsi1 NI block has no
+# `dev_monitor`, so the only safe non-perturbing read action
+# (`acquire_monitors`) is not registered; every other action route drives real
+# hardware. There is therefore no runtime golden-diff config pair for NI --
+# only this openapi-surface canary. The RPC port is HTTP+10000 = 18006.
+dummy: true
+simulation: true
+run_type: nidaqmx_server
+root: C:\INST_hlo
+servers:
+  NI:
+    host: 127.0.0.1
+    port: 8006
+    group: action
+    fast: nidaqmx_server
+    deployment: hexagon
+    params:
+      dev_gasvalve:
+        1A: cDAQ1Mod1/port0/line0
+        1B: cDAQ1Mod1/port0/line1
+        7A: cDAQ1Mod1/port0/line9
+        7B: cDAQ1Mod1/port0/line10
+        10-co2supply: cDAQ1Mod1/port0/line13
+        11-n2supply: cDAQ1Mod1/port0/line16
+      dev_multivalve:
+        multi_CMD0: cDAQ1Mod1/port0/line28
+        multi_CMD1: cDAQ1Mod1/port0/line29
+        multi_CMD2: cDAQ1Mod1/port0/line30
+        multi_CMD3: cDAQ1Mod1/port0/line31
+      dev_liquidvalve:
+        '2': cDAQ1Mod1/port0/line2
+        '3': cDAQ1Mod1/port0/line3
+        '4': cDAQ1Mod1/port0/line4
+        5A-cell: cDAQ1Mod1/port0/line5
+        5B-waste: cDAQ1Mod1/port0/line6
+        6A-waste: cDAQ1Mod1/port0/line7
+        6B: cDAQ1Mod1/port0/line8
+        '8': cDAQ1Mod1/port0/line11
+        '9': cDAQ1Mod1/port0/line12
+      dev_pump:
+        RecirculatingPeriPump1: cDAQ1Mod1/port0/line12
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'NI Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/powersupply.yml
+++ b/helao/deploy/hte/configs/powersupply.yml
@@ -1,0 +1,45 @@
+# STANDALONE power_supply_server canary config (P3a special-split,
+# POWER_SUPPLY). Mirrors galil.yml / kmotor.yml's 2-server shape (one action
+# server + one action_visualizer) so an at-station openapi golden diff can
+# compare legacy vs hexagon like-for-like without pulling in a full station.
+# `resource_name`/`timeout_ms` are copied verbatim from power_supply_test.yml
+# (the only reference for this server) so PowerSupplyDriver.connect() can
+# open the real pyvisa VISA resource -- a wrong/absent resource_name makes
+# connect() fail inside every executor's `_pre_exec` (ApplyVoltageExecutor /
+# SquareWaveExecutor / ConstantCurrentSquareWaveExecutor all call
+# `self.driver.connect()` there), though the openapi route surface itself
+# still registers regardless (route registration does not call connect()).
+#
+# OPENAPI-ONLY canary (no runtime golden-diff counterpart). Every action
+# route power_supply_server.py registers -- `apply_voltage`, `square_wave`,
+# `constant_current_square_wave` -- runs an executor whose `_pre_exec` calls
+# `driver.connect()` followed by `driver.set_output(True)`: EVERY action
+# energizes the supply output before doing anything else. `get_voltage_async`
+# / `get_current_async` are driver-level polling helpers used internally by
+# these executors (see power_supply_driver.py) -- they are NOT exposed as
+# standalone action endpoints, so there is no safe, non-perturbing read
+# action to dispatch for a runtime diff (mirrors ni_canary.bat /
+# kmotor_canary.bat's rationale exactly). The openapi diff (see
+# powersupply_canary.bat) is therefore the safety-appropriate parity check.
+dummy: true
+simulation: true
+run_type: power_supply
+root: C:\INST_hlo
+servers:
+  POWER_SUPPLY:
+    host: 127.0.0.1
+    port: 8002
+    group: action
+    fast: power_supply_server
+    action_vis: power_supply_vis
+    params:
+      resource_name: 'ASRL/dev/cu.usbmodem0031012B04581::INSTR'
+      timeout_ms: 10000
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'POWER_SUPPLY Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/powersupplyhex.yml
+++ b/helao/deploy/hte/configs/powersupplyhex.yml
@@ -1,0 +1,40 @@
+# HEXAGON CANARY for the power_supply_server station (P3a special-split).
+# Copy of powersupply.yml with `deployment: hexagon` flipping POWER_SUPPLY
+# (power_supply_server, via the hexagon shim at
+# helao/deploy/hexagon/servers/action/power_supply_server.py) and ACTVIS
+# (action_visualizer) onto the hexagon factory -- run AT-STATION (Windows /
+# pyvisa serial). powersupply.yml stays legacy for rollback; the cut-over is
+# ONLY the two `deployment: hexagon` keys. Ports/root/params match
+# powersupply.yml so an on-station openapi diff compares like-for-like.
+#
+# OPENAPI-ONLY (see powersupply.yml's header): every action route
+# (apply_voltage / square_wave / constant_current_square_wave) energizes the
+# supply output via `driver.connect()` + `driver.set_output(True)` in its
+# executor's `_pre_exec`; there is no position/status QUERY action to
+# dispatch safely. There is therefore no runtime golden-diff config pair for
+# POWER_SUPPLY -- only this openapi-surface canary (mirrors
+# kmotorhex.yml/nihex's rationale). The RPC port is HTTP+10000 = 18002.
+dummy: true
+simulation: true
+run_type: power_supply
+root: C:\INST_hlo
+servers:
+  POWER_SUPPLY:
+    host: 127.0.0.1
+    port: 8002
+    group: action
+    fast: power_supply_server
+    deployment: hexagon
+    action_vis: power_supply_vis
+    params:
+      resource_name: 'ASRL/dev/cu.usbmodem0031012B04581::INSTR'
+      timeout_ms: 10000
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'POWER_SUPPLY Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/syringe.yml
+++ b/helao/deploy/hte/configs/syringe.yml
@@ -1,0 +1,42 @@
+# STANDALONE syringe_server canary config (P3a special-split, SYRINGE pump).
+# Mirrors galil.yml/spec.yml's 2-server shape (one action server + one
+# action_visualizer) so an at-station openapi/runtime golden diff can compare
+# legacy vs hexagon like-for-like without pulling in the full ccsi1 station
+# (ORCH, the other syringe pumps, MFCs, sensors, DB, ...). The WORKSYRINGE
+# params (port, pumps: zero: {address, diameter}) are copied VERBATIM from
+# ccsi1.yml's WORKSYRINGE block so get_present_volume registers identically
+# (it is gated on nothing beyond the driver being constructed). This is the KD
+# Scientific Legato 100 syringe pump (KDS100 driver, pyserial over COM5) --
+# WINDOWS-ONLY hardware for the full driver lifecycle; the openapi canary only
+# needs the server to boot and serve /openapi.json.
+#
+# NOTE (unlike galil/gamry/spec): get_present_volume reads the driver's
+# software-tracked `present_volume_ul` attribute (initialized to 0.0 in
+# KDS100.__init__ and mutated only by infuse/withdraw/set_present_volume) --
+# it does NOT query the pump over the wire. On a fresh launch that value is
+# deterministically 0.0, so the runtime golden diff is hardware-INDEPENDENT
+# and fully deterministic (no masking needed); see golden_capture_syringe.py.
+dummy: true
+simulation: true
+run_type: syringe_server
+root: C:\INST_hlo
+servers:
+  WORKSYRINGE:
+    host: 127.0.0.1
+    port: 8013
+    group: action
+    fast: syringe_server
+    params:
+      port: COM5
+      pumps:
+        zero:
+          address: 0
+          diameter: 26.7
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'WORKSYRINGE Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/syringegold.yml
+++ b/helao/deploy/hte/configs/syringegold.yml
@@ -1,0 +1,37 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of syringe.yml used
+# solely by helao.hexagon.tests.smoke.golden_capture_syringe / syringe_diff.bat
+# to capture a runtime golden-master get_present_volume tree. The ONLY change
+# from syringe.yml is `root:`, pointed at a dedicated throwaway path so the
+# capture rig's assert_fresh() has a clean tree to start from and production
+# C:\INST_hlo (real run data, DATABASE, USER_CONFIG) is never touched.
+#
+# get_present_volume reads the driver's software-tracked `present_volume_ul`
+# (0.0 on a fresh launch, KDS100.__init__) -- it does NOT query the pump over
+# the wire, so this capture is deterministic and hardware-INDEPENDENT: it does
+# NOT require the Legato pump attached to produce a valid, non-vacuous, exactly
+# reproducible tree (contrast galilgold/gamrygold/specgold, whose reads need
+# the live device). See golden_capture_syringe.py's docstring.
+dummy: true
+simulation: true
+run_type: syringe_server
+root: C:\INST_hlo_golden
+servers:
+  WORKSYRINGE:
+    host: 127.0.0.1
+    port: 8013
+    group: action
+    fast: syringe_server
+    params:
+      port: COM5
+      pumps:
+        zero:
+          address: 0
+          diameter: 26.7
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'WORKSYRINGE Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/syringegoldhex.yml
+++ b/helao/deploy/hte/configs/syringegoldhex.yml
@@ -1,0 +1,39 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of syringehex.yml
+# (keeps `deployment: hexagon` on WORKSYRINGE + ACTVIS -- the hexagon side of
+# the runtime golden diff) used solely by
+# helao.hexagon.tests.smoke.golden_capture_syringe / syringe_diff.bat to
+# capture a runtime golden-master get_present_volume tree. The ONLY change from
+# syringehex.yml is `root:`, pointed at a dedicated throwaway path so the
+# capture rig's assert_fresh() has a clean tree to start from and production
+# C:\INST_hlo is never touched. Ports and params match syringegold.yml so the
+# capture-vs-capture parity diff compares like-for-like.
+#
+# get_present_volume reads the driver's software-tracked `present_volume_ul`
+# (0.0 on a fresh launch) -- it does NOT query the pump over the wire, so this
+# capture is deterministic and hardware-INDEPENDENT (see golden_capture_syringe.py).
+dummy: true
+simulation: true
+run_type: syringe_server
+root: C:\INST_hlo_golden
+servers:
+  WORKSYRINGE:
+    host: 127.0.0.1
+    port: 8013
+    group: action
+    fast: syringe_server
+    deployment: hexagon
+    params:
+      port: COM5
+      pumps:
+        zero:
+          address: 0
+          diameter: 26.7
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'WORKSYRINGE Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/syringehex.yml
+++ b/helao/deploy/hte/configs/syringehex.yml
@@ -1,0 +1,33 @@
+# HEXAGON CANARY for the syringe_server station (P3a special-split). Copy of
+# syringe.yml with `deployment: hexagon` flipping WORKSYRINGE (syringe_server)
+# and ACTVIS (action_visualizer) onto the hexagon factory -- the hte cut-over
+# target, run AT-STATION (Windows/pyserial COM5). syringe.yml stays legacy for
+# rollback; the cut-over is ONLY the two `deployment: hexagon` keys.
+# Ports/root/params match syringe.yml so an on-station openapi diff compares
+# like-for-like.
+dummy: true
+simulation: true
+run_type: syringe_server
+root: C:\INST_hlo
+servers:
+  WORKSYRINGE:
+    host: 127.0.0.1
+    port: 8013
+    group: action
+    fast: syringe_server
+    deployment: hexagon
+    params:
+      port: COM5
+      pumps:
+        zero:
+          address: 0
+          diameter: 26.7
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'WORKSYRINGE Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/tec.yml
+++ b/helao/deploy/hte/configs/tec.yml
@@ -1,0 +1,39 @@
+# STANDALONE tec_server canary config (P3a special-split, TEC). Mirrors
+# galil.yml / gamry.yml's 2-server shape (one action server + one
+# action_visualizer) so an at-station openapi/runtime golden diff can compare
+# legacy vs hexagon like-for-like without pulling in the full anec station
+# (ORCH, other action servers, LIVE visualizer). `channel`/`port` are copied
+# verbatim from anec.yml's commented TEC block (the only station reference)
+# so MeerstetterTEC opens a real MeCom serial session and
+# MeerstetterTECPoller's background poll loop produces live telemetry (see
+# mecom_driver.py) -- the poller lazily connects on its first `get_data()`
+# call, there is no explicit `connect()` call in tec_server.py.
+#
+# `record_tec` (streams TEC telemetry via a TECMonExec) is NON-PERTURBING --
+# it does not change the setpoint or enable/disable the controller -- so it
+# is the safe read used for the runtime golden diff (see tec_diff.bat /
+# golden_capture_tec.py). `set_temperature`/`enable_tec`/`disable_tec`/
+# `wait_till_stable` all drive the controller and must never be dispatched by
+# a canary.
+dummy: true
+simulation: true
+run_type: tec_server
+root: C:\INST_hlo
+servers:
+  TEC:
+    host: 127.0.0.1
+    port: 8008
+    group: action
+    fast: tec_server
+    action_vis: tec_vis
+    params:
+      channel: 1
+      port: COM5
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'TEC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/tecgold.yml
+++ b/helao/deploy/hte/configs/tecgold.yml
@@ -1,0 +1,32 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of tec.yml used solely
+# by helao.hexagon.tests.smoke.golden_capture_tec / tec_diff.bat to capture a
+# runtime golden-master record_tec tree. The ONLY change from tec.yml is
+# `root:`, pointed at a dedicated throwaway path so the capture rig's
+# assert_fresh() has a clean tree to start from and production C:\INST_hlo
+# (real run data, DATABASE, USER_CONFIG calibration) is never touched. This
+# is a REAL-HARDWARE capture (see golden_capture_tec.py docstring) --
+# record_tec only reads TEC telemetry (no setpoint/enable change), but the
+# Meerstetter controller must be reachable at `port` (COM5) for the poller to
+# connect and the capture to produce data.
+dummy: true
+simulation: true
+run_type: tec_server
+root: C:\INST_hlo_golden
+servers:
+  TEC:
+    host: 127.0.0.1
+    port: 8008
+    group: action
+    fast: tec_server
+    action_vis: tec_vis
+    params:
+      channel: 1
+      port: COM5
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    params:
+      doc_name: 'TEC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/tecgoldhex.yml
+++ b/helao/deploy/hte/configs/tecgoldhex.yml
@@ -1,0 +1,37 @@
+# CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of techex.yml (keeps
+# `deployment: hexagon` on TEC + ACTVIS -- the hexagon side of the runtime
+# golden diff) used solely by helao.hexagon.tests.smoke.golden_capture_tec /
+# tec_diff.bat to capture a runtime golden-master record_tec tree. The ONLY
+# change from techex.yml is `root:`, pointed at a dedicated throwaway path so
+# the capture rig's assert_fresh() has a clean tree to start from and
+# production C:\INST_hlo (real run data, DATABASE, USER_CONFIG calibration)
+# is never touched. Ports and params match tecgold.yml so the
+# capture-vs-capture parity diff compares like-for-like. This is a
+# REAL-HARDWARE capture (see golden_capture_tec.py docstring) -- record_tec
+# only reads TEC telemetry (no setpoint/enable change), but the Meerstetter
+# controller must be reachable at `port` (COM5) for the poller to connect and
+# the capture to produce data.
+dummy: true
+simulation: true
+run_type: tec_server
+root: C:\INST_hlo_golden
+servers:
+  TEC:
+    host: 127.0.0.1
+    port: 8008
+    group: action
+    fast: tec_server
+    deployment: hexagon
+    action_vis: tec_vis
+    params:
+      channel: 1
+      port: COM5
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'TEC Visualizer'
+      launch_browser: true

--- a/helao/deploy/hte/configs/techex.yml
+++ b/helao/deploy/hte/configs/techex.yml
@@ -1,0 +1,31 @@
+# HEXAGON CANARY for the tec_server station (P3a special-split). Copy of
+# tec.yml with `deployment: hexagon` flipping TEC (tec_server, via the
+# hexagon shim at helao/deploy/hexagon/servers/action/tec_server.py) and
+# ACTVIS (action_visualizer) onto the hexagon factory -- run AT-STATION
+# (Windows / MeCom serial). tec.yml stays legacy for rollback; the cut-over
+# is ONLY the two `deployment: hexagon` keys. Ports/root/params match tec.yml
+# so an on-station golden diff compares like-for-like.
+dummy: true
+simulation: true
+run_type: tec_server
+root: C:\INST_hlo
+servers:
+  TEC:
+    host: 127.0.0.1
+    port: 8008
+    group: action
+    fast: tec_server
+    deployment: hexagon
+    action_vis: tec_vis
+    params:
+      channel: 1
+      port: COM5
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'TEC Visualizer'
+      launch_browser: true

--- a/helao/helpers/dispatcher.py
+++ b/helao/helpers/dispatcher.py
@@ -136,10 +136,13 @@ async def async_action_dispatcher(
     rpc_args["action"] = A.as_dict()
     try:
         client = await _get_rpc_client(act_addr, act_port)
+        # Pass params via `args=` (not `**rpc_args`) so an action param named
+        # `timeout` (e.g. ANDOR/acquire) cannot collide with call()'s own
+        # `timeout` kwarg ("got multiple values for keyword argument 'timeout'").
         result = await client.call(
             rpc_method,
             timeout=min(timeout, _RPC_PROBE_TIMEOUT),
-            **rpc_args,
+            args=rpc_args,
         )
         return result, ErrorCodes.none
     except (RPCError, asyncio.TimeoutError, zmq.ZMQError, OSError) as e:
@@ -243,10 +246,12 @@ async def async_private_dispatcher(
     rpc_args.update(json_dict or {})
     try:
         client = await _get_rpc_client(host, port)
+        # `args=` (not `**rpc_args`) so a merged param/body key named `timeout`
+        # cannot collide with call()'s own `timeout` kwarg.
         result = await client.call(
             private_action,
             timeout=min(timeout, _RPC_PROBE_TIMEOUT),
-            **rpc_args,
+            args=rpc_args,
         )
         return result, ErrorCodes.none
     except (RPCError, asyncio.TimeoutError, zmq.ZMQError, OSError) as e:
@@ -374,10 +379,12 @@ def private_dispatcher(
     rpc_args.update(json_dict or {})
     try:
         client = _get_sync_rpc_client(server_host, server_port)
+        # `args=` (not `**rpc_args`) so a merged param/body key named `timeout`
+        # cannot collide with call()'s own `timeout` kwarg.
         result = client.call(
             private_action,
             timeout=min(timeout, _RPC_PROBE_TIMEOUT),
-            **rpc_args,
+            args=rpc_args,
         )
         return result, ErrorCodes.none
     except (RPCError, TimeoutError, zmq.ZMQError, OSError) as e:

--- a/helao/helpers/dispatcher.py
+++ b/helao/helpers/dispatcher.py
@@ -56,6 +56,33 @@ _SYNC_RPC_CLIENTS: Dict[Tuple[str, int], RPCSyncClient] = {}
 _RPC_PROBE_TIMEOUT = 3.0
 
 
+def _query_safe(params: dict) -> dict:
+    """Coerce a params dict into values aiohttp/yarl accept as query values.
+
+    aiohttp's query-string encoder (yarl) accepts only ``str``/``int``/``float``
+    and raises ``TypeError: Invalid variable type`` on anything else -- notably
+    a ``bool`` action param such as ``external_trigger`` (``ANDOR/acquire``),
+    which otherwise crashes the HTTP-fallback POST and gets swallowed by the
+    retry loop as an escalating-sleep "hang". Map ``bool`` -> ``"true"``/
+    ``"false"`` (FastAPI parses these back to ``bool`` on the server, and the
+    action envelope's ``action_params`` -- which carries the real typed value
+    and wins in ``_build_action_from_kwargs`` -- is unaffected), drop ``None``
+    (yarl rejects it too; the endpoint default / envelope supplies it), and pass
+    ``str``/``int``/``float`` through unchanged. Non-scalar values (list/dict)
+    are left as-is: those belong in the action envelope body, not the query
+    string, so they are out of scope for this coercion.
+    """
+    safe: dict = {}
+    for key, val in (params or {}).items():
+        if isinstance(val, bool):
+            safe[key] = "true" if val else "false"
+        elif val is None:
+            continue
+        else:
+            safe[key] = val
+    return safe
+
+
 async def _get_rpc_client(host: str, port: int) -> RPCClient:
     """Return (or lazily create) the cached async RPC client for one peer.
 
@@ -170,7 +197,7 @@ async def async_action_dispatcher(
             ) as session:
                 async with session.post(
                     url,
-                    params=params,
+                    params=_query_safe(params),
                     json={"action": A.as_dict()},
                 ) as resp:
                     response = await resp.json()
@@ -279,7 +306,7 @@ async def async_private_dispatcher(
             ) as session:
                 async with session.post(
                     url,
-                    params=params_dict,
+                    params=_query_safe(params_dict),
                     json=json_dict,
                 ) as resp:
                     response = await resp.json()
@@ -399,7 +426,7 @@ def private_dispatcher(
     with requests.Session() as session:
         with session.post(
             url,
-            params=params_dict,
+            params=_query_safe(params_dict),
             json=json_dict,
             timeout=timeout,
         ) as resp:

--- a/helao/hexagon/tests/smoke/andor_canary.bat
+++ b/helao/hexagon/tests/smoke/andor_canary.bat
@@ -1,0 +1,177 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Windows canary for the andorhex hexagon cut-over: runtime /openapi.json diff.
+REM
+REM Launches the LEGACY andor group and the HEXAGON andorhex group in turn, dumps
+REM each ANDOR server's live /openapi.json, and diffs them. An identical
+REM route/schema surface proves the hexagon makeActionApp factory produces a
+REM byte-parity action server for the andor_server (Andor Zyla camera +
+REM ATSpectrograph) cut-over target.
+REM
+REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
+REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
+REM sequences to an orchestrator. andorhex is a 2-server group (ANDOR@8011 +
+REM ACTVIS@5001) with NO orchestrator, so the GM-* scenarios cannot drive it.
+REM The openapi diff is the topology-appropriate parity check (mirrors
+REM spec_canary.bat / cam_canary.bat exactly). See andor_diff.bat for the
+REM runtime `acquire` golden diff, the topology-appropriate DATA check.
+REM
+REM Both configs share root C:\INST_hlo and ports 8011/5001, so they MUST run
+REM sequentially (this script does that) -- never launch both at once.
+REM NOTE: andor.yml's simulation:true is cosmetic (banner color) -- AndorDriver
+REM has no sim/dummy data path (see golden_capture_andor.py). AndorDriver.connect
+REM loads the vendor pyAndorSDK3 / pyAndorSpectrograph runtimes and configures
+REM the physical camera + spectrograph at startup; both should be attached so the
+REM server boots and serves /openapi.json (a data-producing action additionally
+REM requires them, see andor_diff.bat).
+REM
+REM Usage: andor_canary.bat [root] [outdir]
+REM   root   default C:\INST_hlo   (must match the configs' root: key)
+REM   outdir default %TEMP%\andor_canary
+REM ---------------------------------------------------------------------------
+
+set "ROOT=%~1"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\andor_canary"
+
+REM Guard: refuse an unsafe root (drive/fs anchor, or a root that contains the
+REM code repo) BEFORE anything touches it. safe_root.py is the single choke
+REM point; %ROOT% is only ever used read-only in this script, but the check is
+REM defense in depth against a mis-set root: key. See safe_root.py.
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` is
+REM exempt (it runs in a separate child shell).
+call conda run -n helao python "%~dp0safe_root.py" check "%ROOT%"
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT -- root %ROOT% failed the safety guard; see message above
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+set "LEGACY_JSON=%OUTDIR%\andor_openapi.json"
+set "HEX_JSON=%OUTDIR%\andorhex_openapi.json"
+
+call :run_one andor     "%LEGACY_JSON%" || goto :fail
+call :run_one andorhex  "%HEX_JSON%"    || goto :fail
+
+echo.
+echo [canary] diffing openapi surfaces
+REM Persist diff output to a file too, so the result survives the window closing.
+call conda run -n helao python "%~dp0openapi_diff.py" "%LEGACY_JSON%" "%HEX_JSON%" > "%OUTDIR%\openapi_diff.txt" 2>&1
+set "DIFF_RC=!errorlevel!"
+type "%OUTDIR%\openapi_diff.txt"
+popd
+echo.
+if "%DIFF_RC%"=="0" (
+  echo [canary] PASS -- andorhex openapi surface matches legacy andor> "%OUTDIR%\canary_result.txt"
+) else (
+  echo [canary] DIFFS FOUND rc=%DIFF_RC% -- see openapi_diff.txt> "%OUTDIR%\canary_result.txt"
+)
+type "%OUTDIR%\canary_result.txt"
+echo [canary] artifacts + result saved in: %OUTDIR%
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\canary_result.txt regardless.
+pause
+exit /b %DIFF_RC%
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = output json path
+set "PREFIX=%~1"
+set "OUTJSON=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_CANARY_%PREFIX%"
+
+echo.
+echo [canary] === %PREFIX% ===
+REM NEVER wipe %ROOT%. An openapi diff reads the live server's /openapi.json and
+REM produces no output tree, so no "fresh root" is needed. On a station %ROOT%
+REM (e.g. C:\INST_hlo) holds production RUN data, calibration, and may contain
+REM the code repo itself -- deleting it is catastrophic and unrecoverable
+REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
+REM to locate the pid pickle for kill_group.py.
+
+echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [canary] waiting for ANDOR port 8011
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8011))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [canary] FAIL %PREFIX% port 8011 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [canary] fetching /openapi.json -> %OUTJSON%
+call conda run -n helao python -c "import urllib.request,sys; open(sys.argv[2],'wb').write(urllib.request.urlopen('http://127.0.0.1:8011/openapi.json',timeout=30).read())" x "%OUTJSON%"
+set "FETCH_RC=!errorlevel!"
+
+echo [canary] killing %PREFIX%
+call :kill_one
+
+if not "%FETCH_RC%"=="0" (
+  echo [canary] FAIL %PREFIX% openapi fetch rc=%FETCH_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the AndorDriver's shutdown() runs:
+REM AndorDriver.shutdown() disconnects the camera (cam.close()), releasing the
+REM vendor SDK handle. A hard kill skips this and may leave the device claimed
+REM for the next launch -- best-effort (server dies mid-response); then wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8011
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit the canary console.
+REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main canary window.
+REM The match includes " --no-hot-reload" so prefix "andor" cannot match "andorhex".
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the ANDOR server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18011) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (andor vs andorhex) starts while a stale
+REM listener still owns 127.0.0.1:18011, the ANDOR "Address in use" fallback
+REM fires AND a dispatch_action RPC-first call would reach the STALE binder --
+REM the action is ACK'd but never runs on the live server, yielding an empty
+REM capture (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8011) or c(18011)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :andor_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:andor_ports_free
+if not "!RELEASED!"=="1" echo [canary] WARNING %PREFIX% ports 8011/18011 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [canary] ABORTED -- a launch/fetch step failed; see logs in %OUTDIR%
+echo [canary] ABORTED -- see %PREFIX%.launch.log in %OUTDIR%> "%OUTDIR%\canary_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/andor_canary.bat
+++ b/helao/hexagon/tests/smoke/andor_canary.bat
@@ -101,6 +101,18 @@ REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
 REM to locate the pid pickle for kill_group.py.
 
 echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8011 (or its co-located ZMQ RPC sibling 18011); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8011
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8011/18011 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [canary] waiting for ANDOR port 8011

--- a/helao/hexagon/tests/smoke/andor_diff.bat
+++ b/helao/hexagon/tests/smoke/andor_diff.bat
@@ -1,0 +1,225 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Runtime golden-diff driver for the andor_server hexagon canary (P3a
+REM special-split).
+REM
+REM *** DRIVES THE REAL ANDOR ZYLA CAMERA + ATSPECTROGRAPH (SOFTWARE-TRIGGERED,
+REM NON-PERTURBING SPECTRUM STREAM). ***
+REM The Andor camera + spectrograph must be ATTACHED (Windows, vendor
+REM pyAndorSDK3 / pyAndorSpectrograph runtimes present) before running this
+REM script. `acquire` streams a short burst of spectra off the detector -- it
+REM drives nothing -- but AndorDriver.connect() still needs the live devices to
+REM produce any data; see
+REM helao\hexagon\tests\smoke\golden_capture_andor.py's docstring. The capture
+REM dispatches external_trigger=False (SOFTWARE trigger) so frames flow without
+REM an external 5V TTL source.
+REM
+REM Launches andorgold (legacy) then andorgoldhex (hexagon), each against a FRESH
+REM throwaway root, drives one POST /ANDOR/acquire per launch via
+REM golden_capture_andor.py, snapshots the resulting RUNS tree, and diffs the two
+REM captures with harness.parity. Mirrors the conventions already proven in
+REM spec_diff.bat / co2_diff.bat / galil_diff.bat (call conda / ping sleeps /
+REM cmdline-scoped Stop-Process / persisted results + pause) -- see those scripts
+REM for why harness.capture/parity_run.sh cannot drive this orch-less, db-less
+REM 2-server topology.
+REM
+REM Usage: andor_diff.bat [caproot] [outdir]
+REM   caproot default C:\INST_hlo_golden -- a DEDICATED THROWAWAY capture root,
+REM            fully wiped before EACH capture (see :wipe_caproot). NEVER point
+REM            this at C:\INST_hlo or any root holding real data.
+REM   outdir  default %TEMP%\andor_golden -- capture sets + parity report land
+REM            here (outdir\andor, outdir\andorhex, outdir\parity-report.json,
+REM            outdir\golden_result.txt).
+REM ---------------------------------------------------------------------------
+
+set "CAPROOT=%~1"
+if "%CAPROOT%"=="" set "CAPROOT=C:\INST_hlo_golden"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\andor_golden"
+set "PROD_ROOT=C:\INST_hlo"
+
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates
+REM when conda.bat returns (silent exit). Only the conda inside
+REM `start ... cmd /c` (in :run_one below) is exempt -- it runs in a separate
+REM child shell.
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard; see message above
+  exit /b 2
+)
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- caproot equals production root %PROD_ROOT%; refusing to run
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+
+call :wipe_caproot || goto :fail
+call :run_one andorgold    "%OUTDIR%\andor"    || goto :fail
+call :wipe_caproot || goto :fail
+call :run_one andorgoldhex "%OUTDIR%\andorhex" || goto :fail
+
+echo.
+echo [golden] running parity diff
+call conda run -n helao python -m harness.parity --golden "%OUTDIR%\andor" --candidate "%OUTDIR%\andorhex" --report "%OUTDIR%\parity-report.json" > "%OUTDIR%\parity_stdout.txt" 2>&1
+set "PARITY_RC=!errorlevel!"
+type "%OUTDIR%\parity_stdout.txt"
+
+echo.
+echo [golden] full parity report (also saved to %OUTDIR%\parity-report.json):
+type "%OUTDIR%\parity-report.json"
+
+popd
+echo.
+REM The acquire .hlo body columns (tick_time / ch_NNNN) are masked via the
+REM capture manifest's masked_hlo_columns and the row count compared within
+REM hlo_row_count_tolerance (poll-paced stream), and the per-run
+REM action_params.action_path is masked via masked_meta_keys (see
+REM golden_capture_andor.py) -- so parity rc=0 is a genuine PASS and rc!=0 means
+REM a REAL hexagon-vs-legacy diff. The .hlo header `wl` (pixel->wavelength table)
+REM + column_headings are config-deterministic and compared unmasked. The full
+REM report is printed and persisted above either way for inspection.
+if "%PARITY_RC%"=="0" (
+  (
+    echo [golden] PASS -- andorgoldhex RUNS-tree matches legacy andorgold ^(acquire, masked^)
+    echo [golden] artifacts: %OUTDIR%\andor, %OUTDIR%\andorhex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+) else (
+  (
+    echo [golden] DIFFS FOUND rc=%PARITY_RC% -- REAL regression, inspect the report
+    echo [golden] open %OUTDIR%\parity-report.json: tree_diffs / file_diffs list
+    echo [golden]   every differing member and key. The acquire .hlo data
+    echo [golden]   columns + action_path are masked, so anything shown here is a
+    echo [golden]   genuine hexagon-vs-legacy difference.
+    echo [golden] artifacts: %OUTDIR%\andor, %OUTDIR%\andorhex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+)
+type "%OUTDIR%\golden_result.txt"
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\golden_result.txt regardless.
+pause
+exit /b %PARITY_RC%
+
+REM ---------------------------------------------------------------------------
+:wipe_caproot
+REM Full-wipe the throwaway capture root before each capture -- required
+REM because golden_capture_andor.py's assert_fresh() refuses a root that already
+REM contains run artifacts. This rmdir is safe ONLY because %CAPROOT% just
+REM passed safe_root.py's check (repo not underneath it, not a drive/fs anchor)
+REM AND the equality guard below proves it is not production C:\INST_hlo -- it
+REM must NEVER run against a root that could hold real station data (run output,
+REM DATABASE, USER_CONFIG).
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- refusing to wipe production root %PROD_ROOT%
+  exit /b 2
+)
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard before wipe
+  exit /b 2
+)
+if exist "%CAPROOT%" (
+  echo [golden] wiping throwaway caproot %CAPROOT%
+  rmdir /s /q "%CAPROOT%"
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = capture out dir
+set "PREFIX=%~1"
+set "CAPOUT=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
+
+echo.
+echo [golden] === %PREFIX% ===
+echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [golden] waiting for ANDOR port 8011
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8011))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [golden] FAIL %PREFIX% port 8011 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [golden] capturing acquire -^> %CAPOUT%
+call conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_andor --config-prefix %PREFIX% --root "%CAPROOT%" --out "%CAPOUT%" > "%OUTDIR%\%PREFIX%.capture.log" 2>&1
+set "CAPTURE_RC=!errorlevel!"
+type "%OUTDIR%\%PREFIX%.capture.log"
+
+echo [golden] killing %PREFIX%
+call :kill_one
+REM Let the Andor camera handle release before the next launch reopens it --
+REM killing the python server does not instantly guarantee the vendor SDK
+REM released the device. ~5s margin between our two sequential captures.
+ping -n 6 -w 1000 127.0.0.1 >nul
+
+if not "%CAPTURE_RC%"=="0" (
+  echo [golden] FAIL %PREFIX% capture rc=%CAPTURE_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the AndorDriver's shutdown() runs:
+REM AndorDriver.shutdown() disconnects the camera (cam.close()), releasing the
+REM vendor SDK handle. A hard kill skips this and may leave the device claimed
+REM for the next launch. Best-effort (server dies mid-response); then wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8011
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit this console.
+REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can
+REM cascade through a shared conhost.exe and close the main window.
+REM The match includes " --no-hot-reload" so "andorgold" cannot match
+REM "andorgoldhex" (no space follows "andorgold" in that cmdline).
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the ANDOR server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18011) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (andorgold vs andorgoldhex) -- or a preceding
+REM andor_canary run on the same ports -- leaves a stale listener owning
+REM 127.0.0.1:18011, a dispatch_action RPC-first call reaches the STALE binder:
+REM the action is ACK'd but never runs on the live server, yielding an empty
+REM capture (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8011) or c(18011)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :andor_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:andor_ports_free
+if not "!RELEASED!"=="1" echo [golden] WARNING %PREFIX% ports 8011/18011 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [golden] ABORTED -- a launch/capture step failed; see logs in %OUTDIR%
+echo [golden] ABORTED -- see %OUTDIR%\*.launch.log / *.capture.log> "%OUTDIR%\golden_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/andor_diff.bat
+++ b/helao/hexagon/tests/smoke/andor_diff.bat
@@ -176,7 +176,13 @@ REM settle ~3s (ping, not timeout, to survive redirected stdin)
 ping -n 4 -w 1000 127.0.0.1 >nul
 
 echo [golden] capturing acquire -^> %CAPOUT%
-call conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_andor --config-prefix %PREFIX% --root "%CAPROOT%" --out "%CAPOUT%" > "%OUTDIR%\%PREFIX%.capture.log" 2>&1
+REM --no-capture-output + python -u: `conda run` otherwise CAPTURES the child's
+REM stdout/stderr and only releases it when the child exits, so a HUNG capture
+REM leaves an empty .capture.log (even flushed prints never surface) and the
+REM stall is unattributable. With both flags the flushed stage breadcrumbs in
+REM golden_capture_andor land in the log LIVE, so the last line pinpoints where
+REM a hang occurred. Tail it from another window: powershell Get-Content -Wait.
+call conda run --no-capture-output -n helao python -u -m helao.hexagon.tests.smoke.golden_capture_andor --config-prefix %PREFIX% --root "%CAPROOT%" --out "%CAPOUT%" > "%OUTDIR%\%PREFIX%.capture.log" 2>&1
 set "CAPTURE_RC=!errorlevel!"
 type "%OUTDIR%\%PREFIX%.capture.log"
 

--- a/helao/hexagon/tests/smoke/andor_diff.bat
+++ b/helao/hexagon/tests/smoke/andor_diff.bat
@@ -143,6 +143,18 @@ set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
 echo.
 echo [golden] === %PREFIX% ===
 echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8011 (or its co-located ZMQ RPC sibling 18011); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8011
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT %PREFIX% -- ports 8011/18011 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [golden] waiting for ANDOR port 8011

--- a/helao/hexagon/tests/smoke/biologic_canary.bat
+++ b/helao/hexagon/tests/smoke/biologic_canary.bat
@@ -102,6 +102,18 @@ REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
 REM to locate the pid pickle for kill_group.py.
 
 echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8016 (or its co-located ZMQ RPC sibling 18016); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8016
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8016/18016 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [canary] waiting for BIOLOGIC port 8016

--- a/helao/hexagon/tests/smoke/biologic_canary.bat
+++ b/helao/hexagon/tests/smoke/biologic_canary.bat
@@ -1,0 +1,181 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Windows canary for the biologichex hexagon cut-over: runtime /openapi.json
+REM diff.
+REM
+REM Launches the LEGACY biologic group and the HEXAGON biologichex group in turn,
+REM dumps each BIOLOGIC server's live /openapi.json, and diffs them. An identical
+REM route/schema surface proves the hexagon makeActionApp factory produces a
+REM byte-parity action server for the biologic_server (Biologic potentiostat)
+REM cut-over target.
+REM
+REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
+REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
+REM sequences to an orchestrator. biologichex is a 2-server group (BIOLOGIC@8016
+REM + ACTVIS@5001) with NO orchestrator, so the GM-* scenarios cannot drive it.
+REM The openapi diff is the topology-appropriate parity check (mirrors
+REM spec_canary.bat / gamryhex_canary.bat exactly). See biologic_diff.bat for the
+REM runtime run_OCV golden diff, the topology-appropriate DATA check.
+REM
+REM Both configs share root C:\INST_hlo and ports 8016/5001, so they MUST run
+REM sequentially (this script does that) -- never launch both at once.
+REM NOTE: biologic.yml's simulation:true is cosmetic (banner color) -- the
+REM Biologic driver has no sim/dummy data path and easy_biologic imports only on
+REM Windows (see golden_capture_biologic.py). BiologicDriver.connect() opens a
+REM TCP connection to the physical instrument at startup; the instrument should
+REM be attached so the server boots and serves /openapi.json (a data-producing
+REM action additionally requires it + a dummy cell, see biologic_diff.bat).
+REM
+REM Usage: biologic_canary.bat [root] [outdir]
+REM   root   default C:\INST_hlo   (must match the configs' root: key)
+REM   outdir default %TEMP%\biologic_canary
+REM ---------------------------------------------------------------------------
+
+set "ROOT=%~1"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\biologic_canary"
+
+REM Guard: refuse an unsafe root (drive/fs anchor, or a root that contains the
+REM code repo) BEFORE anything touches it. safe_root.py is the single choke
+REM point; %ROOT% is only ever used read-only in this script, but the check is
+REM defense in depth against a mis-set root: key. See safe_root.py.
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` is
+REM exempt (it runs in a separate child shell).
+call conda run -n helao python "%~dp0safe_root.py" check "%ROOT%"
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT -- root %ROOT% failed the safety guard; see message above
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+set "LEGACY_JSON=%OUTDIR%\biologic_openapi.json"
+set "HEX_JSON=%OUTDIR%\biologichex_openapi.json"
+
+call :run_one biologic     "%LEGACY_JSON%" || goto :fail
+call :run_one biologichex  "%HEX_JSON%"    || goto :fail
+
+echo.
+echo [canary] diffing openapi surfaces
+REM Persist diff output to a file too, so the result survives the window closing.
+call conda run -n helao python "%~dp0openapi_diff.py" "%LEGACY_JSON%" "%HEX_JSON%" > "%OUTDIR%\openapi_diff.txt" 2>&1
+set "DIFF_RC=!errorlevel!"
+type "%OUTDIR%\openapi_diff.txt"
+popd
+echo.
+if "%DIFF_RC%"=="0" (
+  echo [canary] PASS -- biologichex openapi surface matches legacy biologic> "%OUTDIR%\canary_result.txt"
+) else (
+  echo [canary] DIFFS FOUND rc=%DIFF_RC% -- see openapi_diff.txt> "%OUTDIR%\canary_result.txt"
+)
+type "%OUTDIR%\canary_result.txt"
+echo [canary] artifacts + result saved in: %OUTDIR%
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\canary_result.txt regardless.
+pause
+exit /b %DIFF_RC%
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = output json path
+set "PREFIX=%~1"
+set "OUTJSON=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_CANARY_%PREFIX%"
+
+echo.
+echo [canary] === %PREFIX% ===
+REM NEVER wipe %ROOT%. An openapi diff reads the live server's /openapi.json and
+REM produces no output tree, so no "fresh root" is needed. On a station %ROOT%
+REM (e.g. C:\INST_hlo) holds production RUN data, calibration matrices, and may
+REM contain the code repo itself -- deleting it is catastrophic and unrecoverable
+REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
+REM to locate the pid pickle for kill_group.py.
+
+echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [canary] waiting for BIOLOGIC port 8016
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8016))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [canary] FAIL %PREFIX% port 8016 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [canary] fetching /openapi.json -> %OUTJSON%
+call conda run -n helao python -c "import urllib.request,sys; open(sys.argv[2],'wb').write(urllib.request.urlopen('http://127.0.0.1:8016/openapi.json',timeout=30).read())" x "%OUTJSON%"
+set "FETCH_RC=!errorlevel!"
+
+echo [canary] killing %PREFIX%
+call :kill_one
+
+if not "%FETCH_RC%"=="0" (
+  echo [canary] FAIL %PREFIX% openapi fetch rc=%FETCH_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the Biologic driver's shutdown() runs:
+REM BiologicDriver.shutdown() stops any running channels and disconnects the
+REM easy_biologic TCP connection (clearing connection_raised so the next launch
+REM can reconnect). A hard kill skips this and may leave the instrument's
+REM connection claimed for the next launch -- best-effort (server dies
+REM mid-response); then wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8016
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit the canary console.
+REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main canary window.
+REM The match includes " --no-hot-reload" so prefix "biologic" cannot match
+REM "biologichex" (no space follows "biologic" in that cmdline).
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the BIOLOGIC server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18016) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (biologic vs biologichex) starts while a stale
+REM listener still owns 127.0.0.1:18016, the BIOLOGIC "Address in use" fallback
+REM fires AND a dispatch_action RPC-first call would reach the STALE binder --
+REM the action is ACK'd but never runs on the live server, yielding an empty
+REM capture (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8016) or c(18016)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :bio_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:bio_ports_free
+if not "!RELEASED!"=="1" echo [canary] WARNING %PREFIX% ports 8016/18016 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [canary] ABORTED -- a launch/fetch step failed; see logs in %OUTDIR%
+echo [canary] ABORTED -- see %PREFIX%.launch.log in %OUTDIR%> "%OUTDIR%\canary_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/biologic_diff.bat
+++ b/helao/hexagon/tests/smoke/biologic_diff.bat
@@ -1,0 +1,225 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Runtime golden-diff driver for the biologic_server hexagon canary (P3a
+REM special-split).
+REM
+REM *** DRIVES THE REAL BIOLOGIC POTENTIOSTAT (OPEN-CIRCUIT READ, NON-PERTURBING). ***
+REM The Biologic instrument must be ATTACHED with a DUMMY CELL / CALIBRATION
+REM RESISTOR (Windows, easy_biologic present) before running this script.
+REM run_OCV monitors the open-circuit potential -- it imposes no potential or
+REM current on the cell (unlike run_CA/run_CP/run_CV/run_PEIS/run_GEIS/run_CAOCV)
+REM -- but BiologicDriver.connect() still needs the live device to produce any
+REM data; see helao\hexagon\tests\smoke\golden_capture_biologic.py's docstring.
+REM
+REM Launches biologicgold (legacy) then biologicgoldhex (hexagon), each against a
+REM FRESH throwaway root, drives one POST /BIOLOGIC/run_OCV per launch via
+REM golden_capture_biologic.py, snapshots the resulting RUNS tree, and diffs the
+REM two captures with harness.parity. Mirrors the conventions already proven in
+REM spec_diff.bat/galil_diff.bat (call conda / ping sleeps / cmdline-scoped
+REM Stop-Process / persisted results + pause) -- see those scripts for why
+REM harness.capture/parity_run.sh cannot drive this orch-less, db-less 2-server
+REM topology.
+REM
+REM Usage: biologic_diff.bat [caproot] [outdir]
+REM   caproot default C:\INST_hlo_golden -- a DEDICATED THROWAWAY capture root,
+REM            fully wiped before EACH capture (see :wipe_caproot). NEVER point
+REM            this at C:\INST_hlo or any root holding real data.
+REM   outdir  default %TEMP%\biologic_golden -- capture sets + parity report land
+REM            here (outdir\biologic, outdir\biologichex, outdir\parity-report.json,
+REM            outdir\golden_result.txt).
+REM ---------------------------------------------------------------------------
+
+set "CAPROOT=%~1"
+if "%CAPROOT%"=="" set "CAPROOT=C:\INST_hlo_golden"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\biologic_golden"
+set "PROD_ROOT=C:\INST_hlo"
+
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates
+REM when conda.bat returns (silent exit). Only the conda inside
+REM `start ... cmd /c` (in :run_one below) is exempt -- it runs in a separate
+REM child shell.
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard; see message above
+  exit /b 2
+)
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- caproot equals production root %PROD_ROOT%; refusing to run
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+
+call :wipe_caproot || goto :fail
+call :run_one biologicgold    "%OUTDIR%\biologic"    || goto :fail
+call :wipe_caproot || goto :fail
+call :run_one biologicgoldhex "%OUTDIR%\biologichex" || goto :fail
+
+echo.
+echo [golden] running parity diff
+call conda run -n helao python -m harness.parity --golden "%OUTDIR%\biologic" --candidate "%OUTDIR%\biologichex" --report "%OUTDIR%\parity-report.json" > "%OUTDIR%\parity_stdout.txt" 2>&1
+set "PARITY_RC=!errorlevel!"
+type "%OUTDIR%\parity_stdout.txt"
+
+echo.
+echo [golden] full parity report (also saved to %OUTDIR%\parity-report.json):
+type "%OUTDIR%\parity-report.json"
+
+popd
+echo.
+REM The run_OCV .hlo body columns (t_s / Ewe_V / the _<Field> CurrentValues
+REM segment columns) are masked via the capture manifest's masked_hlo_columns,
+REM and the data-derived -act.yml action_params (t_s__mean_final /
+REM Ewe_V__mean_final / has_bubble) via masked_meta_keys (see
+REM golden_capture_biologic.py) since they are live measurements, not
+REM deterministic sim data -- so parity rc=0 is a genuine PASS and rc!=0 means a
+REM REAL hexagon-vs-legacy diff. The "channel" column is deterministic and
+REM compared unmasked. The full report is printed and persisted above either way
+REM for inspection.
+if "%PARITY_RC%"=="0" (
+  (
+    echo [golden] PASS -- biologicgoldhex RUNS-tree matches legacy biologicgold ^(run_OCV, masked^)
+    echo [golden] artifacts: %OUTDIR%\biologic, %OUTDIR%\biologichex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+) else (
+  (
+    echo [golden] DIFFS FOUND rc=%PARITY_RC% -- REAL regression, inspect the report
+    echo [golden] open %OUTDIR%\parity-report.json: tree_diffs / file_diffs list
+    echo [golden]   every differing member and key. The run_OCV .hlo data columns
+    echo [golden]   and the data-derived -act.yml means/has_bubble are masked, so
+    echo [golden]   anything shown here is a genuine hexagon-vs-legacy difference.
+    echo [golden] artifacts: %OUTDIR%\biologic, %OUTDIR%\biologichex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+)
+type "%OUTDIR%\golden_result.txt"
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\golden_result.txt regardless.
+pause
+exit /b %PARITY_RC%
+
+REM ---------------------------------------------------------------------------
+:wipe_caproot
+REM Full-wipe the throwaway capture root before each capture -- required
+REM because golden_capture_biologic.py's assert_fresh() refuses a root that
+REM already contains run artifacts. This rmdir is safe ONLY because %CAPROOT%
+REM just passed safe_root.py's check (repo not underneath it, not a drive/fs
+REM anchor) AND the equality guard below proves it is not production C:\INST_hlo
+REM -- it must NEVER run against a root that could hold real station data (run
+REM output, DATABASE, USER_CONFIG calibration matrices).
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- refusing to wipe production root %PROD_ROOT%
+  exit /b 2
+)
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard before wipe
+  exit /b 2
+)
+if exist "%CAPROOT%" (
+  echo [golden] wiping throwaway caproot %CAPROOT%
+  rmdir /s /q "%CAPROOT%"
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = capture out dir
+set "PREFIX=%~1"
+set "CAPOUT=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
+
+echo.
+echo [golden] === %PREFIX% ===
+echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [golden] waiting for BIOLOGIC port 8016
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8016))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [golden] FAIL %PREFIX% port 8016 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [golden] capturing run_OCV -^> %CAPOUT%
+call conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_biologic --config-prefix %PREFIX% --root "%CAPROOT%" --out "%CAPOUT%" > "%OUTDIR%\%PREFIX%.capture.log" 2>&1
+set "CAPTURE_RC=!errorlevel!"
+type "%OUTDIR%\%PREFIX%.capture.log"
+
+echo [golden] killing %PREFIX%
+call :kill_one
+REM Let the Biologic TCP connection release before the next launch reopens it --
+REM killing the python server does not instantly guarantee easy_biologic released
+REM the instrument connection. ~5s margin between our two sequential captures.
+ping -n 6 -w 1000 127.0.0.1 >nul
+
+if not "%CAPTURE_RC%"=="0" (
+  echo [golden] FAIL %PREFIX% capture rc=%CAPTURE_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the Biologic driver's shutdown() runs:
+REM BiologicDriver.shutdown() stops any running channels and disconnects the
+REM easy_biologic TCP connection (clearing connection_raised so the next launch
+REM can reconnect). A hard kill skips this and may leave the instrument's
+REM connection claimed for the next launch. Best-effort (server dies
+REM mid-response); then wait for release.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8016
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit this console.
+REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can
+REM cascade through a shared conhost.exe and close the main window.
+REM The match includes " --no-hot-reload" so "biologicgold" cannot match
+REM "biologicgoldhex" (no space follows "biologicgold" in that cmdline).
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the BIOLOGIC server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18016) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (biologicgold vs biologicgoldhex) -- or a
+REM preceding biologic_canary run on the same ports -- leaves a stale listener
+REM owning 127.0.0.1:18016, a dispatch_action RPC-first call reaches the STALE
+REM binder: the action is ACK'd but never runs on the live server, yielding an
+REM empty capture (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8016) or c(18016)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :bio_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:bio_ports_free
+if not "!RELEASED!"=="1" echo [golden] WARNING %PREFIX% ports 8016/18016 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [golden] ABORTED -- a launch/capture step failed; see logs in %OUTDIR%
+echo [golden] ABORTED -- see %OUTDIR%\*.launch.log / *.capture.log> "%OUTDIR%\golden_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/biologic_diff.bat
+++ b/helao/hexagon/tests/smoke/biologic_diff.bat
@@ -141,6 +141,18 @@ set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
 echo.
 echo [golden] === %PREFIX% ===
 echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8016 (or its co-located ZMQ RPC sibling 18016); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8016
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT %PREFIX% -- ports 8016/18016 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [golden] waiting for BIOLOGIC port 8016

--- a/helao/hexagon/tests/smoke/cam_canary.bat
+++ b/helao/hexagon/tests/smoke/cam_canary.bat
@@ -105,6 +105,18 @@ REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
 REM to locate the pid pickle for kill_group.py.
 
 echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8013 (or its co-located ZMQ RPC sibling 18013); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8013
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8013/18013 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [canary] waiting for CAM port 8013

--- a/helao/hexagon/tests/smoke/cam_diff.bat
+++ b/helao/hexagon/tests/smoke/cam_diff.bat
@@ -140,6 +140,18 @@ set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
 echo.
 echo [golden] === %PREFIX% ===
 echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8013 (or its co-located ZMQ RPC sibling 18013); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8013
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT %PREFIX% -- ports 8013/18013 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [golden] waiting for CAM port 8013

--- a/helao/hexagon/tests/smoke/co2_canary.bat
+++ b/helao/hexagon/tests/smoke/co2_canary.bat
@@ -1,0 +1,177 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Windows canary for the co2hex hexagon cut-over: runtime /openapi.json diff.
+REM
+REM Launches the LEGACY co2 group and the HEXAGON co2hex group in turn, dumps
+REM each CO2SENSOR server's live /openapi.json, and diffs them. An identical
+REM route/schema surface proves the hexagon makeActionApp factory produces a
+REM byte-parity action server for the co2sensor_server (SprintIR-6S CO2 sensor)
+REM cut-over target.
+REM
+REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
+REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
+REM sequences to an orchestrator. co2hex is a 2-server group (CO2SENSOR@8012 +
+REM ACTVIS@5001) with NO orchestrator, so the GM-* scenarios cannot drive it.
+REM The openapi diff is the topology-appropriate parity check (mirrors
+REM spec_canary.bat / galil_canary.bat / gamryhex_canary.bat exactly). See
+REM co2_diff.bat for the runtime acquire_co2 golden diff, the topology-
+REM appropriate DATA check.
+REM
+REM Both configs share root C:\INST_hlo and ports 8012/5001, so they MUST run
+REM sequentially (this script does that) -- never launch both at once.
+REM NOTE: co2.yml's simulation:true is cosmetic (banner color) -- SprintIR has
+REM no sim/dummy data path (see golden_capture_co2.py). SprintIR.connect() opens
+REM the serial port (COM12) and configures the physical sensor at startup; the
+REM sensor should be attached so the server boots and serves /openapi.json (a
+REM data-producing action additionally requires it, see co2_diff.bat).
+REM
+REM Usage: co2_canary.bat [root] [outdir]
+REM   root   default C:\INST_hlo   (must match the configs' root: key)
+REM   outdir default %TEMP%\co2_canary
+REM ---------------------------------------------------------------------------
+
+set "ROOT=%~1"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\co2_canary"
+
+REM Guard: refuse an unsafe root (drive/fs anchor, or a root that contains the
+REM code repo) BEFORE anything touches it. safe_root.py is the single choke
+REM point; %ROOT% is only ever used read-only in this script, but the check is
+REM defense in depth against a mis-set root: key. See safe_root.py.
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` is
+REM exempt (it runs in a separate child shell).
+call conda run -n helao python "%~dp0safe_root.py" check "%ROOT%"
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT -- root %ROOT% failed the safety guard; see message above
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+set "LEGACY_JSON=%OUTDIR%\co2_openapi.json"
+set "HEX_JSON=%OUTDIR%\co2hex_openapi.json"
+
+call :run_one co2     "%LEGACY_JSON%" || goto :fail
+call :run_one co2hex  "%HEX_JSON%"    || goto :fail
+
+echo.
+echo [canary] diffing openapi surfaces
+REM Persist diff output to a file too, so the result survives the window closing.
+call conda run -n helao python "%~dp0openapi_diff.py" "%LEGACY_JSON%" "%HEX_JSON%" > "%OUTDIR%\openapi_diff.txt" 2>&1
+set "DIFF_RC=!errorlevel!"
+type "%OUTDIR%\openapi_diff.txt"
+popd
+echo.
+if "%DIFF_RC%"=="0" (
+  echo [canary] PASS -- co2hex openapi surface matches legacy co2> "%OUTDIR%\canary_result.txt"
+) else (
+  echo [canary] DIFFS FOUND rc=%DIFF_RC% -- see openapi_diff.txt> "%OUTDIR%\canary_result.txt"
+)
+type "%OUTDIR%\canary_result.txt"
+echo [canary] artifacts + result saved in: %OUTDIR%
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\canary_result.txt regardless.
+pause
+exit /b %DIFF_RC%
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = output json path
+set "PREFIX=%~1"
+set "OUTJSON=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_CANARY_%PREFIX%"
+
+echo.
+echo [canary] === %PREFIX% ===
+REM NEVER wipe %ROOT%. An openapi diff reads the live server's /openapi.json and
+REM produces no output tree, so no "fresh root" is needed. On a station %ROOT%
+REM (e.g. C:\INST_hlo) holds production RUN data, calibration matrices, and may
+REM contain the code repo itself -- deleting it is catastrophic and unrecoverable
+REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
+REM to locate the pid pickle for kill_group.py.
+
+echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [canary] waiting for CO2SENSOR port 8012
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8012))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [canary] FAIL %PREFIX% port 8012 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [canary] fetching /openapi.json -> %OUTJSON%
+call conda run -n helao python -c "import urllib.request,sys; open(sys.argv[2],'wb').write(urllib.request.urlopen('http://127.0.0.1:8012/openapi.json',timeout=30).read())" x "%OUTJSON%"
+set "FETCH_RC=!errorlevel!"
+
+echo [canary] killing %PREFIX%
+call :kill_one
+
+if not "%FETCH_RC%"=="0" (
+  echo [canary] FAIL %PREFIX% openapi fetch rc=%FETCH_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the SprintIR driver's shutdown() runs:
+REM SprintIR.shutdown() closes the serial port (COM12). A hard kill skips this
+REM and may leave the port claimed for the next launch -- best-effort (server
+REM dies mid-response); then wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8012
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit the canary console.
+REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main canary window.
+REM The match includes " --no-hot-reload" so prefix "co2" cannot match "co2hex".
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the CO2SENSOR server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18012) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (co2 vs co2hex) starts while a stale listener
+REM still owns 127.0.0.1:18012, the CO2SENSOR "Address in use" fallback fires
+REM AND a dispatch_action RPC-first call would reach the STALE binder -- the
+REM action is ACK'd but never runs on the live server, yielding an empty capture
+REM (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8012) or c(18012)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :co2_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:co2_ports_free
+if not "!RELEASED!"=="1" echo [canary] WARNING %PREFIX% ports 8012/18012 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [canary] ABORTED -- a launch/fetch step failed; see logs in %OUTDIR%
+echo [canary] ABORTED -- see %PREFIX%.launch.log in %OUTDIR%> "%OUTDIR%\canary_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/co2_canary.bat
+++ b/helao/hexagon/tests/smoke/co2_canary.bat
@@ -101,6 +101,18 @@ REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
 REM to locate the pid pickle for kill_group.py.
 
 echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8012 (or its co-located ZMQ RPC sibling 18012); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8012
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8012/18012 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [canary] waiting for CO2SENSOR port 8012

--- a/helao/hexagon/tests/smoke/co2_diff.bat
+++ b/helao/hexagon/tests/smoke/co2_diff.bat
@@ -138,6 +138,18 @@ set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
 echo.
 echo [golden] === %PREFIX% ===
 echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8012 (or its co-located ZMQ RPC sibling 18012); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8012
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT %PREFIX% -- ports 8012/18012 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [golden] waiting for CO2SENSOR port 8012

--- a/helao/hexagon/tests/smoke/co2_diff.bat
+++ b/helao/hexagon/tests/smoke/co2_diff.bat
@@ -1,0 +1,220 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Runtime golden-diff driver for the co2sensor_server hexagon canary (P3a
+REM special-split).
+REM
+REM *** DRIVES THE REAL SprintIR-6S CO2 SENSOR (STREAM READ, NON-PERTURBING). ***
+REM The SprintIR sensor must be ATTACHED (Windows, serial COM12) before running
+REM this script. acquire_co2 mirrors live CO2 ppm off the sensor for a short
+REM finite duration -- it drives nothing -- but SprintIR.connect() still needs
+REM the live device to produce any data; see
+REM helao\hexagon\tests\smoke\golden_capture_co2.py's docstring.
+REM
+REM Launches co2gold (legacy) then co2goldhex (hexagon), each against a FRESH
+REM throwaway root, drives one POST /CO2SENSOR/acquire_co2 per launch via
+REM golden_capture_co2.py, snapshots the resulting RUNS tree, and diffs the two
+REM captures with harness.parity. Mirrors the conventions already proven in
+REM spec_diff.bat / galil_diff.bat / golden_diff.bat (call conda / ping sleeps /
+REM cmdline-scoped Stop-Process / persisted results + pause) -- see those
+REM scripts for why harness.capture/parity_run.sh cannot drive this orch-less,
+REM db-less 2-server topology.
+REM
+REM Usage: co2_diff.bat [caproot] [outdir]
+REM   caproot default C:\INST_hlo_golden -- a DEDICATED THROWAWAY capture root,
+REM            fully wiped before EACH capture (see :wipe_caproot). NEVER point
+REM            this at C:\INST_hlo or any root holding real data.
+REM   outdir  default %TEMP%\co2_golden -- capture sets + parity report land
+REM            here (outdir\co2, outdir\co2hex, outdir\parity-report.json,
+REM            outdir\golden_result.txt).
+REM ---------------------------------------------------------------------------
+
+set "CAPROOT=%~1"
+if "%CAPROOT%"=="" set "CAPROOT=C:\INST_hlo_golden"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\co2_golden"
+set "PROD_ROOT=C:\INST_hlo"
+
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates
+REM when conda.bat returns (silent exit). Only the conda inside
+REM `start ... cmd /c` (in :run_one below) is exempt -- it runs in a separate
+REM child shell.
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard; see message above
+  exit /b 2
+)
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- caproot equals production root %PROD_ROOT%; refusing to run
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+
+call :wipe_caproot || goto :fail
+call :run_one co2gold    "%OUTDIR%\co2"    || goto :fail
+call :wipe_caproot || goto :fail
+call :run_one co2goldhex "%OUTDIR%\co2hex" || goto :fail
+
+echo.
+echo [golden] running parity diff
+call conda run -n helao python -m harness.parity --golden "%OUTDIR%\co2" --candidate "%OUTDIR%\co2hex" --report "%OUTDIR%\parity-report.json" > "%OUTDIR%\parity_stdout.txt" 2>&1
+set "PARITY_RC=!errorlevel!"
+type "%OUTDIR%\parity_stdout.txt"
+
+echo.
+echo [golden] full parity report (also saved to %OUTDIR%\parity-report.json):
+type "%OUTDIR%\parity-report.json"
+
+popd
+echo.
+REM The acquire_co2 .hlo body columns (co2_ppm / epoch_s) are masked via the
+REM capture manifest's masked_hlo_columns (see golden_capture_co2.py) since they
+REM are live sensor readings, not deterministic sim data; the poll-paced row
+REM count is compared within hlo_row_count_tolerance; and the data-derived
+REM action_params key mean_co2_ppm is masked via masked_meta_keys. So parity
+REM rc=0 is a genuine PASS and rc!=0 means a REAL hexagon-vs-legacy diff. The
+REM full report is printed and persisted above either way for inspection.
+if "%PARITY_RC%"=="0" (
+  (
+    echo [golden] PASS -- co2goldhex RUNS-tree matches legacy co2gold ^(acquire_co2, masked^)
+    echo [golden] artifacts: %OUTDIR%\co2, %OUTDIR%\co2hex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+) else (
+  (
+    echo [golden] DIFFS FOUND rc=%PARITY_RC% -- REAL regression, inspect the report
+    echo [golden] open %OUTDIR%\parity-report.json: tree_diffs / file_diffs list
+    echo [golden]   every differing member and key. The acquire_co2 .hlo data
+    echo [golden]   columns + mean_co2_ppm are masked, so anything shown here is
+    echo [golden]   a genuine hexagon-vs-legacy difference.
+    echo [golden] artifacts: %OUTDIR%\co2, %OUTDIR%\co2hex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+)
+type "%OUTDIR%\golden_result.txt"
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\golden_result.txt regardless.
+pause
+exit /b %PARITY_RC%
+
+REM ---------------------------------------------------------------------------
+:wipe_caproot
+REM Full-wipe the throwaway capture root before each capture -- required
+REM because golden_capture_co2.py's assert_fresh() refuses a root that already
+REM contains run artifacts. This rmdir is safe ONLY because %CAPROOT% just
+REM passed safe_root.py's check (repo not underneath it, not a drive/fs anchor)
+REM AND the equality guard below proves it is not production C:\INST_hlo -- it
+REM must NEVER run against a root that could hold real station data (run output,
+REM DATABASE, USER_CONFIG).
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- refusing to wipe production root %PROD_ROOT%
+  exit /b 2
+)
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard before wipe
+  exit /b 2
+)
+if exist "%CAPROOT%" (
+  echo [golden] wiping throwaway caproot %CAPROOT%
+  rmdir /s /q "%CAPROOT%"
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = capture out dir
+set "PREFIX=%~1"
+set "CAPOUT=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
+
+echo.
+echo [golden] === %PREFIX% ===
+echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [golden] waiting for CO2SENSOR port 8012
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8012))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [golden] FAIL %PREFIX% port 8012 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [golden] capturing acquire_co2 -^> %CAPOUT%
+call conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_co2 --config-prefix %PREFIX% --root "%CAPROOT%" --out "%CAPOUT%" > "%OUTDIR%\%PREFIX%.capture.log" 2>&1
+set "CAPTURE_RC=!errorlevel!"
+type "%OUTDIR%\%PREFIX%.capture.log"
+
+echo [golden] killing %PREFIX%
+call :kill_one
+REM Let the SprintIR serial port release before the next launch reopens it --
+REM killing the python server does not instantly guarantee the OS released the
+REM COM handle. ~5s margin between our two sequential captures.
+ping -n 6 -w 1000 127.0.0.1 >nul
+
+if not "%CAPTURE_RC%"=="0" (
+  echo [golden] FAIL %PREFIX% capture rc=%CAPTURE_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the SprintIR driver's shutdown() runs:
+REM SprintIR.shutdown() closes the serial port (COM12). A hard kill skips this
+REM and may leave the port claimed for the next launch.
+REM Best-effort (server dies mid-response); then wait for release.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8012
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit this console.
+REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can
+REM cascade through a shared conhost.exe and close the main window.
+REM The match includes " --no-hot-reload" so "co2gold" cannot match
+REM "co2goldhex" (no space follows "co2gold" in that cmdline).
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the CO2SENSOR server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18012) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (co2gold vs co2goldhex) -- or a preceding
+REM co2_canary run on the same ports -- leaves a stale listener owning
+REM 127.0.0.1:18012, a dispatch_action RPC-first call reaches the STALE binder:
+REM the action is ACK'd but never runs on the live server, yielding an empty
+REM capture (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8012) or c(18012)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :co2_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:co2_ports_free
+if not "!RELEASED!"=="1" echo [golden] WARNING %PREFIX% ports 8012/18012 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [golden] ABORTED -- a launch/capture step failed; see logs in %OUTDIR%
+echo [golden] ABORTED -- see %OUTDIR%\*.launch.log / *.capture.log> "%OUTDIR%\golden_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/diapump_canary.bat
+++ b/helao/hexagon/tests/smoke/diapump_canary.bat
@@ -1,0 +1,177 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Windows canary for the diapumphex hexagon cut-over: runtime /openapi.json diff.
+REM
+REM Launches the LEGACY diapump group and the HEXAGON diapumphex group in turn,
+REM dumps each DOSEPUMP server's live /openapi.json, and diffs them. An identical
+REM route/schema surface proves the hexagon makeActionApp factory produces a
+REM byte-parity action server for the diapump_server (diaphragm dosing pump)
+REM cut-over target.
+REM
+REM OPENAPI-ONLY (single tier -- NO runtime golden-diff tier). Every diapump
+REM action (run_continuous, dispense_byvolume, dispense_byrate) actively DRIVES
+REM fluid; none is a safe non-perturbing read, so there is no valid runtime golden
+REM scenario the way cam's acquire_image is. The /openapi.json surface diff done
+REM here is the whole harness -- same openapi-only precedent as dbpack_canary.sh
+REM and analysis_canary.sh.
+REM
+REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
+REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
+REM sequences to an orchestrator. diapumphex is a 2-server group (DOSEPUMP@8016 +
+REM ACTVIS@5001) with NO orchestrator (mirrors cam_canary.bat exactly).
+REM
+REM Both configs share root C:\INST_hlo and ports 8016/5001, so they MUST run
+REM sequentially (this script does that) -- never launch both at once.
+REM NOTE: this openapi canary only boots each server and reads /openapi.json; it
+REM never dispatches an action, so no pump ever moves fluid and no COM device
+REM needs to be present (the sim/dummy driver serves the route surface).
+REM
+REM Usage: diapump_canary.bat [root] [outdir]
+REM   root   default C:\INST_hlo   (must match the configs' root: key)
+REM   outdir default %TEMP%\diapump_canary
+REM ---------------------------------------------------------------------------
+
+set "ROOT=%~1"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\diapump_canary"
+
+REM Guard: refuse an unsafe root (drive/fs anchor, or a root that contains the
+REM code repo) BEFORE anything touches it. safe_root.py is the single choke
+REM point; %ROOT% is only ever used read-only in this script, but the check is
+REM defense in depth against a mis-set root: key. See safe_root.py.
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` is
+REM exempt (it runs in a separate child shell).
+call conda run -n helao python "%~dp0safe_root.py" check "%ROOT%"
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT -- root %ROOT% failed the safety guard; see message above
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+set "LEGACY_JSON=%OUTDIR%\diapump_openapi.json"
+set "HEX_JSON=%OUTDIR%\diapumphex_openapi.json"
+
+call :run_one diapump     "%LEGACY_JSON%" || goto :fail
+call :run_one diapumphex  "%HEX_JSON%"    || goto :fail
+
+echo.
+echo [canary] diffing openapi surfaces
+REM Persist diff output to a file too, so the result survives the window closing.
+call conda run -n helao python "%~dp0openapi_diff.py" "%LEGACY_JSON%" "%HEX_JSON%" > "%OUTDIR%\openapi_diff.txt" 2>&1
+set "DIFF_RC=!errorlevel!"
+type "%OUTDIR%\openapi_diff.txt"
+popd
+echo.
+if "%DIFF_RC%"=="0" (
+  echo [canary] PASS -- diapumphex openapi surface matches legacy diapump> "%OUTDIR%\canary_result.txt"
+) else (
+  echo [canary] DIFFS FOUND rc=%DIFF_RC% -- see openapi_diff.txt> "%OUTDIR%\canary_result.txt"
+)
+type "%OUTDIR%\canary_result.txt"
+echo [canary] artifacts + result saved in: %OUTDIR%
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\canary_result.txt regardless.
+pause
+exit /b %DIFF_RC%
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = output json path
+set "PREFIX=%~1"
+set "OUTJSON=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_CANARY_%PREFIX%"
+
+echo.
+echo [canary] === %PREFIX% ===
+REM NEVER wipe %ROOT%. An openapi diff reads the live server's /openapi.json and
+REM produces no output tree, so no "fresh root" is needed. On a station %ROOT%
+REM (e.g. C:\INST_hlo) holds production RUN data, calibration matrices, and may
+REM contain the code repo itself -- deleting it is catastrophic and unrecoverable
+REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
+REM to locate the pid pickle for kill_group.py.
+
+echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [canary] waiting for DOSEPUMP port 8016
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8016))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [canary] FAIL %PREFIX% port 8016 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [canary] fetching /openapi.json -> %OUTJSON%
+call conda run -n helao python -c "import urllib.request,sys; open(sys.argv[2],'wb').write(urllib.request.urlopen('http://127.0.0.1:8016/openapi.json',timeout=30).read())" x "%OUTJSON%"
+set "FETCH_RC=!errorlevel!"
+
+echo [canary] killing %PREFIX%
+call :kill_one
+
+if not "%FETCH_RC%"=="0" (
+  echo [canary] FAIL %PREFIX% openapi fetch rc=%FETCH_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the diapump driver's shutdown() runs cleanly.
+REM The dosing pump holds a serial COM handle in a real deployment; graceful
+REM shutdown lets the driver release it. Best-effort (server may die
+REM mid-response); then wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8016
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit the canary console.
+REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main canary window.
+REM The match includes " --no-hot-reload" so prefix "diapump" cannot match "diapumphex".
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the DOSEPUMP server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18016) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (diapump vs diapumphex) starts while a stale
+REM listener still owns 127.0.0.1:18016, the next launch's "Address in use"
+REM fallback fires and a dispatch_action RPC-first call would reach the STALE
+REM binder -- yielding a broken surface. Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8016) or c(18016)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :diapump_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:diapump_ports_free
+if not "!RELEASED!"=="1" echo [canary] WARNING %PREFIX% ports 8016/18016 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [canary] ABORTED -- a launch/fetch step failed; see logs in %OUTDIR%
+echo [canary] ABORTED -- see %PREFIX%.launch.log in %OUTDIR%> "%OUTDIR%\canary_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/diapump_canary.bat
+++ b/helao/hexagon/tests/smoke/diapump_canary.bat
@@ -102,6 +102,18 @@ REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
 REM to locate the pid pickle for kill_group.py.
 
 echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8016 (or its co-located ZMQ RPC sibling 18016); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8016
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8016/18016 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [canary] waiting for DOSEPUMP port 8016

--- a/helao/hexagon/tests/smoke/galil_canary.bat
+++ b/helao/hexagon/tests/smoke/galil_canary.bat
@@ -103,6 +103,18 @@ REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
 REM to locate the pid pickle for kill_group.py.
 
 echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8003 (or its co-located ZMQ RPC sibling 18003); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8003
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8003/18003 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [canary] waiting for MOTOR port 8003

--- a/helao/hexagon/tests/smoke/galil_diff.bat
+++ b/helao/hexagon/tests/smoke/galil_diff.bat
@@ -139,6 +139,18 @@ set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
 echo.
 echo [golden] === %PREFIX% ===
 echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8003 (or its co-located ZMQ RPC sibling 18003); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8003
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT %PREFIX% -- ports 8003/18003 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [golden] waiting for MOTOR port 8003

--- a/helao/hexagon/tests/smoke/galilio_canary.bat
+++ b/helao/hexagon/tests/smoke/galilio_canary.bat
@@ -108,6 +108,18 @@ REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
 REM to locate the pid pickle for kill_group.py.
 
 echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8005 (or its co-located ZMQ RPC sibling 18005); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8005
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8005/18005 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [canary] waiting for IO port 8005

--- a/helao/hexagon/tests/smoke/galilio_diff.bat
+++ b/helao/hexagon/tests/smoke/galilio_diff.bat
@@ -140,6 +140,18 @@ set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
 echo.
 echo [golden] === %PREFIX% ===
 echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8005 (or its co-located ZMQ RPC sibling 18005); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8005
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT %PREFIX% -- ports 8005/18005 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [golden] waiting for IO port 8005

--- a/helao/hexagon/tests/smoke/gamryhex_canary.bat
+++ b/helao/hexagon/tests/smoke/gamryhex_canary.bat
@@ -102,6 +102,18 @@ REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
 REM to locate the pid pickle for kill_group.py.
 
 echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8001 (or its co-located ZMQ RPC sibling 18001); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8001
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8001/18001 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [canary] waiting for PSTAT port 8001

--- a/helao/hexagon/tests/smoke/golden_capture.py
+++ b/helao/hexagon/tests/smoke/golden_capture.py
@@ -69,6 +69,16 @@ from helao.helpers.config_loader import read_config
 from helao.helpers.dispatcher import async_action_dispatcher
 from helao.helpers.premodels import Action
 
+# async_action_dispatcher's RPC-first path opens a zmq.asyncio socket, which
+# requires the add_reader event-loop family the Windows Proactor loop (the
+# default on Windows) does not provide. This standalone capture client runs in
+# its OWN process -- separate from fast_launcher/bokeh_launcher, which already
+# force a selector loop -- so it must apply the same fix here or it emits the
+# "Proactor event loop does not implement add_reader" RuntimeWarning (and spins
+# up an extra tornado selector thread). Mirrors fast_launcher.py's _LOOP_FACTORY:
+# SelectorEventLoop on Windows, default loop elsewhere (loop_factory=None).
+_LOOP_FACTORY = asyncio.SelectorEventLoop if sys.platform == "win32" else None
+
 # HloStatus terminal states. A manual action's -act.yml is written at init with
 # status "active" (base.py:1029 update_act_file) and only REWRITTEN with a
 # terminal status at finish (write_act). Settling on the file's mere existence
@@ -247,7 +257,8 @@ def dispatch_action(
     resp, err = asyncio.run(
         async_action_dispatcher(
             world_cfg, action, params=action_params, timeout=timeout
-        )
+        ),
+        loop_factory=_LOOP_FACTORY,
     )
     if err != ErrorCodes.none:
         raise RuntimeError(

--- a/helao/hexagon/tests/smoke/golden_capture_andor.py
+++ b/helao/hexagon/tests/smoke/golden_capture_andor.py
@@ -1,0 +1,347 @@
+"""Runtime golden-diff capture for the andor_server hexagon canary (P3a
+special-split).
+
+*** DRIVES THE REAL ANDOR ZYLA CAMERA + ATSPECTROGRAPH. NOT A SIMULATION. ***
+
+Like gamry/spec/co2 (and unlike sample), andor_server has NO sim/dummy data
+path: ``AndorDriver.__init__``/``connect`` (helao/deploy/hte/drivers/spec/andor/
+driver.py) lazily loads the vendor ``pyAndorSDK3`` / ``pyAndorSpectrograph``
+runtimes and opens the physical camera + spectrograph, and ``andor_server.py``
+instantiates ``driver_classes=[AndorDriver]`` unconditionally -- the config's
+``dummy``/``simulation`` YAML keys are cosmetic (banner color) for this canary
+only. So this capture rig is an AT-STATION, REAL-HARDWARE gate: the Andor
+camera + spectrograph must be attached (Windows, vendor SDKs present) for
+``acquire`` to produce any data.
+
+``acquire`` (``POST /ANDOR/acquire``) streams spectra: ``AndorAcquire`` (a
+POLL-PACED, non-oneoff executor) arms the camera in ``_exec`` and pulls a batch
+of frames per ``_poll`` via ``AndorDriver.get_data`` until ``duration`` seconds
+of hardware tick-time elapse, enqueuing each frame as a row to the default data
+sink as a ``.hlo``. It is single-read, NON-PERTURBING -- it only reads the
+detector; it drives nothing. IMPORTANT: this capture dispatches with
+``external_trigger=False`` (SOFTWARE trigger) so frames flow WITHOUT an external
+5V TTL source -- with the endpoint default ``external_trigger=True`` the camera
+would block on a trigger that never arrives in a bench/station canary and the
+run would time out with no data.
+
+That .hlo's body columns are ``tick_time`` (camera clock tick / clock_hz, per
+``AndorDriver.get_data``) and ``ch_0000``..``ch_<N_PIXELS-1>`` (per-pixel
+detector intensities) -- ALL live/hardware-derived, none deterministic
+run-to-run -- so their VALUES are masked via the manifest's
+``masked_hlo_columns`` (``elapsed_time_s`` is also masked defensively: the
+endpoint declares it in ``json_data_keys``/``column_headings`` even though the
+driver streams ``tick_time`` as the time column, and masking an absent column
+is a harmless no-op). Column presence is still asserted. Because the executor is
+POLL-PACED over a wall-clock/tick ``duration``, the ROW COUNT jitters run-to-run
+(hardware framerate timing at the duration boundary, NOT anything the hexagon
+graft controls), so a ``hlo_row_count_tolerance`` is allowed (mirrors
+gamry ``run_OCV`` / co2 ``acquire_co2``, not spec's exact single-shot count).
+
+The .hlo HEADER carries ``wl`` (the pixel->wavelength table,
+``list(app.driver.wl_arr)`` from the spectrograph ``GetCalibration``) and
+``column_headings`` -- both config/calibration-deterministic and compared
+UNMASKED (a diff there is a genuine regression).
+
+Unlike spec's ``acquire_spec`` (and like co2's ``acquire_co2``, which writes
+``mean_co2_ppm`` back into ``action_params``), ``AndorAcquire.__init__`` writes
+one run-specific value back into ``action_params``: ``action_path`` = the
+action's ``action_output_dir`` (a per-run absolute path carrying wall-clock
+week/date/timestamp components and uuids). ``normalize_meta`` only §5.1-grammar-
+normalizes string values whose KEY ends in ``_output_dir`` -- ``action_path``
+does not, so only its embedded uuids are mapped and its timestamp components
+would otherwise surface as a spurious -act.yml diff between two independent
+captures. It is therefore value-masked via ``masked_meta_keys`` (the meta-side
+analogue of masked_hlo_columns); the key stays present so a one-sided presence
+difference still surfaces.
+
+Standalone counterpart to ``harness.capture.snapshot_capture`` for the
+orch-less, db-less andor/andorhex 2-server topology (ANDOR@8011 + ACTVIS@5001
+only -- no ORCH, no DB), mirroring spec/co2/gamry's ``golden_capture[_*].py``
+(see those modules' docstrings for the full topology-gap rationale). The
+hardware-agnostic settle / anti-vacuous-guard logic (``settle``,
+``_run_artifacts``, ``_act_status_map``) and the production dispatch path
+(``dispatch_action``) are IMPORTED from ``golden_capture.py`` rather than
+re-implemented here; only the scenario-specific pieces (endpoint, masking,
+manifest notes) are new. ``golden_capture.py`` itself is NOT modified.
+
+Usage (AT-STATION, Windows, conda env ``helao``) -- ATTACH THE CAMERA +
+SPECTROGRAPH FIRST:
+
+    rmdir /s /q C:\\INST_hlo_golden               (or pick a fresh --root)
+    conda run -n helao python launch.py andorgold --no-hot-reload
+    conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_andor ^
+        --config-prefix andorgold --root C:\\INST_hlo_golden ^
+        --out C:\\golden\\andor
+
+then terminate the launch, point ``--root``/``--config-prefix`` at a FRESH
+throwaway root and ``andorgoldhex``, capture again, and diff the two capture
+directories with ``harness.parity``. ``andor_diff.bat`` automates exactly this
+sequence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from harness import HARNESS_VERSION
+from harness.capture import assert_fresh, wait_for_server
+from harness.manifest import ProvenanceManifest
+from harness.treepass import PARITY_TOPS
+
+from helao.hexagon.tests.smoke.golden_capture import (
+    _act_status_map,
+    _run_artifacts,
+    dispatch_action,
+    settle,
+)
+
+ANDOR_HOST, ANDOR_PORT = "127.0.0.1", 8011
+
+SCENARIO = "GM-ANDOR"
+
+# helao/hexagon/tests/smoke/golden_capture_andor.py -> repo root is 4 parents up
+# (matches safe_root.py's own _repo_root()).
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFIG_DIR = REPO_ROOT / "helao" / "deploy" / "hte" / "configs"
+
+# N_PIXELS: AndorDriver.setup_spectroscope reads the calibrated wavelength array
+# via GetCalibration(0, 2560) (NumHorizPixels=2560), so wl_arr has 2560 elements;
+# both the acquire endpoint (range(app.driver.wl_arr.shape[0])) and the driver
+# get_data ({f"ch_{i:04}": [] for i in range(self.wl_arr.size)}) build one ch
+# column per pixel -> ch_0000..ch_2559.
+N_PIXELS = 2560
+
+# ALL acquire .hlo body columns are live/hardware-derived (raw detector
+# intensities + camera clock ticks), none seeded or deterministic -- so their
+# VALUES are masked for parity. tick_time is the driver's time column;
+# elapsed_time_s is the endpoint-declared column_headings name (masked
+# defensively -- a no-op if absent from the body). Column presence + the row
+# count (within tolerance) are still compared. The .hlo HEADER's `wl`
+# (pixel->wavelength table) and `column_headings` are config/calibration-
+# deterministic and are NOT masked (a diff there is a real regression). Pattern
+# "*.hlo" is safe: the only .hlo any acquire capture emits is this spectrum
+# stream file (the driver writes NO image/sidecar files).
+ANDOR_HLO_COLUMNS = ["tick_time", "elapsed_time_s"] + [
+    f"ch_{i:04}" for i in range(N_PIXELS)
+]
+ANDOR_MASKED_HLO_COLUMNS = {
+    "*.hlo": ANDOR_HLO_COLUMNS,
+    "*.hlo.json*": ANDOR_HLO_COLUMNS,
+}
+# The executor is POLL-PACED over a wall-clock/tick `duration`, so the frame/row
+# count jitters run-to-run at the duration boundary (hardware framerate timing,
+# NOT graft-controlled). Masked columns are compared within this tolerance
+# (mirrors gamry run_OCV / co2 acquire_co2; NOT spec/cam's exact single-shot
+# count). The value is a station-tunable ceiling on that timing jitter: it must
+# stay well below the expected row count so a real graft regression (e.g. a
+# broken streaming loop that writes ~1 row) still trips the len check, while
+# absorbing the handful-of-frames boundary jitter. Tune at-station if the two
+# captures' frame counts prove tighter or looser than this.
+ANDOR_HLO_ROW_COUNT_TOLERANCE = {"*.hlo": 20, "*.hlo.json*": 20}
+# AndorAcquire.__init__ writes action_path (= action_output_dir, a per-run
+# absolute path with wall-clock + uuid components) back into the run's -act.yml
+# action_params. normalize_meta only §5.1-normalizes *_output_dir-suffixed
+# string values, so action_path's timestamp components would otherwise diff
+# between two independent captures. Masked via masked_meta_keys (the meta-side
+# analogue of masked_hlo_columns): parity neutralizes its VALUE on both sides
+# while keeping the key present, so the runtime diff is a CLEAN PASS when only it
+# differs and a real regression in any other key/file still surfaces. The key is
+# a no-op on any yml lacking it.
+ANDOR_ACT_YML_MASKED_META_KEYS = {
+    "*-act.yml": [
+        "action_params.action_path",
+    ],
+}
+
+
+def acquire_action(
+    config_prefix: str,
+    duration: float = 1.0,
+    external_trigger: bool = False,
+    frames_per_poll: int = 100,
+    buffer_count: int = 10,
+    exp_time: float = 0.0098,
+    framerate: float = 98,
+    timeout: float = 5000,
+) -> dict:
+    """Run /ANDOR/acquire via ``async_action_dispatcher`` (production
+    action-dispatch path -- RPC then HTTP, full action envelope).
+
+    A SHORT finite ``duration`` (> 0) streams frames for that many
+    (tick-)seconds then the executor finishes on its own. ``external_trigger``
+    is forced ``False`` (SOFTWARE trigger) so frames flow without an external 5V
+    TTL source; the endpoint default (``True``) would block on a trigger that
+    never arrives in a canary. Non-perturbing: reads the detector only, drives
+    nothing. The endpoint requires no ``fast_samples_in``.
+    """
+    return dispatch_action(
+        config_prefix,
+        "ANDOR",
+        "acquire",
+        {
+            "external_trigger": external_trigger,
+            "duration": duration,
+            "frames_per_poll": frames_per_poll,
+            "buffer_count": buffer_count,
+            "exp_time": exp_time,
+            "framerate": framerate,
+            "timeout": timeout,
+        },
+        # duration-bounded stream plus headroom for the endpoint's trailing
+        # dangling-data drain + finish().
+        timeout=120,
+    )
+
+
+def snapshot(
+    root: Path,
+    out_dir: Path,
+    config_prefix: str,
+    duration: float,
+    external_trigger: bool,
+    notes: str = "",
+) -> Path:
+    """Copy PARITY_TOPS from ``root`` and write a provenance manifest.
+
+    Refuses to overwrite an existing ``out_dir``, matching
+    ``harness.capture.snapshot_capture`` / spec/co2's ``snapshot``.
+    """
+    root, out_dir = Path(root), Path(out_dir)
+    if out_dir.exists():
+        raise FileExistsError(
+            f"{out_dir} already exists; refusing to overwrite a capture"
+        )
+    # Anti-vacuous-pass guard (shared convention with spec/co2/gamry/galil/
+    # sample): an empty capture (no action output) compares to nothing and
+    # passes parity trivially. Require at least one -act.yml before writing.
+    acts, hlos = _run_artifacts(root)
+    if not acts:
+        raise RuntimeError(
+            f"{root} has no -act.yml to capture; refusing a vacuous capture "
+            "that would pass parity with 0 diffs. Check the launch/capture "
+            "logs -- the action may have errored or produced no output."
+        )
+    errored = [p for p, st in _act_status_map(root).items() if "errored" in st]
+    if errored:
+        print(
+            f"[golden_capture_andor] WARNING: {len(errored)} action(s) ERRORED "
+            f"and were still captured: {errored}. An errored run is NOT a valid "
+            "parity baseline. Check the -act.yml error fields and the ANDOR log "
+            "before trusting a PASS."
+        )
+    if not hlos:
+        print(
+            f"[golden_capture_andor] WARNING: no .hlo captured under {root} -- "
+            "acquire streamed no spectrum data file. Parity will compare "
+            "-act.yml metadata only, NOT the hlo data-write path. Verify the "
+            "Andor camera + spectrograph are attached and that the SOFTWARE "
+            "trigger (external_trigger=False) delivered frames."
+        )
+    out_root = out_dir / "root"
+    out_root.mkdir(parents=True)
+    for top in PARITY_TOPS:
+        src = root / top
+        if src.is_dir():
+            shutil.copytree(src, out_root / top)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    config_path = CONFIG_DIR / f"{config_prefix}.yml"
+    combined_notes = (
+        "REAL-HARDWARE acquire capture (Andor Zyla camera + ATSpectrograph "
+        "attached); NOT a simulation -- AndorDriver has no sim/dummy data path. "
+        "Dispatched with external_trigger=False (software trigger) so frames flow "
+        "without an external TTL. The .hlo body columns tick_time/ch_NNNN are "
+        "live detector data and are masked via masked_hlo_columns; the row count "
+        "is compared within hlo_row_count_tolerance (poll-paced stream). The .hlo "
+        "header `wl` (pixel->wavelength table) + column_headings are "
+        "config-deterministic and compared unmasked. The per-run action_params "
+        "key action_path is masked via masked_meta_keys, so parity is a clean "
+        "PASS when only these differ."
+    )
+    if notes:
+        combined_notes = f"{combined_notes} {notes}"
+    ProvenanceManifest(
+        scenario=SCENARIO,
+        config_prefix=config_prefix,
+        config_path=str(config_path),
+        legacy_git_sha=sha,
+        launch_cmd=f"conda run -n helao python launch.py {config_prefix} --no-hot-reload",
+        sequence_name="manual_acquire",
+        sequence_params={
+            "manual": True,
+            "endpoint": "POST /ANDOR/acquire",
+            "duration": duration,
+            "external_trigger": external_trigger,
+            "fast_samples_in": [],
+        },
+        capture_timestamp=datetime.datetime.now().isoformat(timespec="seconds"),
+        harness_version=HARNESS_VERSION,
+        masked_hlo_columns=ANDOR_MASKED_HLO_COLUMNS,
+        hlo_row_count_tolerance=ANDOR_HLO_ROW_COUNT_TOLERANCE,
+        masked_meta_keys=ANDOR_ACT_YML_MASKED_META_KEYS,
+        notes=combined_notes,
+    ).save(out_dir)
+    return out_dir
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m helao.hexagon.tests.smoke.golden_capture_andor",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--config-prefix", required=True)
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=1.0,
+        help="acquire duration in (tick-)seconds; must be > 0 so the stream "
+        "terminates on its own (default 1.0)",
+    )
+    parser.add_argument(
+        "--external-trigger",
+        action="store_true",
+        help="use the camera's External Start trigger instead of the default "
+        "software trigger (requires a 5V TTL source; the capture will hang "
+        "without one -- leave unset for a bench/station canary)",
+    )
+    parser.add_argument("--settle-polls", type=int, default=3)
+    parser.add_argument("--notes", default="")
+    args = parser.parse_args(argv)
+
+    if args.duration <= 0:
+        parser.error(
+            "--duration must be > 0 so acquire terminates on its own "
+            "(duration <= 0 runs until cancelled and would hang the capture)"
+        )
+
+    assert_fresh(args.root)
+    wait_for_server(ANDOR_HOST, ANDOR_PORT)
+    acquire_action(
+        args.config_prefix,
+        duration=args.duration,
+        external_trigger=args.external_trigger,
+    )
+    settle(args.root, settle_polls=args.settle_polls)
+    out = snapshot(
+        root=args.root,
+        out_dir=args.out,
+        config_prefix=args.config_prefix,
+        duration=args.duration,
+        external_trigger=args.external_trigger,
+        notes=args.notes,
+    )
+    print(f"captured {SCENARIO} -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/golden_capture_andor.py
+++ b/helao/hexagon/tests/smoke/golden_capture_andor.py
@@ -323,14 +323,35 @@ def main(argv=None) -> int:
             "(duration <= 0 runs until cancelled and would hang the capture)"
         )
 
+    # Flushed stage breadcrumbs: this capture can block for minutes on real
+    # hardware, and stdout is block-buffered when the bat redirects it to a
+    # file, so a plain print would not surface until the process exits. With
+    # flush=True each stage lands in the capture log immediately, so a hang is
+    # attributable to the exact stage reached (server-wait vs dispatch vs
+    # settle) rather than an opaque empty log.
     assert_fresh(args.root)
+    print(
+        f"[golden_capture_andor] waiting for ANDOR at {ANDOR_HOST}:{ANDOR_PORT} ...",
+        flush=True,
+    )
     wait_for_server(ANDOR_HOST, ANDOR_PORT)
+    print(
+        f"[golden_capture_andor] server up; dispatching acquire "
+        f"(duration={args.duration}, external_trigger={args.external_trigger}) ...",
+        flush=True,
+    )
     acquire_action(
         args.config_prefix,
         duration=args.duration,
         external_trigger=args.external_trigger,
     )
+    print(
+        "[golden_capture_andor] acquire dispatch returned; settling on -act.yml "
+        "terminal status ...",
+        flush=True,
+    )
     settle(args.root, settle_polls=args.settle_polls)
+    print("[golden_capture_andor] settled; snapshotting RUNS tree ...", flush=True)
     out = snapshot(
         root=args.root,
         out_dir=args.out,

--- a/helao/hexagon/tests/smoke/golden_capture_biologic.py
+++ b/helao/hexagon/tests/smoke/golden_capture_biologic.py
@@ -1,0 +1,352 @@
+"""Runtime golden-diff capture for the biologic_server hexagon canary (P3a
+special-split).
+
+*** DRIVES THE REAL BIOLOGIC POTENTIOSTAT (OPEN-CIRCUIT READ, NON-PERTURBING). ***
+
+Step 0 of the parent task investigated whether ``run_OCV`` can produce data
+under ``simulation: true``/``dummy: true`` with no real instrument attached,
+and found: no. ``BiologicDriver.__init__`` (helao/deploy/hte/drivers/pstat/
+biologic/driver.py) unconditionally calls ``connect()``, which opens a real
+``easy_biologic.BiologicDevice`` TCP connection to the instrument, and
+``biologic_server.py`` instantiates ``driver_classes=[BiologicDriver]``
+unconditionally -- there is no dummy/sim driver swap anywhere in this code
+path, and ``easy_biologic`` itself imports only on Windows (raises OSError on
+Linux). The config's ``dummy``/``simulation`` YAML keys are therefore cosmetic
+(banner color) for this canary, exactly as already documented for gamry in
+``golden_capture.py`` and galil in ``golden_capture_galil.py``.
+
+``run_OCV`` (``POST /BIOLOGIC/run_OCV``) is NON-PERTURBING: the OCV technique
+(easy_biologic ``blp.OCV``) monitors the open-circuit potential and NEVER
+actively drives the cell (no applied potential/current -- unlike run_CA/run_CP/
+run_CV/run_PEIS/run_GEIS/run_CAOCV, which impose a potential or current on the
+cell). It is therefore safe to run at-station against a dummy cell /
+calibration resistor, but it still requires a live Biologic device to produce
+any data at all.
+
+Standalone counterpart to ``harness.capture.snapshot_capture`` for the
+orch-less, db-less biologic/biologichex 2-server topology (BIOLOGIC@8016 +
+ACTVIS@5001 only -- no ORCH, no DB), mirroring gamry's
+``helao.hexagon.tests.smoke.golden_capture`` (see that module's docstring for
+the full topology-gap rationale already recorded there and in
+``gamryhex_canary.bat``, which hit the same gap for the openapi-diff canary).
+The hardware-agnostic settle/anti-vacuous-guard logic (``settle``,
+``_run_artifacts``, ``_act_status_map``) and the production action-dispatch
+path (``dispatch_action``) are IMPORTED from ``golden_capture.py`` rather than
+re-implemented here -- they are pure -act.yml/RUNS_ACTIVE polling +
+async_action_dispatcher logic with no gamry-specific assumptions (they do not
+reference gamry's OCV scenario name or masking). Only the scenario-specific
+pieces (endpoint params, masking, verify_device_open probe, manifest notes)
+are new in this module. ``golden_capture.py`` itself is NOT modified.
+
+Usage (AT-STATION, Windows, conda env ``helao``) -- ATTACH THE DUMMY CELL /
+CAL RESISTOR FIRST (run_OCV drives nothing, but connect() needs the live
+instrument, and a dummy cell gives a stable open-circuit reading):
+
+    rmdir /s /q C:\\INST_hlo_golden               (or pick a fresh --root)
+    conda run -n helao python launch.py biologicgold --no-hot-reload
+    conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_biologic ^
+        --config-prefix biologicgold --root C:\\INST_hlo_golden ^
+        --out C:\\golden\\biologic
+
+then terminate the launch, point ``--root``/``--config-prefix`` at a FRESH
+throwaway root and ``biologicgoldhex``, capture again, and diff the two capture
+directories with ``harness.parity``. ``biologic_diff.bat`` automates exactly
+this sequence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import requests
+
+from harness import HARNESS_VERSION
+from harness.capture import assert_fresh, wait_for_server
+from harness.manifest import ProvenanceManifest
+from harness.treepass import PARITY_TOPS
+
+from helao.hexagon.tests.smoke.golden_capture import (
+    _act_status_map,
+    _run_artifacts,
+    dispatch_action,
+    settle,
+)
+
+BIO_HOST, BIO_PORT = "127.0.0.1", 8016
+
+SCENARIO = "GM-BIOOCV"
+
+# helao/hexagon/tests/smoke/golden_capture_biologic.py -> repo root is 4 parents
+# up (matches safe_root.py's own _repo_root()).
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFIG_DIR = REPO_ROOT / "helao" / "deploy" / "hte" / "configs"
+
+# The run_OCV .hlo columns. BiologicExec._poll enqueues BiologicDriver.get_data's
+# data dict verbatim (base.py writes datadict keys straight through as hlo
+# columns). For the OCV technique (TECH_OCV, technique.py) get_data emits:
+#   - "t_s"  = field_remap of easy_biologic "time"    (live sample times)
+#   - "Ewe_V"= field_remap of easy_biologic "voltage" (live open-circuit potential)
+#   - the "_<Field>" columns = getdict(segment.values), i.e. the per-segment
+#     ctypes CurrentValues struct (ec_lib.py) prefixed with "_": live device
+#     state / instantaneous readings (State, MemFilled, TimeBase, Ewe, I,
+#     IRange, ElapsedTime, Freq, saturation/overflow flags, ...).
+# ALL of these are raw live measurements / device state pulled straight off the
+# instrument -- no seeded/deterministic sim values exist anywhere in this driver
+# -- so their VALUES are MASKED for parity. Row counts are compared within a
+# small tolerance (the OCV poll loop / dtaq segment retrieval jitters a row or
+# two run-to-run). The "channel" column is NOT masked: BiologicExec adds it as a
+# constant equal to the requested channel index (config/param-deterministic,
+# identical on every capture -- the biologic analogue of galil's unmasked "ax").
+OCV_HLO_COLUMNS = [
+    "t_s",
+    "Ewe_V",
+    "_State",
+    "_MemFilled",
+    "_TimeBase",
+    "_Ewe",
+    "_EweRangeMin",
+    "_EweRangeMax",
+    "_Ece",
+    "_EceRangeMin",
+    "_EceRangeMax",
+    "_Eoverflow",
+    "_I",
+    "_IRange",
+    "_Ioverflow",
+    "_ElapsedTime",
+    "_Freq",
+    "_Rcomp",
+    "_Saturation",
+    "_OptErr",
+    "_OptPos",
+]
+OCV_MASKED_HLO_COLUMNS = {
+    "*OCV*.hlo": OCV_HLO_COLUMNS,
+    "*OCV*.hlo.json*": OCV_HLO_COLUMNS,
+}
+OCV_HLO_ROW_COUNT_TOLERANCE = {"*OCV*.hlo": 2, "*OCV*.hlo.json*": 2}
+
+# BiologicExec._post_exec (biologic_server.py ~269-303) writes data-derived
+# summary values into the run's -act.yml action_params: for each of t_s / Ewe_V
+# that is present in the OCV data buffer it stores "<k>__mean_final" (the mean of
+# the trailing 5 samples), and for run_OCV it stores "has_bubble" (the
+# bubble_detection verdict over the whole OCV trace). All three derive from the
+# exact same live/unmasked measurement and are NOT covered by masked_hlo_columns
+# (which masks .hlo files only) nor by harness.yaml_pass.normalize_meta's §5.5
+# volatile lists (they are plain float/bool leaves under action_params, not
+# uuids/timestamps/host-identity). Without masking, harness.parity's diff_meta
+# would report a diff on these keys between any two independent captures, even
+# against the identical dummy cell. (I_A__mean_final is NOT emitted for OCV: the
+# OCV technique field_map produces no "I_A" column, so that branch never fires.)
+#
+# They are masked via the manifest's masked_meta_keys (the meta-side analogue of
+# masked_hlo_columns): parity neutralizes their VALUES on both sides before
+# diffing while keeping the keys present, so the runtime diff is a CLEAN PASS
+# when only these values differ, and a real regression in ANY other key/file
+# still surfaces normally. Pattern is "*-act.yml" (any action yml in this
+# GM-BIOOCV capture set); the keys are no-ops on any yml lacking them. This
+# mirrors gamry's run_OCV masking (golden_capture.py) exactly.
+OCV_ACT_YML_MASKED_META_KEYS = {
+    "*-act.yml": [
+        "action_params.t_s__mean_final",
+        "action_params.Ewe_V__mean_final",
+        "action_params.has_bubble",
+    ],
+}
+
+
+def verify_device_open(host: str, port: int) -> None:
+    """Fail fast if the Biologic instrument did not connect at startup.
+
+    ``BiologicDriver.connect()`` opens an ``easy_biologic.BiologicDevice`` TCP
+    connection at construction; on failure ``ready`` stays False (and a
+    second process holding the connection yields ``status=busy`` via the "In
+    use by another script" guard). If the instrument is unreachable the server
+    still comes up, but ``get_status`` then reports ``uninitialized``/``error``
+    and running run_OCV just errors with no data (an errored -act.yml, no
+    .hlo). Checking the driver status up front surfaces the real cause instead
+    of a silently-empty capture.
+
+    NOTE: ``get_status`` is a PRIVATE endpoint -- bare ``/get_status``, NOT
+    ``/BIOLOGIC/get_status``. On this server only ACTION endpoints carry the
+    ``/{server_key}/`` prefix (e.g. ``/BIOLOGIC/run_OCV``); private/system
+    routes (get_status, stop_private, shutdown, endpoints) are unprefixed.
+    ``_driver_status`` is ``BiologicDriver.get_status()``'s ``DriverStatus``
+    value, appended by base_api.py's bare ``/get_status`` handler as
+    ``status_dict["_driver_status"]``: "uninitialized"/"error" when the device
+    is not connected, "ok"/"busy" once the TCP connection is open.
+    """
+    try:
+        r = requests.post(f"http://{host}:{port}/get_status", timeout=10)
+        driver_status = r.json().get("_driver_status") if r.status_code == 200 else None
+    except (requests.RequestException, ValueError):
+        driver_status = None
+    if driver_status not in ("ok", "busy"):
+        raise RuntimeError(
+            f"BIOLOGIC device is NOT open (_driver_status={driver_status!r}) -- "
+            "connect() failed at server startup (commonly the instrument "
+            "unreachable/powered off, or 'In use by another script' when "
+            "another biologic process holds the connection). Verify the "
+            "Biologic instrument is powered on and reachable and that no other "
+            "biologic group / leftover python holds it, then re-run. See the "
+            "BIOLOGIC launch log for the connect traceback."
+        )
+
+
+def run_ocv_action(
+    config_prefix: str, tval_s: float, acq_s: float, channel: int
+) -> dict:
+    """Run /BIOLOGIC/run_OCV via ``dispatch_action`` (the production action-dispatch
+    path -- RPC then HTTP, full action envelope).
+
+    ``run_OCV`` monitors open-circuit potential for ``tval_s`` seconds sampling
+    every ``acq_s`` on ``channel``. NON-PERTURBING -- the OCV technique imposes
+    no potential/current on the cell.
+    """
+    return dispatch_action(
+        config_prefix,
+        "BIOLOGIC",
+        "run_OCV",
+        {"Tval__s": tval_s, "AcqInterval__s": acq_s, "channel": channel},
+    )
+
+
+def snapshot(
+    root: Path,
+    out_dir: Path,
+    config_prefix: str,
+    tval_s: float,
+    acq_s: float,
+    channel: int,
+    notes: str = "",
+) -> Path:
+    """Copy PARITY_TOPS from ``root`` and write a provenance manifest.
+
+    Refuses to overwrite an existing ``out_dir``, matching
+    ``harness.capture.snapshot_capture`` / gamry's ``golden_capture.snapshot``.
+    """
+    root, out_dir = Path(root), Path(out_dir)
+    if out_dir.exists():
+        raise FileExistsError(
+            f"{out_dir} already exists; refusing to overwrite a capture"
+        )
+    # Anti-vacuous-pass guard (shared with gamry's golden_capture.snapshot): an
+    # empty capture (no action output) compares to nothing and passes parity
+    # trivially. Require at least one -act.yml before writing anything, so a
+    # false PASS is impossible even if settle() were bypassed. .hlo is NOT
+    # required (a manual run_OCV may emit none if it errors), but its absence is
+    # warned loudly: parity then compares -act.yml metadata only, not the hlo
+    # data-write path.
+    acts, hlos = _run_artifacts(root)
+    if not acts:
+        raise RuntimeError(
+            f"{root} has no -act.yml to capture; refusing a vacuous capture "
+            "that would pass parity with 0 diffs. Check the launch/capture "
+            "logs -- the action may have errored or produced no output."
+        )
+    errored = [p for p, st in _act_status_map(root).items() if "errored" in st]
+    if errored:
+        print(
+            f"[golden_capture_biologic] WARNING: {len(errored)} action(s) ERRORED "
+            f"and were still captured: {errored}. An errored run is NOT a valid "
+            "parity baseline (it likely produced no data / partial output). Check "
+            "the -act.yml error fields and the BIOLOGIC log before trusting a PASS."
+        )
+    if not hlos:
+        print(
+            f"[golden_capture_biologic] WARNING: no .hlo captured under {root} -- "
+            "run_OCV produced no streamed data file. Parity will compare -act.yml "
+            "metadata only, NOT the hlo data-write path. Verify verify_device_open "
+            "passed, the dummy cell is connected, and driver.get_data returns "
+            "samples."
+        )
+    out_root = out_dir / "root"
+    out_root.mkdir(parents=True)
+    for top in PARITY_TOPS:
+        src = root / top
+        if src.is_dir():
+            shutil.copytree(src, out_root / top)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    config_path = CONFIG_DIR / f"{config_prefix}.yml"
+    combined_notes = (
+        "REAL-HARDWARE run_OCV capture (dummy cell / cal resistor at-station); "
+        "NOT a simulation -- BiologicDriver has no sim/dummy data path and "
+        "easy_biologic imports only on Windows. NON-PERTURBING (open-circuit "
+        "monitor, imposes no potential/current). The .hlo data columns (t_s, "
+        "Ewe_V, and the _<Field> CurrentValues segment columns) are live "
+        "measurements masked via masked_hlo_columns; 'channel' is deterministic "
+        "and unmasked. -act.yml action_params t_s__mean_final, Ewe_V__mean_final, "
+        "has_bubble are data-derived from the live measurement and are masked via "
+        "masked_meta_keys so parity is a clean PASS when only they differ."
+    )
+    if notes:
+        combined_notes = f"{combined_notes} {notes}"
+    ProvenanceManifest(
+        scenario=SCENARIO,
+        config_prefix=config_prefix,
+        config_path=str(config_path),
+        legacy_git_sha=sha,
+        launch_cmd=f"conda run -n helao python launch.py {config_prefix} --no-hot-reload",
+        sequence_name="manual_run_OCV",
+        sequence_params={
+            "manual": True,
+            "endpoint": "POST /BIOLOGIC/run_OCV",
+            "Tval__s": tval_s,
+            "AcqInterval__s": acq_s,
+            "channel": channel,
+        },
+        capture_timestamp=datetime.datetime.now().isoformat(timespec="seconds"),
+        harness_version=HARNESS_VERSION,
+        masked_hlo_columns=OCV_MASKED_HLO_COLUMNS,
+        hlo_row_count_tolerance=OCV_HLO_ROW_COUNT_TOLERANCE,
+        masked_meta_keys=OCV_ACT_YML_MASKED_META_KEYS,
+        notes=combined_notes,
+    ).save(out_dir)
+    return out_dir
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m helao.hexagon.tests.smoke.golden_capture_biologic",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--config-prefix", required=True)
+    parser.add_argument(
+        "--tval", type=float, default=3.0, help="Tval__s (default 3.0s)"
+    )
+    parser.add_argument("--acq", type=float, default=0.1, help="AcqInterval__s")
+    parser.add_argument("--channel", type=int, default=0, help="channel index")
+    parser.add_argument("--settle-polls", type=int, default=3)
+    parser.add_argument("--notes", default="")
+    args = parser.parse_args(argv)
+
+    assert_fresh(args.root)
+    wait_for_server(BIO_HOST, BIO_PORT)
+    verify_device_open(BIO_HOST, BIO_PORT)
+    run_ocv_action(args.config_prefix, args.tval, args.acq, args.channel)
+    settle(args.root, settle_polls=args.settle_polls)
+    out = snapshot(
+        root=args.root,
+        out_dir=args.out,
+        config_prefix=args.config_prefix,
+        tval_s=args.tval,
+        acq_s=args.acq,
+        channel=args.channel,
+        notes=args.notes,
+    )
+    print(f"captured {SCENARIO} -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/golden_capture_co2.py
+++ b/helao/hexagon/tests/smoke/golden_capture_co2.py
@@ -1,0 +1,290 @@
+"""Runtime golden-diff capture for the co2sensor_server hexagon canary (P3a
+special-split).
+
+*** DRIVES THE REAL SprintIR-6S CO2 SENSOR. THIS IS NOT A SIMULATION. ***
+
+Like gamry/spec (and unlike sample), co2sensor_server has NO sim/dummy data
+path: ``SprintIR.connect`` (helao/deploy/hte/drivers/sensor/sprintir_driver.py)
+unconditionally opens the serial port (``serial.Serial(port=...)``) and
+configures the physical sensor, and ``co2sensor_server.py`` instantiates
+``driver_classes=[SprintIR]`` / ``poller_class=SprintIRPoller`` unconditionally
+-- the config's ``dummy``/``simulation`` YAML keys are cosmetic (banner color)
+for this canary only. So this capture rig is an AT-STATION, REAL-HARDWARE gate:
+the SprintIR sensor must be attached (Windows station, serial ``COM12``) for
+``acquire_co2`` to produce any data.
+
+``acquire_co2`` (``POST /CO2SENSOR/acquire_co2``) with a SHORT finite
+``duration`` streams live CO2 ppm off the sensor's live buffer at
+``acquisition_rate`` Hz and terminates on its own once ``duration`` elapses
+(``CO2MonExec._poll`` returns ``HloStatus.finished`` when
+``elapsed >= duration``; ``duration <= 0`` would run until cancelled, so a
+positive finite duration is used here so the capture terminates without a
+cancel). It is single-read, NON-PERTURBING -- it only mirrors the sensor's
+live-buffer reading; it drives nothing. Each poll enqueues one row to the
+default data sink as a ``.hlo``.
+
+That .hlo's body columns are ``co2_ppm`` (live sensor ppm) and ``epoch_s``
+(wall clock) -- BOTH live/hardware-derived, none deterministic run-to-run. Their
+VALUES are therefore masked via the manifest's ``masked_hlo_columns`` (column
+presence is still asserted). Because the executor is POLL-PACED (one row per
+``acquisition_rate``-second poll over a wall-clock ``duration``), the ROW COUNT
+jitters by a row or two run-to-run, so a small ``hlo_row_count_tolerance`` is
+allowed (mirrors gamry ``run_OCV``, not spec's exact single-shot count).
+
+Unlike spec's ``acquire_spec`` (and like gamry's ``run_OCV``), the
+``acquire_co2`` executor writes ONE data-derived summary value back into
+``action_params``: ``CO2MonExec._post_exec`` stashes ``mean_co2_ppm`` (mean of
+the masked live samples) into ``action_params`` at the end of the run. That
+value derives from the same live measurement and is NOT covered by
+``masked_hlo_columns`` (which masks .hlo files only) nor by
+``normalize_meta``'s §5.5 volatile lists (it is a plain float leaf under
+``action_params``), so it is masked via ``masked_meta_keys`` -- otherwise
+parity would report a diff on it between any two independent captures.
+
+Standalone counterpart to ``harness.capture.snapshot_capture`` for the
+orch-less, db-less co2/co2hex 2-server topology (CO2SENSOR@8012 + ACTVIS@5001
+only -- no ORCH, no DB), mirroring spec/gamry's ``golden_capture[_spec].py``
+(see those modules' docstrings for the full topology-gap rationale). The
+hardware-agnostic settle / anti-vacuous-guard logic (``settle``,
+``_run_artifacts``, ``_act_status_map``) and the production dispatch path
+(``dispatch_action``) are IMPORTED from ``golden_capture.py`` rather than
+re-implemented here; only the scenario-specific pieces (endpoint, masking,
+manifest notes) are new. ``golden_capture.py`` itself is NOT modified.
+
+Usage (AT-STATION, Windows, conda env ``helao``) -- ATTACH THE SENSOR FIRST:
+
+    rmdir /s /q C:\\INST_hlo_golden               (or pick a fresh --root)
+    conda run -n helao python launch.py co2gold --no-hot-reload
+    conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_co2 ^
+        --config-prefix co2gold --root C:\\INST_hlo_golden ^
+        --out C:\\golden\\co2
+
+then terminate the launch, point ``--root``/``--config-prefix`` at a FRESH
+throwaway root and ``co2goldhex``, capture again, and diff the two capture
+directories with ``harness.parity``. ``co2_diff.bat`` automates exactly this
+sequence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from harness import HARNESS_VERSION
+from harness.capture import assert_fresh, wait_for_server
+from harness.manifest import ProvenanceManifest
+from harness.treepass import PARITY_TOPS
+
+from helao.hexagon.tests.smoke.golden_capture import (
+    _act_status_map,
+    _run_artifacts,
+    dispatch_action,
+    settle,
+)
+
+CO2_HOST, CO2_PORT = "127.0.0.1", 8012
+
+SCENARIO = "GM-CO2"
+
+# helao/hexagon/tests/smoke/golden_capture_co2.py -> repo root is 4 parents up
+# (matches safe_root.py's own _repo_root()).
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFIG_DIR = REPO_ROOT / "helao" / "deploy" / "hte" / "configs"
+
+# CO2MonExec._poll (sprintir_driver.py) builds each data row as
+# {"co2_ppm": <live sensor ppm>, "epoch_s": <wall clock>}. Both are
+# live/hardware-derived -- no seeded/deterministic sim values exist anywhere in
+# this driver -- so their VALUES must be masked for parity; column presence is
+# still compared. Pattern "*.hlo" is safe: the only .hlo an acquire_co2 capture
+# emits is this CO2 stream file.
+CO2_HLO_COLUMNS = ["co2_ppm", "epoch_s"]
+CO2_MASKED_HLO_COLUMNS = {
+    "*.hlo": CO2_HLO_COLUMNS,
+    "*.hlo.json*": CO2_HLO_COLUMNS,
+}
+# The executor is POLL-PACED (one row per acquisition_rate-second poll over a
+# wall-clock `duration`), so the row count jitters by a row or two run-to-run --
+# masked columns compared within a small tolerance (mirrors gamry run_OCV; NOT
+# spec's exact single-shot count).
+CO2_HLO_ROW_COUNT_TOLERANCE = {"*.hlo": 2, "*.hlo.json*": 2}
+# CO2MonExec._post_exec writes the data-derived summary value mean_co2_ppm back
+# into the run's -act.yml action_params. It derives from the same live/unmasked
+# measurement and is NOT covered by masked_hlo_columns (hlo files only) nor by
+# normalize_meta's §5.5 volatile lists (a plain float leaf under action_params).
+# Masked via masked_meta_keys (the meta-side analogue of masked_hlo_columns):
+# parity neutralizes its VALUE on both sides while keeping the key present, so
+# the runtime diff is a CLEAN PASS when only it differs and a real regression in
+# any other key/file still surfaces. The key is a no-op on any yml lacking it.
+CO2_ACT_YML_MASKED_META_KEYS = {
+    "*-act.yml": [
+        "action_params.mean_co2_ppm",
+    ],
+}
+
+
+def acquire_co2_action(
+    config_prefix: str, duration: float = 3.0, acquisition_rate: float = 0.2
+) -> dict:
+    """Run /CO2SENSOR/acquire_co2 via ``async_action_dispatcher`` (production
+    action-dispatch path -- RPC then HTTP, full action envelope).
+
+    A SHORT finite ``duration`` (> 0) streams live CO2 ppm for that many seconds
+    then terminates on its own (``CO2MonExec._poll`` finishes when the elapsed
+    wall clock reaches ``duration``); ``duration <= 0`` would run until
+    cancelled. Non-perturbing: mirrors the sensor's live-buffer reading, drives
+    nothing. The endpoint's ``fast_samples_in`` defaults to ``Body([])`` so no
+    sample is required.
+    """
+    return dispatch_action(
+        config_prefix,
+        "CO2SENSOR",
+        "acquire_co2",
+        {"duration": duration, "acquisition_rate": acquisition_rate},
+        # duration-bounded stream plus headroom for the endpoint's trailing
+        # dangling-data drain + finish().
+        timeout=60,
+    )
+
+
+def snapshot(
+    root: Path,
+    out_dir: Path,
+    config_prefix: str,
+    duration: float,
+    acquisition_rate: float,
+    notes: str = "",
+) -> Path:
+    """Copy PARITY_TOPS from ``root`` and write a provenance manifest.
+
+    Refuses to overwrite an existing ``out_dir``, matching
+    ``harness.capture.snapshot_capture`` / spec/gamry's ``snapshot``.
+    """
+    root, out_dir = Path(root), Path(out_dir)
+    if out_dir.exists():
+        raise FileExistsError(
+            f"{out_dir} already exists; refusing to overwrite a capture"
+        )
+    # Anti-vacuous-pass guard (shared convention with spec/gamry/galil/sample):
+    # an empty capture (no action output) compares to nothing and passes parity
+    # trivially. Require at least one -act.yml before writing anything.
+    acts, hlos = _run_artifacts(root)
+    if not acts:
+        raise RuntimeError(
+            f"{root} has no -act.yml to capture; refusing a vacuous capture "
+            "that would pass parity with 0 diffs. Check the launch/capture "
+            "logs -- the action may have errored or produced no output."
+        )
+    errored = [p for p, st in _act_status_map(root).items() if "errored" in st]
+    if errored:
+        print(
+            f"[golden_capture_co2] WARNING: {len(errored)} action(s) ERRORED "
+            f"and were still captured: {errored}. An errored run is NOT a valid "
+            "parity baseline. Check the -act.yml error fields and the CO2SENSOR "
+            "log before trusting a PASS."
+        )
+    if not hlos:
+        print(
+            f"[golden_capture_co2] WARNING: no .hlo captured under {root} -- "
+            "acquire_co2 produced no CO2 stream data file. Parity will compare "
+            "-act.yml metadata only, NOT the hlo data-write path. Verify the "
+            "SprintIR is attached on COM12 and the poller returned ppm samples."
+        )
+    out_root = out_dir / "root"
+    out_root.mkdir(parents=True)
+    for top in PARITY_TOPS:
+        src = root / top
+        if src.is_dir():
+            shutil.copytree(src, out_root / top)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    config_path = CONFIG_DIR / f"{config_prefix}.yml"
+    combined_notes = (
+        "REAL-HARDWARE acquire_co2 capture (SprintIR-6S CO2 sensor attached on "
+        "COM12); NOT a simulation -- SprintIR has no sim/dummy data path. The "
+        ".hlo body columns co2_ppm/epoch_s are live sensor data and are masked "
+        "via masked_hlo_columns; the row count is compared within "
+        "hlo_row_count_tolerance (the executor is poll-paced). The data-derived "
+        "action_params key mean_co2_ppm is masked via masked_meta_keys, so "
+        "parity is a clean PASS when only these differ."
+    )
+    if notes:
+        combined_notes = f"{combined_notes} {notes}"
+    ProvenanceManifest(
+        scenario=SCENARIO,
+        config_prefix=config_prefix,
+        config_path=str(config_path),
+        legacy_git_sha=sha,
+        launch_cmd=f"conda run -n helao python launch.py {config_prefix} --no-hot-reload",
+        sequence_name="manual_acquire_co2",
+        sequence_params={
+            "manual": True,
+            "endpoint": "POST /CO2SENSOR/acquire_co2",
+            "duration": duration,
+            "acquisition_rate": acquisition_rate,
+            "fast_samples_in": [],
+        },
+        capture_timestamp=datetime.datetime.now().isoformat(timespec="seconds"),
+        harness_version=HARNESS_VERSION,
+        masked_hlo_columns=CO2_MASKED_HLO_COLUMNS,
+        hlo_row_count_tolerance=CO2_HLO_ROW_COUNT_TOLERANCE,
+        masked_meta_keys=CO2_ACT_YML_MASKED_META_KEYS,
+        notes=combined_notes,
+    ).save(out_dir)
+    return out_dir
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m helao.hexagon.tests.smoke.golden_capture_co2",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--config-prefix", required=True)
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=3.0,
+        help="acquire_co2 duration in seconds; must be > 0 so the stream "
+        "terminates on its own (default 3.0)",
+    )
+    parser.add_argument(
+        "--acquisition-rate",
+        type=float,
+        default=0.2,
+        help="acquisition_rate (poll pacing, seconds/sample) (default 0.2)",
+    )
+    parser.add_argument("--settle-polls", type=int, default=3)
+    parser.add_argument("--notes", default="")
+    args = parser.parse_args(argv)
+
+    if args.duration <= 0:
+        parser.error(
+            "--duration must be > 0 so acquire_co2 terminates on its own "
+            "(duration <= 0 runs until cancelled and would hang the capture)"
+        )
+
+    assert_fresh(args.root)
+    wait_for_server(CO2_HOST, CO2_PORT)
+    acquire_co2_action(args.config_prefix, args.duration, args.acquisition_rate)
+    settle(args.root, settle_polls=args.settle_polls)
+    out = snapshot(
+        root=args.root,
+        out_dir=args.out,
+        config_prefix=args.config_prefix,
+        duration=args.duration,
+        acquisition_rate=args.acquisition_rate,
+        notes=args.notes,
+    )
+    print(f"captured {SCENARIO} -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/golden_capture_mfc.py
+++ b/helao/hexagon/tests/smoke/golden_capture_mfc.py
@@ -1,0 +1,336 @@
+"""Runtime golden-diff capture for the mfc_server hexagon canary (P3a
+special-split).
+
+*** DRIVES THE REAL ALICAT MASS FLOW CONTROLLER (READ-ONLY, NON-PERTURBING). ***
+
+Like gamry/galil (and unlike sample), mfc_server has NO sim/dummy data path:
+``AliCatMFC.connect`` (helao/deploy/hte/drivers/mfc/alicat_driver.py) opens a
+real ``FlowController`` on the configured serial COM port and ``mfc_server.py``
+instantiates ``driver_classes=[AliCatMFC]`` unconditionally -- the config's
+``dummy``/``simulation`` YAML keys are cosmetic (banner color) for this canary
+only. (One difference from gamry: ``AliCatMFC.__init__`` does NO device I/O and
+``connect()`` exceptions are caught, so the server still BOOTS + serves
+/openapi.json with no MFC attached -- that is what the openapi mfc_canary.bat
+relies on. This RUNTIME capture, however, needs the live device: with no Alicat
+on COM9 the poller buffers nothing and ``MfcExec._poll`` errors reading an empty
+live buffer.) So this capture rig is an AT-STATION, REAL-HARDWARE gate: the
+Alicat MFC must be attached on COM9 for ``acquire_flowrate`` to produce data.
+
+SAFETY -- why acquire_flowrate is the non-perturbing choice
+-----------------------------------------------------------
+``acquire_flowrate`` (``POST /MFC/acquire_flowrate``) is dispatched here with
+``flowrate_sccm`` LEFT UNSET (defaults to ``None``). Under that default the
+``MfcExec`` executor:
+  * ``_pre_exec``: ``if flowrate_sccm is not None`` -> SKIPPED. No ``set_flowrate``
+    is issued (no setpoint written, no flow commanded).
+  * ``_exec``:     ``if flowrate_sccm is not None`` -> SKIPPED. No ``hold_cancel``
+    is issued (the valve is NEVER opened).
+  * ``_poll``:     reads the live status buffer only (pressure/temperature/
+    flow/setpoint/gas/...); it drives nothing.
+  * ``_post_exec``: unless ``stay_open`` (left False here), ``hold_valve_closed``
+    forces the setpoint to 0 and latches the valve CLOSED -- i.e. it ends in the
+    SAFEST state (no gas flow), not a perturbed one.
+So the action never opens the valve or commands flow: it streams telemetry and
+finishes with the valve closed. The set_flowrate/set_pressure/maintain_*/
+hold_valve_* endpoints (which actively drive gas/valves) and the cancel_*
+endpoints are deliberately NOT exercised.
+
+A SHORT finite ``duration`` (default 2.0s) is passed so the streamed action
+reaches a TERMINAL ``action_status`` and writes its ``-act.yml``; the default
+``duration=-1`` would run until cancelled and never settle.
+
+Masking
+-------
+``acquire_flowrate`` streams the per-poll live-buffer dict as the ``.hlo`` body:
+``epoch_s``, ``acquire_time``, ``pressure``, ``temperature``, ``volumetric_flow``,
+``mass_flow``, ``setpoint`` (and ``total flow`` on totalizer units) are live
+sensor/clock readings, non-deterministic run-to-run, so their VALUES are masked
+via the manifest's ``masked_hlo_columns``. The categorical/config-deterministic
+columns ``gas`` and ``control_point`` are NOT masked (they are the deterministic
+anchors -- the .hlo analogue of spec's ``wl`` header -- and a diff there is a
+real regression). The stream is POLL-PACED (~``duration``/``acquisition_rate``
+rows), so row counts jitter a row or two run-to-run and are compared within
+``hlo_row_count_tolerance`` (not exact).
+
+Unlike gamry's ``run_OCV`` (which stashes several summaries), ``MfcExec._post_exec``
+writes exactly ONE data-derived value back into ``action_params``:
+``total_scc`` (the integral of the live flow reading). It is masked via the
+manifest's ``masked_meta_keys`` so ``-act.yml`` parity is a clean PASS when only
+that integrated value differs, while a diff in any other key still surfaces.
+
+Standalone counterpart to ``harness.capture.snapshot_capture`` for the
+orch-less, db-less mfc/mfchex 2-server topology (MFC@8009 + ACTVIS@5001 only --
+no ORCH, no DB), mirroring gamry/galil/spec's ``golden_capture[_spec].py`` (see
+those modules' docstrings for the full topology-gap rationale). The
+hardware-agnostic settle / anti-vacuous-guard logic (``settle``,
+``_run_artifacts``, ``_act_status_map``) and the production dispatch path
+(``dispatch_action``) are IMPORTED from ``golden_capture.py`` rather than
+re-implemented here; only the scenario-specific pieces (endpoint, masking,
+manifest notes) are new. ``golden_capture.py`` itself is NOT modified.
+
+Usage (AT-STATION, Windows, conda env ``helao``) -- ATTACH THE ALICAT MFC FIRST:
+
+    rmdir /s /q C:\\INST_hlo_golden               (or pick a fresh --root)
+    conda run -n helao python launch.py mfcgold --no-hot-reload
+    conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_mfc ^
+        --config-prefix mfcgold --root C:\\INST_hlo_golden ^
+        --out C:\\golden\\mfc
+
+then terminate the launch, point ``--root``/``--config-prefix`` at a FRESH
+throwaway root and ``mfcgoldhex``, capture again, and diff the two capture
+directories with ``harness.parity``. ``mfc_diff.bat`` automates exactly this
+sequence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from harness import HARNESS_VERSION
+from harness.capture import assert_fresh, wait_for_server
+from harness.manifest import ProvenanceManifest
+from harness.treepass import PARITY_TOPS
+
+from helao.hexagon.tests.smoke.golden_capture import (
+    _act_status_map,
+    _run_artifacts,
+    dispatch_action,
+    settle,
+)
+
+MFC_HOST, MFC_PORT = "127.0.0.1", 8009
+
+SCENARIO = "GM-MFCFLOW"
+
+# helao/hexagon/tests/smoke/golden_capture_mfc.py -> repo root is 4 parents up
+# (matches safe_root.py's own _repo_root()).
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFIG_DIR = REPO_ROOT / "helao" / "deploy" / "hte" / "configs"
+
+# The single MFC device declared in the mfc*.yml MFC block (ccsi1.yml verbatim:
+# devices: {CO2: {port: COM9, unit_id: A}}). devices[0] == "CO2" is the endpoint
+# default for device_name; passed explicitly here so both captures target the
+# same controller deterministically.
+DEVICE_NAME = "CO2"
+
+# acquire_flowrate (MfcExec._poll) streams the per-poll live-buffer status dict
+# (helao/deploy/hte/drivers/mfc/alicat_driver.py: FlowController.get_status +
+# the executor's added epoch_s) as the .hlo body. These columns are live
+# sensor/clock readings pulled straight off the Alicat -- no seeded/
+# deterministic sim values exist in this driver -- so their VALUES are masked
+# for parity. "total flow" is present only on totalizer-equipped units; masking
+# it is a harmless no-op otherwise. The categorical config-deterministic columns
+# (gas, control_point) are intentionally NOT masked (the deterministic anchors).
+MFC_HLO_COLUMNS = [
+    "epoch_s",
+    "acquire_time",
+    "pressure",
+    "temperature",
+    "volumetric_flow",
+    "mass_flow",
+    "setpoint",
+    "total flow",
+]
+MFC_MASKED_HLO_COLUMNS = {
+    "*.hlo": MFC_HLO_COLUMNS,
+    "*.hlo.json*": MFC_HLO_COLUMNS,
+}
+# acquire_flowrate is a POLL-PACED stream (~duration/acquisition_rate rows), so
+# the row count jitters a row or two run-to-run (poll timing) -- compare masked
+# columns within a small tolerance, not exactly (mirrors gamry run_OCV).
+MFC_HLO_ROW_COUNT_TOLERANCE = {"*.hlo": 2, "*.hlo.json*": 2}
+# MfcExec._post_exec writes exactly one data-derived summary back into
+# action_params: total_scc (integral of the live flow). It derives from the same
+# masked live measurement and is not covered by masked_hlo_columns (.hlo only)
+# nor by normalize_meta's §5.5 volatile lists (it is a plain float leaf under
+# action_params). Mask its VALUE via masked_meta_keys so -act.yml parity is a
+# clean PASS when only it differs; presence + every other key still diff normally.
+MFC_ACT_YML_MASKED_META_KEYS = {
+    "*-act.yml": ["action_params.total_scc"],
+}
+
+
+def acquire_flowrate_action(
+    config_prefix: str,
+    device_name: str = DEVICE_NAME,
+    duration: float = 2.0,
+    acquisition_rate: float = 0.2,
+) -> dict:
+    """Run /MFC/acquire_flowrate via ``async_action_dispatcher`` (production
+    action-dispatch path -- RPC then HTTP, full action envelope).
+
+    ``flowrate_sccm`` is deliberately OMITTED (defaults to ``None``): under that
+    default ``MfcExec`` never issues ``set_flowrate`` and never opens the valve
+    -- it only READS live telemetry, then (``stay_open`` False) latches the valve
+    CLOSED at the end. ``duration`` is a SHORT finite value so the streamed
+    action settles to a terminal status (the default ``-1`` runs until cancelled).
+    """
+    return dispatch_action(
+        config_prefix,
+        "MFC",
+        "acquire_flowrate",
+        {
+            "device_name": device_name,
+            "duration": duration,
+            "acquisition_rate": acquisition_rate,
+        },
+        # short stream, but leave headroom for the endpoint's trailing
+        # dangling-data drain + finish().
+        timeout=60,
+    )
+
+
+def snapshot(
+    root: Path,
+    out_dir: Path,
+    config_prefix: str,
+    device_name: str,
+    duration: float,
+    acquisition_rate: float,
+    notes: str = "",
+) -> Path:
+    """Copy PARITY_TOPS from ``root`` and write a provenance manifest.
+
+    Refuses to overwrite an existing ``out_dir``, matching
+    ``harness.capture.snapshot_capture`` / gamry/spec's ``golden_capture.snapshot``.
+    """
+    root, out_dir = Path(root), Path(out_dir)
+    if out_dir.exists():
+        raise FileExistsError(
+            f"{out_dir} already exists; refusing to overwrite a capture"
+        )
+    # Anti-vacuous-pass guard (shared convention with gamry/galil/spec/sample):
+    # an empty capture (no action output) compares to nothing and passes parity
+    # trivially. Require at least one -act.yml before writing anything.
+    acts, hlos = _run_artifacts(root)
+    if not acts:
+        raise RuntimeError(
+            f"{root} has no -act.yml to capture; refusing a vacuous capture "
+            "that would pass parity with 0 diffs. Check the launch/capture "
+            "logs -- the action may have errored or produced no output."
+        )
+    errored = [p for p, st in _act_status_map(root).items() if "errored" in st]
+    if errored:
+        print(
+            f"[golden_capture_mfc] WARNING: {len(errored)} action(s) ERRORED "
+            f"and were still captured: {errored}. An errored run is NOT a valid "
+            "parity baseline. Check the -act.yml error fields and the MFC log "
+            "before trusting a PASS (e.g. no Alicat on COM9 -> empty live buffer)."
+        )
+    if not hlos:
+        print(
+            f"[golden_capture_mfc] WARNING: no .hlo captured under {root} -- "
+            "acquire_flowrate produced no telemetry data file. Parity will "
+            "compare -act.yml metadata only, NOT the hlo data-write path. Verify "
+            "the Alicat MFC is attached on COM9 and the poller is buffering data."
+        )
+    out_root = out_dir / "root"
+    out_root.mkdir(parents=True)
+    for top in PARITY_TOPS:
+        src = root / top
+        if src.is_dir():
+            shutil.copytree(src, out_root / top)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    config_path = CONFIG_DIR / f"{config_prefix}.yml"
+    combined_notes = (
+        "REAL-HARDWARE acquire_flowrate capture (Alicat MFC attached on COM9); "
+        "NOT a simulation -- AliCatMFC has no sim/dummy data path. Dispatched "
+        "with flowrate_sccm=None so the MFC valve is NEVER opened and NO flow is "
+        "commanded (pure telemetry read; ends valve-closed). The .hlo body "
+        "columns epoch_s/acquire_time/pressure/temperature/volumetric_flow/"
+        "mass_flow/setpoint (+ total flow) are live device readings, masked via "
+        "masked_hlo_columns; gas/control_point are config-deterministic and "
+        "compared unmasked. action_params.total_scc (integrated live flow) is "
+        "masked via masked_meta_keys. Row counts are poll-paced -> compared "
+        "within hlo_row_count_tolerance."
+    )
+    if notes:
+        combined_notes = f"{combined_notes} {notes}"
+    ProvenanceManifest(
+        scenario=SCENARIO,
+        config_prefix=config_prefix,
+        config_path=str(config_path),
+        legacy_git_sha=sha,
+        launch_cmd=f"conda run -n helao python launch.py {config_prefix} --no-hot-reload",
+        sequence_name="manual_acquire_flowrate",
+        sequence_params={
+            "manual": True,
+            "endpoint": "POST /MFC/acquire_flowrate",
+            "device_name": device_name,
+            "flowrate_sccm": None,
+            "duration": duration,
+            "acquisition_rate": acquisition_rate,
+            "fast_samples_in": [],
+        },
+        capture_timestamp=datetime.datetime.now().isoformat(timespec="seconds"),
+        harness_version=HARNESS_VERSION,
+        masked_hlo_columns=MFC_MASKED_HLO_COLUMNS,
+        hlo_row_count_tolerance=MFC_HLO_ROW_COUNT_TOLERANCE,
+        masked_meta_keys=MFC_ACT_YML_MASKED_META_KEYS,
+        notes=combined_notes,
+    ).save(out_dir)
+    return out_dir
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m helao.hexagon.tests.smoke.golden_capture_mfc",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--config-prefix", required=True)
+    parser.add_argument(
+        "--device-name",
+        default=DEVICE_NAME,
+        help=f"MFC device_name (default {DEVICE_NAME})",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=2.0,
+        help="acquire_flowrate duration in seconds; SHORT + finite so the "
+        "stream settles (default 2.0). flowrate_sccm stays None (safe read).",
+    )
+    parser.add_argument(
+        "--acquisition-rate",
+        type=float,
+        default=0.2,
+        help="executor poll period in seconds (default 0.2)",
+    )
+    parser.add_argument("--settle-polls", type=int, default=3)
+    parser.add_argument("--notes", default="")
+    args = parser.parse_args(argv)
+
+    assert_fresh(args.root)
+    wait_for_server(MFC_HOST, MFC_PORT)
+    acquire_flowrate_action(
+        args.config_prefix,
+        device_name=args.device_name,
+        duration=args.duration,
+        acquisition_rate=args.acquisition_rate,
+    )
+    settle(args.root, settle_polls=args.settle_polls)
+    out = snapshot(
+        root=args.root,
+        out_dir=args.out,
+        config_prefix=args.config_prefix,
+        device_name=args.device_name,
+        duration=args.duration,
+        acquisition_rate=args.acquisition_rate,
+        notes=args.notes,
+    )
+    print(f"captured {SCENARIO} -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/golden_capture_syringe.py
+++ b/helao/hexagon/tests/smoke/golden_capture_syringe.py
@@ -1,0 +1,293 @@
+"""Runtime golden-diff capture for the syringe_server hexagon canary (P3a
+special-split).
+
+*** READS A SOFTWARE VOLUME COUNTER -- NON-PERTURBING, HARDWARE-INDEPENDENT. ***
+
+Step 0 of the parent task investigated ``get_present_volume`` and found it is
+fundamentally different from the galil/gamry/spec reads:
+
+``get_present_volume`` (``POST /WORKSYRINGE/get_present_volume``,
+syringe_server.py) reads the KDS100 driver's **software-tracked**
+``present_volume_ul`` attribute, writes it into the -act.yml action_params as
+``_present_volume_ul`` (exactly as galil query_positions writes ``_positions``),
+enqueues ONE .hlo data row (columns ``present_volume_ul`` + ``error_code``),
+and finishes. ``present_volume_ul`` is initialized to ``0.0`` in
+``KDS100.__init__`` (legato_driver.py) and is mutated ONLY by
+infuse/withdraw (``clear_volume`` with a non-zero direction, in PumpExec
+_post_exec) or the private ``set_present_volume`` endpoint. ``connect()`` opens
+the pyserial COM port but NEVER reads the volume off the wire. So on a FRESH
+launch, before any dispense action, the value is deterministically ``0.0`` --
+and ``get_present_volume`` returns that Python attribute, NOT a device query.
+
+Two consequences, both distinct from galil/gamry/spec:
+
+  1. **No masking.** Both the -act.yml ``_present_volume_ul`` leaf and the .hlo
+     ``present_volume_ul`` / ``error_code`` columns are deterministic on a fresh
+     idle pump (``0.0`` / ``ErrorCodes.none``). They are NOT live/nondeterministic
+     device readings, so masked_meta_keys / masked_hlo_columns are EMPTY here
+     (masking a deterministic value would only weaken the parity check). Any
+     legacy-vs-hexagon difference in these values is therefore a REAL regression
+     and is compared unmasked. Contrast galil (``position`` is a live encoder
+     read -> masked_hlo_columns) and gamry (``*_mean_final`` are live-measurement
+     derived -> masked_meta_keys).
+
+  2. **Hardware-independent.** Because the read never touches the wire, this
+     capture produces a valid, non-vacuous, exactly-reproducible tree even with
+     the Legato pump DETACHED (or on Linux, where COM5 does not exist and
+     connect() just fails soft). ``check_device_open`` below therefore only WARNS
+     (it does not raise like galil's verify_device_open): a closed serial port
+     does not invalidate a get_present_volume capture, it just means the driver's
+     full serial lifecycle wasn't exercised.
+
+``get_present_volume`` is NON-PERTURBING regardless: it issues no infuse/
+withdraw/run command and does not move the plunger or fluid (contrast infuse/
+withdraw, which drive the pump -- deliberately NOT chosen for this canary).
+
+Standalone counterpart to ``harness.capture.snapshot_capture`` for the
+orch-less, db-less syringe/syringehex 2-server topology (WORKSYRINGE@8013 +
+ACTVIS@5001 only -- no ORCH, no DB), mirroring galil's
+``helao.hexagon.tests.smoke.golden_capture_galil`` and gamry's
+``golden_capture`` (see those modules for the full topology-gap rationale). The
+hardware-agnostic settle/anti-vacuous-guard logic (``settle``,
+``_run_artifacts``, ``_act_status_map``, ``dispatch_action``) is IMPORTED from
+``golden_capture.py`` -- it is pure -act.yml/RUNS_ACTIVE polling logic with no
+scenario-specific assumptions. Only the scenario-specific pieces (endpoint,
+masking=NONE, manifest notes) are new here. ``golden_capture.py`` is NOT modified.
+
+Usage (conda env ``helao``) -- the Legato pump need NOT be attached for a valid
+capture, and THE PLUNGER DOES NOT MOVE for this scenario:
+
+    rmdir /s /q C:\\INST_hlo_golden               (or pick a fresh --root)
+    conda run -n helao python launch.py syringegold --no-hot-reload
+    conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_syringe ^
+        --config-prefix syringegold --root C:\\INST_hlo_golden ^
+        --out C:\\golden\\syringe
+
+then terminate the launch, point ``--root``/``--config-prefix`` at a FRESH
+throwaway root and ``syringegoldhex``, capture again, and diff the two capture
+directories with ``harness.parity``. ``syringe_diff.bat`` automates exactly
+this sequence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import requests
+
+from harness import HARNESS_VERSION
+from harness.capture import assert_fresh, wait_for_server
+from harness.manifest import ProvenanceManifest
+from harness.treepass import PARITY_TOPS
+
+from helao.hexagon.tests.smoke.golden_capture import (
+    _act_status_map,
+    _run_artifacts,
+    dispatch_action,
+    settle,
+)
+
+SYRINGE_HOST, SYRINGE_PORT = "127.0.0.1", 8013
+
+SCENARIO = "GM-SYRVOL"
+
+# helao/hexagon/tests/smoke/golden_capture_syringe.py -> repo root is 4 parents
+# up (matches safe_root.py's own _repo_root()).
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFIG_DIR = REPO_ROOT / "helao" / "deploy" / "hte" / "configs"
+
+# MASKING = NONE (deliberate -- see module docstring). get_present_volume
+# writes the driver's software-tracked present_volume_ul (0.0 on a fresh idle
+# pump) into:
+#   - -act.yml action_params ._present_volume_ul  (deterministic 0.0)
+#   - one .hlo row: present_volume_ul (0.0) + error_code (ErrorCodes.none)
+# All three are config-deterministic on a fresh launch, NOT live/nondeterministic
+# device readings, so nothing is masked. Any legacy-vs-hexagon diff on them is a
+# REAL regression. These are exported (empty) so the unit test can assert the
+# masking decision explicitly -- a future edit that adds masking here must be a
+# conscious change that flips the test.
+SYRVOL_MASKED_HLO_COLUMNS: dict = {}
+SYRVOL_MASKED_META_KEYS: dict = {}
+
+
+def check_device_open(host: str, port: int) -> bool:
+    """WARN (do NOT raise) if the KDS100 serial port did not open at startup.
+
+    ``KDS100.connect()`` opens the pyserial COM port; if it is unreachable
+    (pump detached, wrong COM, or Linux where COM5 does not exist) connect()
+    catches the exception and returns a failed ``DriverResponse`` WITHOUT
+    raising, so the server still comes up with ``self.com is None`` and
+    ``KDS100.get_status()`` reports ``uninitialized``.
+
+    Unlike galil's ``verify_device_open`` (which HARD-RAISES because
+    query_positions returns empty data off a closed controller), this check is
+    NON-FATAL: ``get_present_volume`` reads the software-tracked
+    ``present_volume_ul`` attribute (0.0 on a fresh launch), NOT the wire, so it
+    produces a valid, deterministic, non-vacuous capture even with the serial
+    port closed. A closed port only means the driver's full serial lifecycle was
+    not exercised -- worth a loud warning, not an abort.
+
+    NOTE: ``get_status`` is a PRIVATE endpoint -- bare ``/get_status``, NOT
+    ``/WORKSYRINGE/get_status``. On this server only ACTION endpoints carry the
+    ``/{server_key}/`` prefix (e.g. ``/WORKSYRINGE/get_present_volume``);
+    private/system routes (get_status, shutdown, endpoints) are unprefixed.
+    ``_driver_status`` is ``KDS100.get_status()``'s ``DriverStatus`` value:
+    "uninitialized" when ``self.com`` is None, "ok" once the serial port is open
+    (base_api.py's bare ``/get_status`` handler appends it as
+    ``status_dict["_driver_status"]``).
+
+    Returns True if the device serial port is open, else False (after warning).
+    """
+    try:
+        r = requests.post(f"http://{host}:{port}/get_status", timeout=10)
+        driver_status = r.json().get("_driver_status") if r.status_code == 200 else None
+    except (requests.RequestException, ValueError):
+        driver_status = None
+    if driver_status not in ("ok", "busy"):
+        print(
+            f"[golden_capture_syringe] WARNING: WORKSYRINGE serial port is NOT "
+            f"open (_driver_status={driver_status!r}) -- connect() failed at "
+            "startup (pump detached / wrong COM / Linux with no COM5). This does "
+            "NOT invalidate the capture: get_present_volume reads the software "
+            "present_volume_ul counter (0.0 on a fresh launch), not the wire, so "
+            "the tree is still valid and deterministic. Attach the pump if you "
+            "want to exercise the full serial driver lifecycle."
+        )
+        return False
+    return True
+
+
+def get_present_volume_action(config_prefix: str) -> dict:
+    """Run /WORKSYRINGE/get_present_volume via ``async_action_dispatcher`` (the
+    production action-dispatch path -- RPC then HTTP, full action envelope).
+
+    No params: ``get_present_volume`` takes none. Non-perturbing -- reads the
+    tracked ``present_volume_ul`` counter only, issues no pump motion command.
+    """
+    return dispatch_action(config_prefix, "WORKSYRINGE", "get_present_volume")
+
+
+def snapshot(
+    root: Path,
+    out_dir: Path,
+    config_prefix: str,
+    notes: str = "",
+) -> Path:
+    """Copy PARITY_TOPS from ``root`` and write a provenance manifest.
+
+    Refuses to overwrite an existing ``out_dir``, matching
+    ``harness.capture.snapshot_capture`` / galil's ``golden_capture_galil.snapshot``.
+    """
+    root, out_dir = Path(root), Path(out_dir)
+    if out_dir.exists():
+        raise FileExistsError(
+            f"{out_dir} already exists; refusing to overwrite a capture"
+        )
+    # Anti-vacuous-pass guard (shared with galil/gamry): an empty capture (no
+    # action output) compares to nothing and passes parity trivially. Require at
+    # least one -act.yml before writing anything.
+    #
+    # For THIS scenario a .hlo IS expected (get_present_volume always enqueues
+    # one data row and finishes -- it is NOT metadata-only), so a missing .hlo is
+    # a strong signal of a broken data-write path and is warned loudly below.
+    acts, hlos = _run_artifacts(root)
+    if not acts:
+        raise RuntimeError(
+            f"{root} has no -act.yml to capture; refusing a vacuous capture "
+            "that would pass parity with 0 diffs. Check the launch/capture "
+            "logs -- the action may have errored or produced no output."
+        )
+    errored = [p for p, st in _act_status_map(root).items() if "errored" in st]
+    if errored:
+        print(
+            f"[golden_capture_syringe] WARNING: {len(errored)} action(s) ERRORED "
+            f"and were still captured: {errored}. An errored run is NOT a valid "
+            "parity baseline (it likely produced no data / partial output). Check "
+            "the -act.yml error fields and the WORKSYRINGE log before trusting a "
+            "PASS."
+        )
+    if not hlos:
+        print(
+            f"[golden_capture_syringe] WARNING: no .hlo captured under {root} -- "
+            "get_present_volume ALWAYS enqueues one data row, so its absence "
+            "means the data-write path did not run. Parity will compare -act.yml "
+            "metadata only, NOT the hlo data-write path. Check the WORKSYRINGE "
+            "log."
+        )
+    out_root = out_dir / "root"
+    out_root.mkdir(parents=True)
+    for top in PARITY_TOPS:
+        src = root / top
+        if src.is_dir():
+            shutil.copytree(src, out_root / top)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    config_path = CONFIG_DIR / f"{config_prefix}.yml"
+    combined_notes = (
+        "get_present_volume capture: reads the KDS100 driver's software-tracked "
+        "present_volume_ul counter (0.0 on a fresh launch, KDS100.__init__), NOT "
+        "a wire query -- NON-PERTURBING (no plunger motion) and "
+        "hardware-INDEPENDENT (valid even with the pump detached). The -act.yml "
+        "_present_volume_ul leaf and the .hlo present_volume_ul/error_code "
+        "columns are config-deterministic on a fresh idle pump, so NOTHING is "
+        "masked (masking a deterministic value would only weaken the parity "
+        "check); any legacy-vs-hexagon diff on them is a REAL regression."
+    )
+    if notes:
+        combined_notes = f"{combined_notes} {notes}"
+    ProvenanceManifest(
+        scenario=SCENARIO,
+        config_prefix=config_prefix,
+        config_path=str(config_path),
+        legacy_git_sha=sha,
+        launch_cmd=f"conda run -n helao python launch.py {config_prefix} --no-hot-reload",
+        sequence_name="manual_get_present_volume",
+        sequence_params={
+            "manual": True,
+            "endpoint": "POST /WORKSYRINGE/get_present_volume",
+        },
+        capture_timestamp=datetime.datetime.now().isoformat(timespec="seconds"),
+        harness_version=HARNESS_VERSION,
+        masked_hlo_columns=SYRVOL_MASKED_HLO_COLUMNS,
+        masked_meta_keys=SYRVOL_MASKED_META_KEYS,
+        notes=combined_notes,
+    ).save(out_dir)
+    return out_dir
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m helao.hexagon.tests.smoke.golden_capture_syringe",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--config-prefix", required=True)
+    parser.add_argument("--settle-polls", type=int, default=3)
+    parser.add_argument("--notes", default="")
+    args = parser.parse_args(argv)
+
+    assert_fresh(args.root)
+    wait_for_server(SYRINGE_HOST, SYRINGE_PORT)
+    check_device_open(SYRINGE_HOST, SYRINGE_PORT)  # non-fatal warning only
+    get_present_volume_action(args.config_prefix)
+    settle(args.root, settle_polls=args.settle_polls)
+    out = snapshot(
+        root=args.root,
+        out_dir=args.out,
+        config_prefix=args.config_prefix,
+        notes=args.notes,
+    )
+    print(f"captured {SCENARIO} -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/golden_capture_tec.py
+++ b/helao/hexagon/tests/smoke/golden_capture_tec.py
@@ -1,0 +1,282 @@
+"""Runtime golden-diff capture for the tec_server hexagon canary (P3a
+special-split).
+
+*** DRIVES THE REAL MEERSTETTER TEC CONTROLLER (READ-ONLY TELEMETRY, NO
+SETPOINT/ENABLE CHANGE). ***
+
+``record_tec`` (``POST /TEC/record_tec``, ``tec_server.py``) starts a
+``TECMonExec`` that streams TEC telemetry (``tec_vals`` off the poller's live
+buffer) for a fixed ``duration`` and never calls ``set_temp``/``enable``/
+``disable`` -- it is NON-PERTURBING. It still requires a live MeCom serial
+session to produce any real data: ``MeerstetterTEC`` has no sim/dummy data
+path (``get_data`` raises/returns empty on a closed session; see
+``mecom_driver.py``), and unlike ``galil_motion``/``gamry`` the MeCom session
+is opened LAZILY -- ``MeerstetterTECPoller``'s background poll loop calls
+``driver.get_data()`` which calls ``driver.session()``, which opens the
+connection on its first call if not already open. There is no explicit
+``connect()`` call anywhere in ``tec_server.py``, so the connection is only
+open once the poller has run at least once after server startup. The
+config's ``dummy``/``simulation`` YAML keys are therefore cosmetic (banner
+color) for this canary, exactly as already documented for galil/gamry.
+
+Standalone counterpart to ``harness.capture.snapshot_capture`` for the
+orch-less, db-less tec/techex 2-server topology (TEC@8008 + ACTVIS@5001 only
+-- no ORCH, no DB), mirroring gamry's
+``helao.hexagon.tests.smoke.golden_capture`` / galil's
+``golden_capture_galil`` (see those modules' docstrings for the full
+topology-gap rationale already recorded there and in ``gamryhex_canary.bat``,
+which hit the same gap for the openapi-diff canary). The hardware-agnostic
+settle/anti-vacuous-guard logic (``settle``, ``_run_artifacts``,
+``_act_status_map``, ``dispatch_action``) is IMPORTED from
+``golden_capture.py`` rather than re-implemented here. Only the
+scenario-specific pieces (endpoint, masking, manifest notes) are new in this
+module. ``golden_capture.py`` itself is NOT modified.
+
+Usage (AT-STATION, Windows, conda env ``helao``) -- the Meerstetter
+controller must be powered on and reachable at the configured serial ``port``
+(COM5 by default). NO setpoint/enable change is issued for this scenario:
+
+    rmdir /s /q C:\\INST_hlo_golden               (or pick a fresh --root)
+    conda run -n helao python launch.py tecgold --no-hot-reload
+    conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_tec ^
+        --config-prefix tecgold --root C:\\INST_hlo_golden ^
+        --out C:\\golden\\tec
+
+then terminate the launch, point ``--root``/``--config-prefix`` at a FRESH
+throwaway root and ``tecgoldhex``, capture again, and diff the two capture
+directories with ``harness.parity``. ``tec_diff.bat`` automates exactly this
+sequence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import requests
+
+from harness import HARNESS_VERSION
+from harness.capture import assert_fresh, wait_for_server
+from harness.manifest import ProvenanceManifest
+from harness.treepass import PARITY_TOPS
+
+from helao.hexagon.tests.smoke.golden_capture import (
+    _act_status_map,
+    _run_artifacts,
+    dispatch_action,
+    settle,
+)
+
+TEC_HOST, TEC_PORT = "127.0.0.1", 8008
+
+SCENARIO = "GM-TEC"
+
+# helao/hexagon/tests/smoke/golden_capture_tec.py -> repo root is 4 parents
+# up (matches safe_root.py's own _repo_root()).
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFIG_DIR = REPO_ROOT / "helao" / "deploy" / "hte" / "configs"
+
+# TECMonExec._poll (mecom_driver.py) reads the poller's live buffer
+# (`tec_vals` + `epoch_s`) and returns it verbatim as the polled `data` dict,
+# which the Executor plumbing enqueues straight through as hlo columns.
+# `tec_vals` keys mirror MeerstetterTEC.queries (default: DEFAULT_QUERIES) --
+# every one is a raw live reading off the MeCom serial session, no
+# seeded/deterministic sim value exists anywhere in this driver, so all
+# columns (including `epoch_s`, a live timestamp) must be masked for parity.
+# Row counts are compared within a small tolerance: the executor's poll
+# cadence is wall-clock/asyncio-scheduling driven (like gamry's OCV), not a
+# fixed sample count.
+TEC_HLO_COLUMNS = [
+    "epoch_s",
+    "enabled_status",
+    "object_temperature",
+    "target_object_temperature",
+    "output_current",
+    "temperature_is_stable",
+]
+TEC_MASKED_HLO_COLUMNS = {
+    "*record_tec*.hlo": TEC_HLO_COLUMNS,
+    "*record_tec*.hlo.json*": TEC_HLO_COLUMNS,
+}
+TEC_HLO_ROW_COUNT_TOLERANCE = {"*record_tec*.hlo": 2, "*record_tec*.hlo.json*": 2}
+
+
+def verify_device_open(host: str, port: int) -> None:
+    """Fail fast if the Meerstetter MeCom session did not open.
+
+    ``MeerstetterTEC``'s MeCom session is opened LAZILY by the poller's first
+    ``get_data()`` call (there is no explicit ``connect()`` call in
+    ``tec_server.py``), so give the poller a moment to run before checking.
+    ``get_status()`` returns ``status=ok`` once ``self._session`` is set,
+    else ``status=uninitialized`` (see ``mecom_driver.py``).
+
+    NOTE: ``get_status`` is a PRIVATE endpoint -- bare ``/get_status``, NOT
+    ``/TEC/get_status``. On this server only ACTION endpoints carry the
+    ``/{server_key}/`` prefix (e.g. ``/TEC/record_tec``); private/system
+    routes (get_status, shutdown, endpoints) are unprefixed.
+    """
+    try:
+        r = requests.post(f"http://{host}:{port}/get_status", timeout=10)
+        driver_status = r.json().get("_driver_status") if r.status_code == 200 else None
+    except (requests.RequestException, ValueError):
+        driver_status = None
+    if driver_status != "ok":
+        raise RuntimeError(
+            f"TEC MeCom session is NOT open (_driver_status={driver_status!r}) "
+            "-- the poller's lazy connect failed (commonly the Meerstetter "
+            "controller unreachable/powered off at the configured serial "
+            "`port`). Verify the controller is powered on and reachable, "
+            "then re-run. See the TEC launch log for the connect traceback."
+        )
+
+
+def record_tec_action(
+    config_prefix: str, duration_s: float, acquisition_rate: float
+) -> dict:
+    """Dispatch /TEC/record_tec via ``async_action_dispatcher`` (the production
+    action-dispatch path -- RPC then HTTP, full action envelope).
+
+    ``duration_s`` bounds the executor's ``TECMonExec._poll`` loop -- it
+    self-terminates (``HloStatus.finished``) once elapsed time exceeds
+    ``duration``, so no separate ``cancel_record_tec`` call is needed.
+    Non-perturbing: does not change the setpoint or enable/disable state.
+    """
+    return dispatch_action(
+        config_prefix,
+        "TEC",
+        "record_tec",
+        {"duration": duration_s, "acquisition_rate": acquisition_rate},
+    )
+
+
+def snapshot(
+    root: Path,
+    out_dir: Path,
+    config_prefix: str,
+    duration_s: float,
+    acquisition_rate: float,
+    notes: str = "",
+) -> Path:
+    """Copy PARITY_TOPS from ``root`` and write a provenance manifest.
+
+    Refuses to overwrite an existing ``out_dir``, matching
+    ``harness.capture.snapshot_capture`` / gamry's ``golden_capture.snapshot``.
+    """
+    root, out_dir = Path(root), Path(out_dir)
+    if out_dir.exists():
+        raise FileExistsError(
+            f"{out_dir} already exists; refusing to overwrite a capture"
+        )
+    # Anti-vacuous-pass guard (shared with gamry's/galil's golden_capture.snapshot):
+    # an empty capture (no action output) compares to nothing and passes
+    # parity trivially. Require at least one -act.yml before writing anything.
+    acts, hlos = _run_artifacts(root)
+    if not acts:
+        raise RuntimeError(
+            f"{root} has no -act.yml to capture; refusing a vacuous capture "
+            "that would pass parity with 0 diffs. Check the launch/capture "
+            "logs -- the action may have errored or produced no output."
+        )
+    errored = [p for p, st in _act_status_map(root).items() if "errored" in st]
+    if errored:
+        print(
+            f"[golden_capture_tec] WARNING: {len(errored)} action(s) ERRORED "
+            f"and were still captured: {errored}. An errored run is NOT a "
+            "valid parity baseline (it likely produced no data / partial "
+            "output). Check the -act.yml error fields and the TEC log "
+            "before trusting a PASS."
+        )
+    if not hlos:
+        print(
+            f"[golden_capture_tec] WARNING: no .hlo captured under {root} -- "
+            "record_tec produced no streamed data file. Parity will compare "
+            "-act.yml metadata only, NOT the hlo data-write path. Verify "
+            "verify_device_open passed and the Meerstetter controller is "
+            "reachable."
+        )
+    out_root = out_dir / "root"
+    out_root.mkdir(parents=True)
+    for top in PARITY_TOPS:
+        src = root / top
+        if src.is_dir():
+            shutil.copytree(src, out_root / top)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    config_path = CONFIG_DIR / f"{config_prefix}.yml"
+    combined_notes = (
+        "REAL-HARDWARE record_tec capture (Meerstetter TEC controller "
+        "reachable at-station); NON-PERTURBING (no setpoint/enable change "
+        "issued). All tec_vals + epoch_s hlo values are masked via "
+        "masked_hlo_columns since they are live device readings, not "
+        "deterministic sim data."
+    )
+    if notes:
+        combined_notes = f"{combined_notes} {notes}"
+    ProvenanceManifest(
+        scenario=SCENARIO,
+        config_prefix=config_prefix,
+        config_path=str(config_path),
+        legacy_git_sha=sha,
+        launch_cmd=f"conda run -n helao python launch.py {config_prefix} --no-hot-reload",
+        sequence_name="manual_record_tec",
+        sequence_params={
+            "manual": True,
+            "endpoint": "POST /TEC/record_tec",
+            "duration": duration_s,
+            "acquisition_rate": acquisition_rate,
+        },
+        capture_timestamp=datetime.datetime.now().isoformat(timespec="seconds"),
+        harness_version=HARNESS_VERSION,
+        masked_hlo_columns=TEC_MASKED_HLO_COLUMNS,
+        hlo_row_count_tolerance=TEC_HLO_ROW_COUNT_TOLERANCE,
+        notes=combined_notes,
+    ).save(out_dir)
+    return out_dir
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m helao.hexagon.tests.smoke.golden_capture_tec",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--config-prefix", required=True)
+    parser.add_argument(
+        "--duration", type=float, default=3.0, help="record_tec duration (default 3.0s)"
+    )
+    parser.add_argument(
+        "--acquisition-rate",
+        type=float,
+        default=0.2,
+        help="poll cadence (default 0.2s)",
+    )
+    parser.add_argument("--settle-polls", type=int, default=3)
+    parser.add_argument("--notes", default="")
+    args = parser.parse_args(argv)
+
+    assert_fresh(args.root)
+    wait_for_server(TEC_HOST, TEC_PORT)
+    verify_device_open(TEC_HOST, TEC_PORT)
+    record_tec_action(args.config_prefix, args.duration, args.acquisition_rate)
+    settle(args.root, settle_polls=args.settle_polls)
+    out = snapshot(
+        root=args.root,
+        out_dir=args.out,
+        config_prefix=args.config_prefix,
+        duration_s=args.duration,
+        acquisition_rate=args.acquisition_rate,
+        notes=args.notes,
+    )
+    print(f"captured {SCENARIO} -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/golden_diff.bat
+++ b/helao/hexagon/tests/smoke/golden_diff.bat
@@ -136,6 +136,18 @@ set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
 echo.
 echo [golden] === %PREFIX% ===
 echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8001 (or its co-located ZMQ RPC sibling 18001); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8001
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT %PREFIX% -- ports 8001/18001 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [golden] waiting for PSTAT port 8001

--- a/helao/hexagon/tests/smoke/kmotor_canary.bat
+++ b/helao/hexagon/tests/smoke/kmotor_canary.bat
@@ -1,0 +1,203 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Windows canary for the kmotorhex hexagon cut-over: runtime /openapi.json diff.
+REM
+REM Launches the LEGACY kmotor group and the HEXAGON kmotorhex group in turn,
+REM dumps each KMOTOR server's live /openapi.json, and diffs them. An identical
+REM route/schema surface proves the hexagon makeActionApp factory produces a
+REM byte-parity action server for the kinesis_server (Thorlabs Kinesis Z-motor)
+REM cut-over target.
+REM
+REM OPENAPI-ONLY canary (no runtime golden diff). hispec.yml's KMOTOR block
+REM declares a single axis `z`; every action route kinesis_server.py registers
+REM under a configured axis -- kmove (commands motion, even a 0.0mm relative
+REM move still issues a real move command), cancel_kmove (stops/cancels a move
+REM executor), and set_velocity (writes live velocity/acceleration parameters
+REM to the device) -- either drives the stage or mutates its hardware state.
+REM There is no position/status QUERY action analogous to galil_motion's
+REM query_positions (the poller samples position internally via
+REM get_lbuf/live_dict, but that is not exposed as a callable action route), so
+REM there is no SAFE non-perturbing read action to dispatch as a canary -- and
+REM no kmotor_diff.bat runtime counterpart. The openapi diff is the topology-
+REM and safety-appropriate parity check (mirrors ni_canary.bat exactly).
+REM
+REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
+REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
+REM sequences to an orchestrator. kmotorhex is a 2-server group (KMOTOR@8015 +
+REM ACTVIS@5001) with NO orchestrator, so the GM-* scenarios cannot drive it.
+REM
+REM Both configs share root C:\INST_hlo and ports 8015/5001, so they MUST run
+REM sequentially (this script does that) -- never launch both at once.
+REM NOTE: kmotor.yml's simulation:true is cosmetic (banner color) -- Kinesis
+REM has no sim/dummy data path. KinesisMotor.connect() opens a real pylablib
+REM Thorlabs.KinesisMotor handle per configured axis against `serial_no`; the
+REM device must be attached and powered so the server boots and serves
+REM /openapi.json (a failed connect() leaves `driver.dev_kinesis` unset, which
+REM raises AttributeError when kinesis_dyn_endpoints registers the axis-typed
+REM route signatures, so the app never boots at all -- this is why the REAL
+REM hispec serial_no/scale params are baked into kmotor.yml/kmotorhex.yml
+REM verbatim rather than placeholders).
+REM
+REM Usage: kmotor_canary.bat [root] [outdir]
+REM   root   default C:\INST_hlo   (must match the configs' root: key)
+REM   outdir default %TEMP%\kmotor_canary
+REM ---------------------------------------------------------------------------
+
+set "ROOT=%~1"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\kmotor_canary"
+
+REM Guard: refuse an unsafe root (drive/fs anchor, or a root that contains the
+REM code repo) BEFORE anything touches it. safe_root.py is the single choke
+REM point; %ROOT% is only ever used read-only in this script, but the check is
+REM defense in depth against a mis-set root: key. See safe_root.py.
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` is
+REM exempt (it runs in a separate child shell).
+call conda run -n helao python "%~dp0safe_root.py" check "%ROOT%"
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT -- root %ROOT% failed the safety guard; see message above
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+set "LEGACY_JSON=%OUTDIR%\kmotor_openapi.json"
+set "HEX_JSON=%OUTDIR%\kmotorhex_openapi.json"
+
+call :run_one kmotor     "%LEGACY_JSON%" || goto :fail
+call :run_one kmotorhex  "%HEX_JSON%"    || goto :fail
+
+echo.
+echo [canary] diffing openapi surfaces
+REM Persist diff output to a file too, so the result survives the window closing.
+call conda run -n helao python "%~dp0openapi_diff.py" "%LEGACY_JSON%" "%HEX_JSON%" > "%OUTDIR%\openapi_diff.txt" 2>&1
+set "DIFF_RC=!errorlevel!"
+type "%OUTDIR%\openapi_diff.txt"
+popd
+echo.
+if "%DIFF_RC%"=="0" (
+  echo [canary] PASS -- kmotorhex openapi surface matches legacy kmotor> "%OUTDIR%\canary_result.txt"
+) else (
+  echo [canary] DIFFS FOUND rc=%DIFF_RC% -- see openapi_diff.txt> "%OUTDIR%\canary_result.txt"
+)
+type "%OUTDIR%\canary_result.txt"
+echo [canary] artifacts + result saved in: %OUTDIR%
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\canary_result.txt regardless.
+pause
+exit /b %DIFF_RC%
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = output json path
+set "PREFIX=%~1"
+set "OUTJSON=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_CANARY_%PREFIX%"
+
+echo.
+echo [canary] === %PREFIX% ===
+REM NEVER wipe %ROOT%. An openapi diff reads the live server's /openapi.json and
+REM produces no output tree, so no "fresh root" is needed. On a station %ROOT%
+REM (e.g. C:\INST_hlo) holds production RUN data, calibration matrices, and may
+REM contain the code repo itself -- deleting it is catastrophic and unrecoverable
+REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
+REM to locate the pid pickle for kill_group.py.
+
+echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8015 (or its co-located ZMQ RPC sibling 18015); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8015
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8015/18015 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [canary] waiting for KMOTOR port 8015
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8015))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [canary] FAIL %PREFIX% port 8015 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [canary] fetching /openapi.json -> %OUTJSON%
+call conda run -n helao python -c "import urllib.request,sys; open(sys.argv[2],'wb').write(urllib.request.urlopen('http://127.0.0.1:8015/openapi.json',timeout=30).read())" x "%OUTJSON%"
+set "FETCH_RC=!errorlevel!"
+
+echo [canary] killing %PREFIX%
+call :kill_one
+
+if not "%FETCH_RC%"=="0" (
+  echo [canary] FAIL %PREFIX% openapi fetch rc=%FETCH_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the Kinesis driver's shutdown() runs:
+REM KinesisMotor.disconnect() calls kmotor.close() for every configured axis
+REM (releases the pylablib handle on the Thorlabs device). A hard kill skips
+REM this and may leave the device's USB/serial handle reserved for the next
+REM launch -- best-effort (server dies mid-response); then wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8015
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit the canary console.
+REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main canary window.
+REM The match includes " --no-hot-reload" so prefix "kmotor" cannot match "kmotorhex".
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the KMOTOR server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18015) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (kmotor vs kmotorhex) starts while a stale
+REM listener still owns 127.0.0.1:18015, the KMOTOR "Address in use" fallback
+REM fires AND a dispatch_action RPC-first call would reach the STALE binder --
+REM the action is ACK'd but never runs on the live server. Poll both ports
+REM until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8015) or c(18015)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :kmotor_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:kmotor_ports_free
+if not "!RELEASED!"=="1" echo [canary] WARNING %PREFIX% ports 8015/18015 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [canary] ABORTED -- a launch/fetch step failed; see logs in %OUTDIR%
+echo [canary] ABORTED -- see %PREFIX%.launch.log in %OUTDIR%> "%OUTDIR%\canary_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/mfc_canary.bat
+++ b/helao/hexagon/tests/smoke/mfc_canary.bat
@@ -1,0 +1,180 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Windows canary for the mfchex hexagon cut-over: runtime /openapi.json diff.
+REM
+REM Launches the LEGACY mfc group and the HEXAGON mfchex group in turn, dumps
+REM each MFC server's live /openapi.json, and diffs them. An identical
+REM route/schema surface proves the hexagon makeActionApp factory produces a
+REM byte-parity action server for the mfc_server (Alicat mass flow controller)
+REM cut-over target.
+REM
+REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
+REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
+REM sequences to an orchestrator. mfchex is a 2-server group (MFC@8009 +
+REM ACTVIS@5001) with NO orchestrator, so the GM-* scenarios cannot drive it.
+REM The openapi diff is the topology-appropriate parity check (mirrors
+REM galil_canary.bat / gamryhex_canary.bat / spec_canary.bat exactly). See
+REM mfc_diff.bat for the runtime acquire_flowrate golden diff, the
+REM topology-appropriate DATA check.
+REM
+REM Both configs share root C:\INST_hlo and ports 8009/5001, so they MUST run
+REM sequentially (this script does that) -- never launch both at once.
+REM NOTE: mfc.yml's simulation:true is cosmetic (banner color) -- AliCatMFC has
+REM no sim/dummy data path (see golden_capture_mfc.py). BUT unlike gamry/spec,
+REM AliCatMFC.__init__ does NO device I/O and connect() failures are caught, and
+REM dev_mfcs (used to type the endpoints) is built from config alone -- so the
+REM MFC server BOOTS and serves /openapi.json even with NO Alicat attached. A
+REM data-producing action additionally requires the device on COM9 (see
+REM mfc_diff.bat).
+REM
+REM Usage: mfc_canary.bat [root] [outdir]
+REM   root   default C:\INST_hlo   (must match the configs' root: key)
+REM   outdir default %TEMP%\mfc_canary
+REM ---------------------------------------------------------------------------
+
+set "ROOT=%~1"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\mfc_canary"
+
+REM Guard: refuse an unsafe root (drive/fs anchor, or a root that contains the
+REM code repo) BEFORE anything touches it. safe_root.py is the single choke
+REM point; %ROOT% is only ever used read-only in this script, but the check is
+REM defense in depth against a mis-set root: key. See safe_root.py.
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` is
+REM exempt (it runs in a separate child shell).
+call conda run -n helao python "%~dp0safe_root.py" check "%ROOT%"
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT -- root %ROOT% failed the safety guard; see message above
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+set "LEGACY_JSON=%OUTDIR%\mfc_openapi.json"
+set "HEX_JSON=%OUTDIR%\mfchex_openapi.json"
+
+call :run_one mfc     "%LEGACY_JSON%" || goto :fail
+call :run_one mfchex  "%HEX_JSON%"    || goto :fail
+
+echo.
+echo [canary] diffing openapi surfaces
+REM Persist diff output to a file too, so the result survives the window closing.
+call conda run -n helao python "%~dp0openapi_diff.py" "%LEGACY_JSON%" "%HEX_JSON%" > "%OUTDIR%\openapi_diff.txt" 2>&1
+set "DIFF_RC=!errorlevel!"
+type "%OUTDIR%\openapi_diff.txt"
+popd
+echo.
+if "%DIFF_RC%"=="0" (
+  echo [canary] PASS -- mfchex openapi surface matches legacy mfc> "%OUTDIR%\canary_result.txt"
+) else (
+  echo [canary] DIFFS FOUND rc=%DIFF_RC% -- see openapi_diff.txt> "%OUTDIR%\canary_result.txt"
+)
+type "%OUTDIR%\canary_result.txt"
+echo [canary] artifacts + result saved in: %OUTDIR%
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\canary_result.txt regardless.
+pause
+exit /b %DIFF_RC%
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = output json path
+set "PREFIX=%~1"
+set "OUTJSON=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_CANARY_%PREFIX%"
+
+echo.
+echo [canary] === %PREFIX% ===
+REM NEVER wipe %ROOT%. An openapi diff reads the live server's /openapi.json and
+REM produces no output tree, so no "fresh root" is needed. On a station %ROOT%
+REM (e.g. C:\INST_hlo) holds production RUN data, calibration, and may contain
+REM the code repo itself -- deleting it is catastrophic and unrecoverable (rmdir
+REM /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only to
+REM locate the pid pickle for kill_group.py.
+
+echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [canary] waiting for MFC port 8009
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8009))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [canary] FAIL %PREFIX% port 8009 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [canary] fetching /openapi.json -> %OUTJSON%
+call conda run -n helao python -c "import urllib.request,sys; open(sys.argv[2],'wb').write(urllib.request.urlopen('http://127.0.0.1:8009/openapi.json',timeout=30).read())" x "%OUTJSON%"
+set "FETCH_RC=!errorlevel!"
+
+echo [canary] killing %PREFIX%
+call :kill_one
+
+if not "%FETCH_RC%"=="0" (
+  echo [canary] FAIL %PREFIX% openapi fetch rc=%FETCH_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the AliCatMFC driver's async_shutdown() runs:
+REM it stops polling, closes all valves (safe state -- no gas flow), then closes
+REM every serial connection, releasing the COM port for the next launch. A hard
+REM kill skips this and may leave the COM port claimed / a valve latched --
+REM best-effort (server dies mid-response); then wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8009
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit the canary console.
+REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main canary window.
+REM The match includes " --no-hot-reload" so prefix "mfc" cannot match "mfchex".
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the MFC server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18009) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (mfc vs mfchex) starts while a stale listener
+REM still owns 127.0.0.1:18009, the MFC "Address in use" fallback fires AND a
+REM dispatch_action RPC-first call would reach the STALE binder -- the action is
+REM ACK'd but never runs on the live server, yielding an empty capture
+REM (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8009) or c(18009)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :mfc_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:mfc_ports_free
+if not "!RELEASED!"=="1" echo [canary] WARNING %PREFIX% ports 8009/18009 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [canary] ABORTED -- a launch/fetch step failed; see logs in %OUTDIR%
+echo [canary] ABORTED -- see %PREFIX%.launch.log in %OUTDIR%> "%OUTDIR%\canary_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/mfc_canary.bat
+++ b/helao/hexagon/tests/smoke/mfc_canary.bat
@@ -103,6 +103,18 @@ REM /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only to
 REM locate the pid pickle for kill_group.py.
 
 echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8009 (or its co-located ZMQ RPC sibling 18009); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8009
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8009/18009 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [canary] waiting for MFC port 8009

--- a/helao/hexagon/tests/smoke/mfc_diff.bat
+++ b/helao/hexagon/tests/smoke/mfc_diff.bat
@@ -1,0 +1,224 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Runtime golden-diff driver for the mfc_server hexagon canary (P3a
+REM special-split).
+REM
+REM *** DRIVES THE REAL ALICAT MFC (TELEMETRY READ, NON-PERTURBING). ***
+REM The Alicat mass flow controller must be ATTACHED on COM9 (Windows, pyserial)
+REM before running this script. acquire_flowrate is dispatched with
+REM flowrate_sccm=None, so the MFC valve is NEVER opened and NO flow is commanded
+REM -- it only READS live telemetry and ends by holding the valve CLOSED (safe).
+REM AliCatMFC.connect() still needs the live device to buffer any data; see
+REM helao\hexagon\tests\smoke\golden_capture_mfc.py's docstring.
+REM
+REM Launches mfcgold (legacy) then mfcgoldhex (hexagon), each against a FRESH
+REM throwaway root, drives one POST /MFC/acquire_flowrate per launch via
+REM golden_capture_mfc.py, snapshots the resulting RUNS tree, and diffs the two
+REM captures with harness.parity. Mirrors the conventions already proven in
+REM galil_diff.bat / golden_diff.bat / spec_diff.bat (call conda / ping sleeps /
+REM cmdline-scoped Stop-Process / persisted results + pause) -- see those scripts
+REM for why harness.capture/parity_run.sh cannot drive this orch-less, db-less
+REM 2-server topology.
+REM
+REM Usage: mfc_diff.bat [caproot] [outdir]
+REM   caproot default C:\INST_hlo_golden -- a DEDICATED THROWAWAY capture root,
+REM            fully wiped before EACH capture (see :wipe_caproot). NEVER point
+REM            this at C:\INST_hlo or any root holding real data.
+REM   outdir  default %TEMP%\mfc_golden -- capture sets + parity report land
+REM            here (outdir\mfc, outdir\mfchex, outdir\parity-report.json,
+REM            outdir\golden_result.txt).
+REM ---------------------------------------------------------------------------
+
+set "CAPROOT=%~1"
+if "%CAPROOT%"=="" set "CAPROOT=C:\INST_hlo_golden"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\mfc_golden"
+set "PROD_ROOT=C:\INST_hlo"
+
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates
+REM when conda.bat returns (silent exit). Only the conda inside
+REM `start ... cmd /c` (in :run_one below) is exempt -- it runs in a separate
+REM child shell.
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard; see message above
+  exit /b 2
+)
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- caproot equals production root %PROD_ROOT%; refusing to run
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+
+call :wipe_caproot || goto :fail
+call :run_one mfcgold    "%OUTDIR%\mfc"    || goto :fail
+call :wipe_caproot || goto :fail
+call :run_one mfcgoldhex "%OUTDIR%\mfchex" || goto :fail
+
+echo.
+echo [golden] running parity diff
+call conda run -n helao python -m harness.parity --golden "%OUTDIR%\mfc" --candidate "%OUTDIR%\mfchex" --report "%OUTDIR%\parity-report.json" > "%OUTDIR%\parity_stdout.txt" 2>&1
+set "PARITY_RC=!errorlevel!"
+type "%OUTDIR%\parity_stdout.txt"
+
+echo.
+echo [golden] full parity report (also saved to %OUTDIR%\parity-report.json):
+type "%OUTDIR%\parity-report.json"
+
+popd
+echo.
+REM The acquire_flowrate .hlo body columns (epoch_s / acquire_time / pressure /
+REM temperature / volumetric_flow / mass_flow / setpoint / total flow) are masked
+REM via the capture manifest's masked_hlo_columns, and action_params.total_scc
+REM (integrated live flow) via masked_meta_keys (see golden_capture_mfc.py), since
+REM they are live device readings, not deterministic sim data -- so parity rc=0 is
+REM a genuine PASS and rc!=0 means a REAL hexagon-vs-legacy diff. The categorical
+REM columns gas / control_point are config-deterministic and compared unmasked.
+REM Row counts are poll-paced and compared within hlo_row_count_tolerance. The
+REM full report is printed and persisted above either way for inspection.
+if "%PARITY_RC%"=="0" (
+  (
+    echo [golden] PASS -- mfcgoldhex RUNS-tree matches legacy mfcgold ^(acquire_flowrate, masked^)
+    echo [golden] artifacts: %OUTDIR%\mfc, %OUTDIR%\mfchex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+) else (
+  (
+    echo [golden] DIFFS FOUND rc=%PARITY_RC% -- REAL regression, inspect the report
+    echo [golden] open %OUTDIR%\parity-report.json: tree_diffs / file_diffs list
+    echo [golden]   every differing member and key. The acquire_flowrate .hlo data
+    echo [golden]   columns + total_scc are masked, so anything shown here is a
+    echo [golden]   genuine hexagon-vs-legacy difference.
+    echo [golden] artifacts: %OUTDIR%\mfc, %OUTDIR%\mfchex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+)
+type "%OUTDIR%\golden_result.txt"
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\golden_result.txt regardless.
+pause
+exit /b %PARITY_RC%
+
+REM ---------------------------------------------------------------------------
+:wipe_caproot
+REM Full-wipe the throwaway capture root before each capture -- required
+REM because golden_capture_mfc.py's assert_fresh() refuses a root that already
+REM contains run artifacts. This rmdir is safe ONLY because %CAPROOT% just
+REM passed safe_root.py's check (repo not underneath it, not a drive/fs anchor)
+REM AND the equality guard below proves it is not production C:\INST_hlo -- it
+REM must NEVER run against a root that could hold real station data (run output,
+REM DATABASE, USER_CONFIG).
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- refusing to wipe production root %PROD_ROOT%
+  exit /b 2
+)
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard before wipe
+  exit /b 2
+)
+if exist "%CAPROOT%" (
+  echo [golden] wiping throwaway caproot %CAPROOT%
+  rmdir /s /q "%CAPROOT%"
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = capture out dir
+set "PREFIX=%~1"
+set "CAPOUT=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
+
+echo.
+echo [golden] === %PREFIX% ===
+echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [golden] waiting for MFC port 8009
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8009))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [golden] FAIL %PREFIX% port 8009 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [golden] capturing acquire_flowrate -^> %CAPOUT%
+call conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_mfc --config-prefix %PREFIX% --root "%CAPROOT%" --out "%CAPOUT%" > "%OUTDIR%\%PREFIX%.capture.log" 2>&1
+set "CAPTURE_RC=!errorlevel!"
+type "%OUTDIR%\%PREFIX%.capture.log"
+
+echo [golden] killing %PREFIX%
+call :kill_one
+REM Let the Alicat COM port release before the next launch reopens it -- killing
+REM the python server does not instantly guarantee pyserial released COM9. ~5s
+REM margin between our two sequential captures.
+ping -n 6 -w 1000 127.0.0.1 >nul
+
+if not "%CAPTURE_RC%"=="0" (
+  echo [golden] FAIL %PREFIX% capture rc=%CAPTURE_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the AliCatMFC driver's async_shutdown() runs:
+REM it stops polling, closes all valves (safe state -- no gas flow), then closes
+REM every serial connection, releasing the COM port for the next launch. A hard
+REM kill skips this and may leave COM9 claimed / a valve latched.
+REM Best-effort (server dies mid-response); then wait for release.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8009
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit this console.
+REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can
+REM cascade through a shared conhost.exe and close the main window.
+REM The match includes " --no-hot-reload" so "mfcgold" cannot match
+REM "mfcgoldhex" (no space follows "mfcgold" in that cmdline).
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the MFC server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18009) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (mfcgold vs mfcgoldhex) -- or a preceding
+REM mfc_canary run on the same ports -- leaves a stale listener owning
+REM 127.0.0.1:18009, a dispatch_action RPC-first call reaches the STALE binder:
+REM the action is ACK'd but never runs on the live server, yielding an empty
+REM capture (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8009) or c(18009)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :mfc_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:mfc_ports_free
+if not "!RELEASED!"=="1" echo [golden] WARNING %PREFIX% ports 8009/18009 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [golden] ABORTED -- a launch/capture step failed; see logs in %OUTDIR%
+echo [golden] ABORTED -- see %OUTDIR%\*.launch.log / *.capture.log> "%OUTDIR%\golden_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/mfc_diff.bat
+++ b/helao/hexagon/tests/smoke/mfc_diff.bat
@@ -141,6 +141,18 @@ set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
 echo.
 echo [golden] === %PREFIX% ===
 echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8009 (or its co-located ZMQ RPC sibling 18009); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8009
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT %PREFIX% -- ports 8009/18009 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [golden] waiting for MFC port 8009

--- a/helao/hexagon/tests/smoke/ni_canary.bat
+++ b/helao/hexagon/tests/smoke/ni_canary.bat
@@ -1,0 +1,180 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Windows canary for the nihex hexagon cut-over: runtime /openapi.json diff.
+REM
+REM Launches the LEGACY ni group and the HEXAGON nihex group in turn, dumps each
+REM NI server's live /openapi.json, and diffs them. An identical route/schema
+REM surface proves the hexagon makeActionApp factory produces a byte-parity
+REM action server for the nidaqmx_server (NI-DAQmx cDAQ) cut-over target.
+REM
+REM OPENAPI-ONLY canary (no runtime golden diff). ccsi1.yml's NI block declares
+REM NO dev_monitor (nor dev_heat / dev_cellcurrent+dev_cellvoltage), so the only
+REM SAFE non-perturbing read action (acquire_monitors, gated on `if dev_monitor:`)
+REM is not registered under the verbatim params. Every action route ni.yml DOES
+REM expose (pump/gasvalve/liquidvalve/multivalve/stop) drives real hardware and
+REM must never be dispatched as a canary -- so there is no ni_diff.bat runtime
+REM counterpart. The openapi diff is the topology- AND safety-appropriate parity
+REM check (mirrors galil_canary.bat / gamryhex_canary.bat / spec_canary.bat).
+REM
+REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
+REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
+REM sequences to an orchestrator. nihex is a 2-server group (NI@8006 +
+REM ACTVIS@5001) with NO orchestrator, so the GM-* scenarios cannot drive it.
+REM
+REM Both configs share root C:\INST_hlo and ports 8006/5001, so they MUST run
+REM sequentially (this script does that) -- never launch both at once.
+REM NOTE: ni.yml's simulation:true is cosmetic (banner color) -- NI-DAQmx has no
+REM sim/dummy data path. cNIMAX.connect() opens NI-DAQmx tasks against the cDAQ
+REM chassis at startup; the chassis should be attached so the server boots and
+REM serves /openapi.json.
+REM
+REM Usage: ni_canary.bat [root] [outdir]
+REM   root   default C:\INST_hlo   (must match the configs' root: key)
+REM   outdir default %TEMP%\ni_canary
+REM ---------------------------------------------------------------------------
+
+set "ROOT=%~1"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\ni_canary"
+
+REM Guard: refuse an unsafe root (drive/fs anchor, or a root that contains the
+REM code repo) BEFORE anything touches it. safe_root.py is the single choke
+REM point; %ROOT% is only ever used read-only in this script, but the check is
+REM defense in depth against a mis-set root: key. See safe_root.py.
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` is
+REM exempt (it runs in a separate child shell).
+call conda run -n helao python "%~dp0safe_root.py" check "%ROOT%"
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT -- root %ROOT% failed the safety guard; see message above
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+set "LEGACY_JSON=%OUTDIR%\ni_openapi.json"
+set "HEX_JSON=%OUTDIR%\nihex_openapi.json"
+
+call :run_one ni     "%LEGACY_JSON%" || goto :fail
+call :run_one nihex  "%HEX_JSON%"    || goto :fail
+
+echo.
+echo [canary] diffing openapi surfaces
+REM Persist diff output to a file too, so the result survives the window closing.
+call conda run -n helao python "%~dp0openapi_diff.py" "%LEGACY_JSON%" "%HEX_JSON%" > "%OUTDIR%\openapi_diff.txt" 2>&1
+set "DIFF_RC=!errorlevel!"
+type "%OUTDIR%\openapi_diff.txt"
+popd
+echo.
+if "%DIFF_RC%"=="0" (
+  echo [canary] PASS -- nihex openapi surface matches legacy ni> "%OUTDIR%\canary_result.txt"
+) else (
+  echo [canary] DIFFS FOUND rc=%DIFF_RC% -- see openapi_diff.txt> "%OUTDIR%\canary_result.txt"
+)
+type "%OUTDIR%\canary_result.txt"
+echo [canary] artifacts + result saved in: %OUTDIR%
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\canary_result.txt regardless.
+pause
+exit /b %DIFF_RC%
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = output json path
+set "PREFIX=%~1"
+set "OUTJSON=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_CANARY_%PREFIX%"
+
+echo.
+echo [canary] === %PREFIX% ===
+REM NEVER wipe %ROOT%. An openapi diff reads the live server's /openapi.json and
+REM produces no output tree, so no "fresh root" is needed. On a station %ROOT%
+REM (e.g. C:\INST_hlo) holds production RUN data, calibration matrices, and may
+REM contain the code repo itself -- deleting it is catastrophic and unrecoverable
+REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
+REM to locate the pid pickle for kill_group.py.
+
+echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [canary] waiting for NI port 8006
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8006))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [canary] FAIL %PREFIX% port 8006 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [canary] fetching /openapi.json -> %OUTJSON%
+call conda run -n helao python -c "import urllib.request,sys; open(sys.argv[2],'wb').write(urllib.request.urlopen('http://127.0.0.1:8006/openapi.json',timeout=30).read())" x "%OUTJSON%"
+set "FETCH_RC=!errorlevel!"
+
+echo [canary] killing %PREFIX%
+call :kill_one
+
+if not "%FETCH_RC%"=="0" (
+  echo [canary] FAIL %PREFIX% openapi fetch rc=%FETCH_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the NI driver's shutdown() runs:
+REM cNIMAX.shutdown()/disconnect() closes the NI-DAQmx tasks it opened on the
+REM cDAQ chassis. A hard kill skips this and may leave a task reserved on a
+REM channel for the next launch -- best-effort (server dies mid-response); then
+REM wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8006
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit the canary console.
+REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main canary window.
+REM The match includes " --no-hot-reload" so prefix "ni" cannot match "nihex".
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the NI server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18006) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (ni vs nihex) starts while a stale listener
+REM still owns 127.0.0.1:18006, the NI "Address in use" fallback fires AND a
+REM dispatch_action RPC-first call would reach the STALE binder -- the action is
+REM ACK'd but never runs on the live server. Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8006) or c(18006)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :ni_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:ni_ports_free
+if not "!RELEASED!"=="1" echo [canary] WARNING %PREFIX% ports 8006/18006 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [canary] ABORTED -- a launch/fetch step failed; see logs in %OUTDIR%
+echo [canary] ABORTED -- see %PREFIX%.launch.log in %OUTDIR%> "%OUTDIR%\canary_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/ni_canary.bat
+++ b/helao/hexagon/tests/smoke/ni_canary.bat
@@ -104,6 +104,18 @@ REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
 REM to locate the pid pickle for kill_group.py.
 
 echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8006 (or its co-located ZMQ RPC sibling 18006); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8006
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8006/18006 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [canary] waiting for NI port 8006

--- a/helao/hexagon/tests/smoke/powersupply_canary.bat
+++ b/helao/hexagon/tests/smoke/powersupply_canary.bat
@@ -1,0 +1,200 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Windows canary for the powersupplyhex hexagon cut-over: runtime
+REM /openapi.json diff.
+REM
+REM Launches the LEGACY powersupply group and the HEXAGON powersupplyhex
+REM group in turn, dumps each POWER_SUPPLY server's live /openapi.json, and
+REM diffs them. An identical route/schema surface proves the hexagon
+REM makeActionApp factory produces a byte-parity action server for the
+REM power_supply_server (generic VISA bench supply) cut-over target.
+REM
+REM OPENAPI-ONLY canary (no runtime golden diff). Every action route
+REM power_supply_server.py registers -- apply_voltage, square_wave,
+REM constant_current_square_wave -- runs an executor whose _pre_exec calls
+REM driver.connect() then driver.set_output(True): EVERY action energizes the
+REM supply output. get_voltage_async/get_current_async are driver-level
+REM polling helpers used internally by these executors, NOT standalone action
+REM endpoints -- there is no safe, non-perturbing read action to dispatch as a
+REM canary, and no powersupply_diff.bat runtime counterpart (mirrors
+REM ni_canary.bat / kmotor_canary.bat exactly).
+REM
+REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
+REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
+REM sequences to an orchestrator. powersupplyhex is a 2-server group
+REM (POWER_SUPPLY@8002 + ACTVIS@5001) with NO orchestrator, so the GM-*
+REM scenarios cannot drive it.
+REM
+REM Both configs share root C:\INST_hlo and ports 8002/5001, so they MUST run
+REM sequentially (this script does that) -- never launch both at once.
+REM NOTE: powersupply.yml's simulation:true is cosmetic (banner color) --
+REM PowerSupplyDriver has no sim/dummy data path. connect() is only called
+REM inside each executor's _pre_exec (NOT at route-registration/server-startup
+REM time), so an unreachable resource_name does NOT block this openapi-surface
+REM canary from passing -- only a dispatched action would fail.
+REM
+REM Usage: powersupply_canary.bat [root] [outdir]
+REM   root   default C:\INST_hlo   (must match the configs' root: key)
+REM   outdir default %TEMP%\powersupply_canary
+REM ---------------------------------------------------------------------------
+
+set "ROOT=%~1"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\powersupply_canary"
+
+REM Guard: refuse an unsafe root (drive/fs anchor, or a root that contains the
+REM code repo) BEFORE anything touches it. safe_root.py is the single choke
+REM point; %ROOT% is only ever used read-only in this script, but the check is
+REM defense in depth against a mis-set root: key. See safe_root.py.
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` is
+REM exempt (it runs in a separate child shell).
+call conda run -n helao python "%~dp0safe_root.py" check "%ROOT%"
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT -- root %ROOT% failed the safety guard; see message above
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+set "LEGACY_JSON=%OUTDIR%\powersupply_openapi.json"
+set "HEX_JSON=%OUTDIR%\powersupplyhex_openapi.json"
+
+call :run_one powersupply     "%LEGACY_JSON%" || goto :fail
+call :run_one powersupplyhex  "%HEX_JSON%"    || goto :fail
+
+echo.
+echo [canary] diffing openapi surfaces
+REM Persist diff output to a file too, so the result survives the window closing.
+call conda run -n helao python "%~dp0openapi_diff.py" "%LEGACY_JSON%" "%HEX_JSON%" > "%OUTDIR%\openapi_diff.txt" 2>&1
+set "DIFF_RC=!errorlevel!"
+type "%OUTDIR%\openapi_diff.txt"
+popd
+echo.
+if "%DIFF_RC%"=="0" (
+  echo [canary] PASS -- powersupplyhex openapi surface matches legacy powersupply> "%OUTDIR%\canary_result.txt"
+) else (
+  echo [canary] DIFFS FOUND rc=%DIFF_RC% -- see openapi_diff.txt> "%OUTDIR%\canary_result.txt"
+)
+type "%OUTDIR%\canary_result.txt"
+echo [canary] artifacts + result saved in: %OUTDIR%
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\canary_result.txt regardless.
+pause
+exit /b %DIFF_RC%
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = output json path
+set "PREFIX=%~1"
+set "OUTJSON=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_CANARY_%PREFIX%"
+
+echo.
+echo [canary] === %PREFIX% ===
+REM NEVER wipe %ROOT%. An openapi diff reads the live server's /openapi.json and
+REM produces no output tree, so no "fresh root" is needed. On a station %ROOT%
+REM (e.g. C:\INST_hlo) holds production RUN data, calibration matrices, and may
+REM contain the code repo itself -- deleting it is catastrophic and unrecoverable
+REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
+REM to locate the pid pickle for kill_group.py.
+
+echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8002 (or its co-located ZMQ RPC sibling 18002); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8002
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8002/18002 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [canary] waiting for POWER_SUPPLY port 8002
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8002))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [canary] FAIL %PREFIX% port 8002 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [canary] fetching /openapi.json -> %OUTJSON%
+call conda run -n helao python -c "import urllib.request,sys; open(sys.argv[2],'wb').write(urllib.request.urlopen('http://127.0.0.1:8002/openapi.json',timeout=30).read())" x "%OUTJSON%"
+set "FETCH_RC=!errorlevel!"
+
+echo [canary] killing %PREFIX%
+call :kill_one
+
+if not "%FETCH_RC%"=="0" (
+  echo [canary] FAIL %PREFIX% openapi fetch rc=%FETCH_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the power-supply driver's disconnect runs:
+REM the `/stop_private` handler (power_supply_server.py) calls
+REM app.driver.disconnect(), which closes the pyvisa instrument + resource
+REM manager. A hard kill skips this and may leave the VISA resource claimed
+REM for the next launch -- best-effort (server dies mid-response); then wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8002
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit the canary console.
+REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main canary window.
+REM The match includes " --no-hot-reload" so prefix "powersupply" cannot match
+REM "powersupplyhex".
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the POWER_SUPPLY server's HTTP + co-located ZMQ RPC ports (RPC
+REM = HTTP+10000 = 18002) to actually RELEASE before returning. The RPC
+REM listener is a thread inside the server process and lives as long as the
+REM process does; if the next sequential launch (powersupply vs
+REM powersupplyhex) starts while a stale listener still owns
+REM 127.0.0.1:18002, the POWER_SUPPLY "Address in use" fallback fires AND a
+REM dispatch_action RPC-first call would reach the STALE binder -- the action
+REM is ACK'd but never runs on the live server. Poll both ports until free
+REM (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8002) or c(18002)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :ps_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:ps_ports_free
+if not "!RELEASED!"=="1" echo [canary] WARNING %PREFIX% ports 8002/18002 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [canary] ABORTED -- a launch/fetch step failed; see logs in %OUTDIR%
+echo [canary] ABORTED -- see %PREFIX%.launch.log in %OUTDIR%> "%OUTDIR%\canary_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/spec_canary.bat
+++ b/helao/hexagon/tests/smoke/spec_canary.bat
@@ -101,6 +101,18 @@ REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
 REM to locate the pid pickle for kill_group.py.
 
 echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8011 (or its co-located ZMQ RPC sibling 18011); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8011
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8011/18011 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [canary] waiting for SPEC port 8011

--- a/helao/hexagon/tests/smoke/spec_diff.bat
+++ b/helao/hexagon/tests/smoke/spec_diff.bat
@@ -138,6 +138,18 @@ set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
 echo.
 echo [golden] === %PREFIX% ===
 echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8011 (or its co-located ZMQ RPC sibling 18011); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8011
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT %PREFIX% -- ports 8011/18011 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [golden] waiting for SPEC port 8011

--- a/helao/hexagon/tests/smoke/syringe_canary.bat
+++ b/helao/hexagon/tests/smoke/syringe_canary.bat
@@ -104,6 +104,18 @@ REM the Recycle Bin). %ROOT% is used read-only here, only to locate the pid
 REM pickle for kill_group.py.
 
 echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8013 (or its co-located ZMQ RPC sibling 18013); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8013
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8013/18013 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [canary] waiting for WORKSYRINGE port 8013

--- a/helao/hexagon/tests/smoke/syringe_canary.bat
+++ b/helao/hexagon/tests/smoke/syringe_canary.bat
@@ -1,0 +1,182 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Windows canary for the syringehex hexagon cut-over: runtime /openapi.json
+REM diff.
+REM
+REM Launches the LEGACY syringe group and the HEXAGON syringehex group in turn,
+REM dumps each WORKSYRINGE server's live /openapi.json, and diffs them. An
+REM identical route/schema surface proves the hexagon makeActionApp factory
+REM produces a byte-parity action server for the syringe_server (KD Scientific
+REM Legato syringe pump) cut-over target.
+REM
+REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
+REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
+REM sequences to an orchestrator. syringehex is a 2-server group
+REM (WORKSYRINGE@8013 + ACTVIS@5001) with NO orchestrator, so the GM-* scenarios
+REM cannot drive it. The openapi diff is the topology-appropriate parity check
+REM (mirrors spec_canary.bat / galil_canary.bat / gamryhex_canary.bat exactly).
+REM See syringe_diff.bat for the runtime get_present_volume golden diff, the
+REM topology-appropriate DATA check.
+REM
+REM Both configs share root C:\INST_hlo and ports 8013/5001, so they MUST run
+REM sequentially (this script does that) -- never launch both at once.
+REM NOTE: syringe.yml's simulation:true is cosmetic (banner color) -- KDS100 has
+REM no sim/dummy driver swap. KDS100.connect() opens the pyserial COM5 port at
+REM startup, but it CATCHES a connect failure (no raise), so the server boots
+REM and serves /openapi.json even with the pump detached (the openapi surface is
+REM built from the registered routes, independent of the serial connection). A
+REM data-producing action additionally does NOT require the pump (see
+REM syringe_diff.bat) because get_present_volume reads a software counter.
+REM
+REM Usage: syringe_canary.bat [root] [outdir]
+REM   root   default C:\INST_hlo   (must match the configs' root: key)
+REM   outdir default %TEMP%\syringe_canary
+REM ---------------------------------------------------------------------------
+
+set "ROOT=%~1"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\syringe_canary"
+
+REM Guard: refuse an unsafe root (drive/fs anchor, or a root that contains the
+REM code repo) BEFORE anything touches it. safe_root.py is the single choke
+REM point; %ROOT% is only ever used read-only in this script, but the check is
+REM defense in depth against a mis-set root: key. See safe_root.py.
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` is
+REM exempt (it runs in a separate child shell).
+call conda run -n helao python "%~dp0safe_root.py" check "%ROOT%"
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT -- root %ROOT% failed the safety guard; see message above
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+set "LEGACY_JSON=%OUTDIR%\syringe_openapi.json"
+set "HEX_JSON=%OUTDIR%\syringehex_openapi.json"
+
+call :run_one syringe     "%LEGACY_JSON%" || goto :fail
+call :run_one syringehex  "%HEX_JSON%"    || goto :fail
+
+echo.
+echo [canary] diffing openapi surfaces
+REM Persist diff output to a file too, so the result survives the window closing.
+call conda run -n helao python "%~dp0openapi_diff.py" "%LEGACY_JSON%" "%HEX_JSON%" > "%OUTDIR%\openapi_diff.txt" 2>&1
+set "DIFF_RC=!errorlevel!"
+type "%OUTDIR%\openapi_diff.txt"
+popd
+echo.
+if "%DIFF_RC%"=="0" (
+  echo [canary] PASS -- syringehex openapi surface matches legacy syringe> "%OUTDIR%\canary_result.txt"
+) else (
+  echo [canary] DIFFS FOUND rc=%DIFF_RC% -- see openapi_diff.txt> "%OUTDIR%\canary_result.txt"
+)
+type "%OUTDIR%\canary_result.txt"
+echo [canary] artifacts + result saved in: %OUTDIR%
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\canary_result.txt regardless.
+pause
+exit /b %DIFF_RC%
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = output json path
+set "PREFIX=%~1"
+set "OUTJSON=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_CANARY_%PREFIX%"
+
+echo.
+echo [canary] === %PREFIX% ===
+REM NEVER wipe %ROOT%. An openapi diff reads the live server's /openapi.json and
+REM produces no output tree, so no "fresh root" is needed. On a station %ROOT%
+REM (e.g. C:\INST_hlo) holds production RUN data and may contain the code repo
+REM itself -- deleting it is catastrophic and unrecoverable (rmdir /s /q bypasses
+REM the Recycle Bin). %ROOT% is used read-only here, only to locate the pid
+REM pickle for kill_group.py.
+
+echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [canary] waiting for WORKSYRINGE port 8013
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8013))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [canary] FAIL %PREFIX% port 8013 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [canary] fetching /openapi.json -> %OUTJSON%
+call conda run -n helao python -c "import urllib.request,sys; open(sys.argv[2],'wb').write(urllib.request.urlopen('http://127.0.0.1:8013/openapi.json',timeout=30).read())" x "%OUTJSON%"
+set "FETCH_RC=!errorlevel!"
+
+echo [canary] killing %PREFIX%
+call :kill_one
+
+if not "%FETCH_RC%"=="0" (
+  echo [canary] FAIL %PREFIX% openapi fetch rc=%FETCH_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the KDS100 driver's async_shutdown() runs:
+REM async_shutdown() returns the pump to a safe idle state and closes the
+REM pyserial COM5 handle. A hard kill skips this and may leave the serial port
+REM claimed for the next launch -- best-effort (server dies mid-response); then
+REM wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8013
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit the canary console.
+REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main canary window.
+REM The match includes " --no-hot-reload" so prefix "syringe" cannot match
+REM "syringehex" (no space follows "syringe" in that cmdline).
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the WORKSYRINGE server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18013) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (syringe vs syringehex) starts while a stale
+REM listener still owns 127.0.0.1:18013, the WORKSYRINGE "Address in use"
+REM fallback fires AND a dispatch_action RPC-first call would reach the STALE
+REM binder -- the action is ACK'd but never runs on the live server, yielding an
+REM empty capture (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8013) or c(18013)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :syringe_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:syringe_ports_free
+if not "!RELEASED!"=="1" echo [canary] WARNING %PREFIX% ports 8013/18013 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [canary] ABORTED -- a launch/fetch step failed; see logs in %OUTDIR%
+echo [canary] ABORTED -- see %PREFIX%.launch.log in %OUTDIR%> "%OUTDIR%\canary_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/syringe_diff.bat
+++ b/helao/hexagon/tests/smoke/syringe_diff.bat
@@ -139,6 +139,18 @@ set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
 echo.
 echo [golden] === %PREFIX% ===
 echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8013 (or its co-located ZMQ RPC sibling 18013); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8013
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT %PREFIX% -- ports 8013/18013 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
 start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
 
 echo [golden] waiting for WORKSYRINGE port 8013

--- a/helao/hexagon/tests/smoke/syringe_diff.bat
+++ b/helao/hexagon/tests/smoke/syringe_diff.bat
@@ -1,0 +1,222 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Runtime golden-diff driver for the syringe_server hexagon canary (P3a
+REM special-split).
+REM
+REM *** READS A SOFTWARE VOLUME COUNTER -- NON-PERTURBING, HARDWARE-INDEPENDENT. ***
+REM get_present_volume reads the KDS100 driver's software-tracked
+REM present_volume_ul attribute (0.0 on a fresh launch) -- it drives NOTHING
+REM (no infuse/withdraw, the plunger does not move) and does NOT query the pump
+REM over the wire, so this capture is deterministic and produces valid data even
+REM with the KD Scientific Legato pump DETACHED. See
+REM helao\hexagon\tests\smoke\golden_capture_syringe.py's docstring.
+REM
+REM Launches syringegold (legacy) then syringegoldhex (hexagon), each against a
+REM FRESH throwaway root, drives one POST /WORKSYRINGE/get_present_volume per
+REM launch via golden_capture_syringe.py, snapshots the resulting RUNS tree, and
+REM diffs the two captures with harness.parity. Mirrors the conventions proven
+REM in spec_diff.bat / galil_diff.bat / golden_diff.bat (call conda / ping sleeps
+REM / cmdline-scoped Stop-Process / persisted results + pause) -- see those
+REM scripts for why harness.capture/parity_run.sh cannot drive this orch-less,
+REM db-less 2-server topology.
+REM
+REM Usage: syringe_diff.bat [caproot] [outdir]
+REM   caproot default C:\INST_hlo_golden -- a DEDICATED THROWAWAY capture root,
+REM            fully wiped before EACH capture (see :wipe_caproot). NEVER point
+REM            this at C:\INST_hlo or any root holding real data.
+REM   outdir  default %TEMP%\syringe_golden -- capture sets + parity report land
+REM            here (outdir\syringe, outdir\syringehex, outdir\parity-report.json,
+REM            outdir\golden_result.txt).
+REM ---------------------------------------------------------------------------
+
+set "CAPROOT=%~1"
+if "%CAPROOT%"=="" set "CAPROOT=C:\INST_hlo_golden"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\syringe_golden"
+set "PROD_ROOT=C:\INST_hlo"
+
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates
+REM when conda.bat returns (silent exit). Only the conda inside
+REM `start ... cmd /c` (in :run_one below) is exempt -- it runs in a separate
+REM child shell.
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard; see message above
+  exit /b 2
+)
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- caproot equals production root %PROD_ROOT%; refusing to run
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+
+call :wipe_caproot || goto :fail
+call :run_one syringegold    "%OUTDIR%\syringe"    || goto :fail
+call :wipe_caproot || goto :fail
+call :run_one syringegoldhex "%OUTDIR%\syringehex" || goto :fail
+
+echo.
+echo [golden] running parity diff
+call conda run -n helao python -m harness.parity --golden "%OUTDIR%\syringe" --candidate "%OUTDIR%\syringehex" --report "%OUTDIR%\parity-report.json" > "%OUTDIR%\parity_stdout.txt" 2>&1
+set "PARITY_RC=!errorlevel!"
+type "%OUTDIR%\parity_stdout.txt"
+
+echo.
+echo [golden] full parity report (also saved to %OUTDIR%\parity-report.json):
+type "%OUTDIR%\parity-report.json"
+
+popd
+echo.
+REM get_present_volume writes a deterministic present_volume_ul (0.0 on a fresh
+REM idle pump) into both the -act.yml action_params (_present_volume_ul) and a
+REM single .hlo row (present_volume_ul / error_code). NOTHING is masked (see
+REM golden_capture_syringe.py) because those values are config-deterministic, NOT
+REM live device readings -- so parity rc=0 is a genuine PASS and ANY diff shown
+REM is a REAL hexagon-vs-legacy difference. The full report is printed and
+REM persisted above either way for inspection.
+if "%PARITY_RC%"=="0" (
+  (
+    echo [golden] PASS -- syringegoldhex RUNS-tree matches legacy syringegold ^(get_present_volume, unmasked^)
+    echo [golden] artifacts: %OUTDIR%\syringe, %OUTDIR%\syringehex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+) else (
+  (
+    echo [golden] DIFFS FOUND rc=%PARITY_RC% -- REAL regression, inspect the report
+    echo [golden] open %OUTDIR%\parity-report.json: tree_diffs / file_diffs list
+    echo [golden]   every differing member and key. The get_present_volume values
+    echo [golden]   are UNMASKED and deterministic, so anything shown here is a
+    echo [golden]   genuine hexagon-vs-legacy difference.
+    echo [golden] artifacts: %OUTDIR%\syringe, %OUTDIR%\syringehex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+)
+type "%OUTDIR%\golden_result.txt"
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\golden_result.txt regardless.
+pause
+exit /b %PARITY_RC%
+
+REM ---------------------------------------------------------------------------
+:wipe_caproot
+REM Full-wipe the throwaway capture root before each capture -- required
+REM because golden_capture_syringe.py's assert_fresh() refuses a root that
+REM already contains run artifacts. This rmdir is safe ONLY because %CAPROOT%
+REM just passed safe_root.py's check (repo not underneath it, not a drive/fs
+REM anchor) AND the equality guard below proves it is not production
+REM C:\INST_hlo -- it must NEVER run against a root that could hold real station
+REM data (run output, DATABASE, USER_CONFIG).
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- refusing to wipe production root %PROD_ROOT%
+  exit /b 2
+)
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard before wipe
+  exit /b 2
+)
+if exist "%CAPROOT%" (
+  echo [golden] wiping throwaway caproot %CAPROOT%
+  rmdir /s /q "%CAPROOT%"
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = capture out dir
+set "PREFIX=%~1"
+set "CAPOUT=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
+
+echo.
+echo [golden] === %PREFIX% ===
+echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [golden] waiting for WORKSYRINGE port 8013
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8013))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [golden] FAIL %PREFIX% port 8013 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [golden] capturing get_present_volume -^> %CAPOUT%
+call conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_syringe --config-prefix %PREFIX% --root "%CAPROOT%" --out "%CAPOUT%" > "%OUTDIR%\%PREFIX%.capture.log" 2>&1
+set "CAPTURE_RC=!errorlevel!"
+type "%OUTDIR%\%PREFIX%.capture.log"
+
+echo [golden] killing %PREFIX%
+call :kill_one
+REM Let the KDS100 serial port release before the next launch reopens it --
+REM killing the python server does not instantly guarantee the OS freed COM5.
+REM ~5s margin between our two sequential captures.
+ping -n 6 -w 1000 127.0.0.1 >nul
+
+if not "%CAPTURE_RC%"=="0" (
+  echo [golden] FAIL %PREFIX% capture rc=%CAPTURE_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the KDS100 driver's async_shutdown() runs:
+REM async_shutdown() returns the pump to a safe idle state and closes the
+REM pyserial COM5 handle. A hard kill skips this and may leave the serial port
+REM claimed for the next launch. Best-effort (server dies mid-response); then
+REM wait for release.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8013
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit this console.
+REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can
+REM cascade through a shared conhost.exe and close the main window.
+REM The match includes " --no-hot-reload" so "syringegold" cannot match
+REM "syringegoldhex" (no space follows "syringegold" in that cmdline).
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the WORKSYRINGE server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18013) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (syringegold vs syringegoldhex) -- or a
+REM preceding syringe_canary run on the same ports -- leaves a stale listener
+REM owning 127.0.0.1:18013, a dispatch_action RPC-first call reaches the STALE
+REM binder: the action is ACK'd but never runs on the live server, yielding an
+REM empty capture (statuses={}). Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8013) or c(18013)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :syringe_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:syringe_ports_free
+if not "!RELEASED!"=="1" echo [golden] WARNING %PREFIX% ports 8013/18013 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [golden] ABORTED -- a launch/capture step failed; see logs in %OUTDIR%
+echo [golden] ABORTED -- see %OUTDIR%\*.launch.log / *.capture.log> "%OUTDIR%\golden_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/tec_canary.bat
+++ b/helao/hexagon/tests/smoke/tec_canary.bat
@@ -1,0 +1,191 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Windows canary for the techex hexagon cut-over: runtime /openapi.json diff.
+REM
+REM Launches the LEGACY tec group and the HEXAGON techex group in turn, dumps
+REM each TEC server's live /openapi.json, and diffs them. An identical
+REM route/schema surface proves the hexagon makeActionApp factory produces a
+REM byte-parity action server for the tec_server (Meerstetter TEC) cut-over
+REM target. See tec_diff.bat for the runtime record_tec golden diff, the
+REM topology-appropriate DATA check.
+REM
+REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
+REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
+REM sequences to an orchestrator. techex is a 2-server group (TEC@8008 +
+REM ACTVIS@5001) with NO orchestrator, so the GM-* scenarios cannot drive it.
+REM The openapi diff is the topology-appropriate parity check (mirrors
+REM galil_canary.bat / gamryhex_canary.bat exactly).
+REM
+REM Both configs share root C:\INST_hlo and ports 8008/5001, so they MUST run
+REM sequentially (this script does that) -- never launch both at once.
+REM NOTE: tec.yml's simulation:true is cosmetic (banner color) here --
+REM MeerstetterTEC has no sim/dummy data path (see mecom_driver.py / see
+REM golden_capture_tec.py's docstring). The MeCom session is opened lazily by
+REM MeerstetterTECPoller's background poll loop (not at route-registration
+REM time), so a failed/unreachable connect does NOT block this openapi-surface
+REM canary from passing -- a data-producing action (see tec_diff.bat's
+REM record_tec capture) additionally requires the controller powered on and
+REM reachable at the configured `port` (COM5).
+REM
+REM Usage: tec_canary.bat [root] [outdir]
+REM   root   default C:\INST_hlo   (must match the configs' root: key)
+REM   outdir default %TEMP%\tec_canary
+REM ---------------------------------------------------------------------------
+
+set "ROOT=%~1"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\tec_canary"
+
+REM Guard: refuse an unsafe root (drive/fs anchor, or a root that contains the
+REM code repo) BEFORE anything touches it. safe_root.py is the single choke
+REM point; %ROOT% is only ever used read-only in this script, but the check is
+REM defense in depth against a mis-set root: key. See safe_root.py.
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates when
+REM conda.bat returns (silent exit). Only the conda inside `start ... cmd /c` is
+REM exempt (it runs in a separate child shell).
+call conda run -n helao python "%~dp0safe_root.py" check "%ROOT%"
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT -- root %ROOT% failed the safety guard; see message above
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+set "LEGACY_JSON=%OUTDIR%\tec_openapi.json"
+set "HEX_JSON=%OUTDIR%\techex_openapi.json"
+
+call :run_one tec     "%LEGACY_JSON%" || goto :fail
+call :run_one techex  "%HEX_JSON%"    || goto :fail
+
+echo.
+echo [canary] diffing openapi surfaces
+REM Persist diff output to a file too, so the result survives the window closing.
+call conda run -n helao python "%~dp0openapi_diff.py" "%LEGACY_JSON%" "%HEX_JSON%" > "%OUTDIR%\openapi_diff.txt" 2>&1
+set "DIFF_RC=!errorlevel!"
+type "%OUTDIR%\openapi_diff.txt"
+popd
+echo.
+if "%DIFF_RC%"=="0" (
+  echo [canary] PASS -- techex openapi surface matches legacy tec> "%OUTDIR%\canary_result.txt"
+) else (
+  echo [canary] DIFFS FOUND rc=%DIFF_RC% -- see openapi_diff.txt> "%OUTDIR%\canary_result.txt"
+)
+type "%OUTDIR%\canary_result.txt"
+echo [canary] artifacts + result saved in: %OUTDIR%
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\canary_result.txt regardless.
+pause
+exit /b %DIFF_RC%
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = output json path
+set "PREFIX=%~1"
+set "OUTJSON=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_CANARY_%PREFIX%"
+
+echo.
+echo [canary] === %PREFIX% ===
+REM NEVER wipe %ROOT%. An openapi diff reads the live server's /openapi.json and
+REM produces no output tree, so no "fresh root" is needed. On a station %ROOT%
+REM (e.g. C:\INST_hlo) holds production RUN data, calibration matrices, and may
+REM contain the code repo itself -- deleting it is catastrophic and unrecoverable
+REM (rmdir /s /q bypasses the Recycle Bin). %ROOT% is used read-only here, only
+REM to locate the pid pickle for kill_group.py.
+
+echo [canary] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8008 (or its co-located ZMQ RPC sibling 18008); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8008
+if not "%errorlevel%"=="0" (
+  echo [canary] ABORT %PREFIX% -- ports 8008/18008 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [canary] waiting for TEC port 8008
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8008))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [canary] FAIL %PREFIX% port 8008 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin)
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [canary] fetching /openapi.json -> %OUTJSON%
+call conda run -n helao python -c "import urllib.request,sys; open(sys.argv[2],'wb').write(urllib.request.urlopen('http://127.0.0.1:8008/openapi.json',timeout=30).read())" x "%OUTJSON%"
+set "FETCH_RC=!errorlevel!"
+
+echo [canary] killing %PREFIX%
+call :kill_one
+
+if not "%FETCH_RC%"=="0" (
+  echo [canary] FAIL %PREFIX% openapi fetch rc=%FETCH_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the TEC driver's shutdown() runs:
+REM MeerstetterTEC.async_shutdown() disables the control loop (safe state)
+REM then closes the MeCom serial session. A hard kill skips this and may leave
+REM the serial port held for the next launch -- best-effort (server dies
+REM mid-response); then wait.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8008
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit the canary console.
+REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade
+REM through a shared conhost.exe and close the main canary window.
+REM The match includes " --no-hot-reload" so prefix "tec" cannot match "techex".
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+REM 3) WAIT for the TEC server's HTTP + co-located ZMQ RPC ports (RPC =
+REM HTTP+10000 = 18008) to actually RELEASE before returning. The RPC listener
+REM is a thread inside the server process and lives as long as the process does;
+REM if the next sequential launch (tec vs techex) starts while a stale listener
+REM still owns 127.0.0.1:18008, the TEC "Address in use" fallback fires AND a
+REM dispatch_action RPC-first call would reach the STALE binder -- the action is
+REM ACK'd but never runs on the live server. Poll both ports until free (~30s cap).
+set "RELEASED=0"
+for /l %%i in (1,1,30) do (
+  call conda run -n helao python -c "import socket,sys; c=lambda p: socket.socket().connect_ex(('127.0.0.1',p))==0; sys.exit(1 if (c(8008) or c(18008)) else 0)" 2>nul
+  if !errorlevel! equ 0 ( set "RELEASED=1" & goto :tec_ports_free )
+  ping -n 2 -w 1000 127.0.0.1 >nul
+)
+:tec_ports_free
+if not "!RELEASED!"=="1" echo [canary] WARNING %PREFIX% ports 8008/18008 still bound after wait -- next launch may hit a stale RPC binder
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [canary] ABORTED -- a launch/fetch step failed; see logs in %OUTDIR%
+echo [canary] ABORTED -- see %PREFIX%.launch.log in %OUTDIR%> "%OUTDIR%\canary_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/tec_diff.bat
+++ b/helao/hexagon/tests/smoke/tec_diff.bat
@@ -1,0 +1,223 @@
+@echo off
+setlocal enabledelayedexpansion
+REM ---------------------------------------------------------------------------
+REM Runtime golden-diff driver for the tec_server hexagon canary (P3a
+REM special-split).
+REM
+REM *** DRIVES THE REAL MEERSTETTER TEC CONTROLLER (READ-ONLY TELEMETRY, NO
+REM SETPOINT/ENABLE CHANGE). ***
+REM The Meerstetter controller must be POWERED ON and reachable at the
+REM configured serial `port` (COM5) before running this script. record_tec
+REM (TECMonExec) never calls set_temp/enable/disable -- the controller's
+REM setpoint and enable state are NOT touched -- but MeerstetterTEC's MeCom
+REM session must still be open (lazily, via the poller's first get_data())
+REM to produce any real telemetry; see
+REM helao\hexagon\tests\smoke\golden_capture_tec.py's docstring.
+REM
+REM Launches tecgold (legacy) then tecgoldhex (hexagon), each against a FRESH
+REM throwaway root, drives one POST /TEC/record_tec per launch via
+REM golden_capture_tec.py, snapshots the resulting RUNS tree, and diffs the
+REM two captures with harness.parity. Mirrors the conventions already proven
+REM in golden_diff.bat / galil_diff.bat (call conda / ping sleeps /
+REM cmdline-scoped Stop-Process / persisted results + pause) -- see those
+REM scripts' headers for why harness.capture/parity_run.sh cannot drive this
+REM orch-less, db-less 2-server topology (no ORCH, no DB -- see
+REM golden_capture_tec.py for the RUNS_ACTIVE-only settle this uses instead
+REM of quiesce()).
+REM
+REM Usage: tec_diff.bat [caproot] [outdir]
+REM   caproot default C:\INST_hlo_golden -- a DEDICATED THROWAWAY capture
+REM            root, fully wiped before EACH capture (see :wipe_caproot).
+REM            NEVER point this at C:\INST_hlo or any root holding real data.
+REM   outdir  default %TEMP%\tec_golden -- capture sets + parity report land
+REM            here (outdir\tec, outdir\techex, outdir\parity-report.json,
+REM            outdir\golden_result.txt).
+REM ---------------------------------------------------------------------------
+
+set "CAPROOT=%~1"
+if "%CAPROOT%"=="" set "CAPROOT=C:\INST_hlo_golden"
+set "OUTDIR=%~2"
+if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\tec_golden"
+set "PROD_ROOT=C:\INST_hlo"
+
+REM NOTE: `conda` is conda.bat on Windows -- every conda call in this script's
+REM own flow MUST be prefixed with `call`, else the parent batch terminates
+REM when conda.bat returns (silent exit). Only the conda inside
+REM `start ... cmd /c` (in :run_one below) is exempt -- it runs in a separate
+REM child shell.
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard; see message above
+  exit /b 2
+)
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- caproot equals production root %PROD_ROOT%; refusing to run
+  exit /b 2
+)
+
+REM repo root = four levels up from this script (helao\hexagon\tests\smoke\)
+pushd "%~dp0..\..\..\.." || exit /b 2
+set "REPO=%CD%"
+
+if not exist "%OUTDIR%" mkdir "%OUTDIR%"
+
+call :wipe_caproot || goto :fail
+call :run_one tecgold    "%OUTDIR%\tec"    || goto :fail
+call :wipe_caproot || goto :fail
+call :run_one tecgoldhex "%OUTDIR%\techex" || goto :fail
+
+echo.
+echo [golden] running parity diff
+call conda run -n helao python -m harness.parity --golden "%OUTDIR%\tec" --candidate "%OUTDIR%\techex" --report "%OUTDIR%\parity-report.json" > "%OUTDIR%\parity_stdout.txt" 2>&1
+set "PARITY_RC=!errorlevel!"
+type "%OUTDIR%\parity_stdout.txt"
+
+echo.
+echo [golden] full parity report (also saved to %OUTDIR%\parity-report.json):
+type "%OUTDIR%\parity-report.json"
+
+popd
+echo.
+REM The tec_vals columns + epoch_s are masked via the capture manifest's
+REM masked_hlo_columns (see golden_capture_tec.py) since they are live device
+REM readings, not deterministic sim data -- so parity rc=0 is a genuine PASS
+REM and rc!=0 means a REAL hexagon-vs-legacy diff. The full report is printed
+REM and persisted above either way for inspection.
+if "%PARITY_RC%"=="0" (
+  (
+    echo [golden] PASS -- techex RUNS-tree matches legacy tec ^(record_tec, masked^)
+    echo [golden] artifacts: %OUTDIR%\tec, %OUTDIR%\techex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+) else (
+  (
+    echo [golden] DIFFS FOUND rc=%PARITY_RC% -- REAL regression, inspect the report
+    echo [golden] open %OUTDIR%\parity-report.json: tree_diffs / file_diffs list
+    echo [golden]   every differing member and key. The tec_vals + epoch_s
+    echo [golden]   columns are masked, so anything shown here is a genuine
+    echo [golden]   hexagon-vs-legacy difference.
+    echo [golden] artifacts: %OUTDIR%\tec, %OUTDIR%\techex, %OUTDIR%\parity-report.json
+  ) > "%OUTDIR%\golden_result.txt"
+)
+type "%OUTDIR%\golden_result.txt"
+echo.
+REM Keep the window open so the result is readable when double-clicked. `pause`
+REM is a no-op if stdin is redirected (non-interactive run), which is fine --
+REM the result is also in %OUTDIR%\golden_result.txt regardless.
+pause
+exit /b %PARITY_RC%
+
+REM ---------------------------------------------------------------------------
+:wipe_caproot
+REM Full-wipe the throwaway capture root before each capture -- required
+REM because golden_capture_tec.py's assert_fresh() refuses a root that
+REM already contains run artifacts. This rmdir is safe ONLY because
+REM %CAPROOT% just passed safe_root.py's check (repo not underneath it, not a
+REM drive/fs anchor) AND the equality guard below proves it is not
+REM production C:\INST_hlo -- it must NEVER run against a root that could
+REM hold real station data (run output, DATABASE, USER_CONFIG calibration
+REM matrices).
+if /I "%CAPROOT%"=="%PROD_ROOT%" (
+  echo [golden] ABORT -- refusing to wipe production root %PROD_ROOT%
+  exit /b 2
+)
+call conda run -n helao python "%~dp0safe_root.py" check "%CAPROOT%"
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT -- caproot %CAPROOT% failed the safety guard before wipe
+  exit /b 2
+)
+if exist "%CAPROOT%" (
+  echo [golden] wiping throwaway caproot %CAPROOT%
+  rmdir /s /q "%CAPROOT%"
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:run_one
+REM %1 = config prefix, %2 = capture out dir
+set "PREFIX=%~1"
+set "CAPOUT=%~2"
+set "LAUNCHLOG=%OUTDIR%\%PREFIX%.launch.log"
+set "WINTITLE=HELAO_GOLDEN_%PREFIX%"
+
+echo.
+echo [golden] === %PREFIX% ===
+echo [golden] launching %PREFIX% (log: %LAUNCHLOG%)
+REM Pre-launch guard: refuse to launch onto a still-bound HTTP/RPC port. A
+REM stale binder from a previous leg or a prior *_canary/_diff run can still
+REM own 127.0.0.1:8008 (or its co-located ZMQ RPC sibling 18008); the new
+REM server then fails to bind and falls back to the 0.0.0.0 wildcard while the
+REM stale binder keeps the loopback port, so the RPC-first action dispatch
+REM reaches the STALE binder (ACK'd but never executed) -> a silent capture
+REM hang. Wait for both ports to release before launching (mirrors :kill_one).
+call conda run -n helao python "%~dp0wait_ports_free.py" 8008
+if not "%errorlevel%"=="0" (
+  echo [golden] ABORT %PREFIX% -- ports 8008/18008 still bound before launch; kill the stale holder and retry
+  exit /b 2
+)
+start "%WINTITLE%" cmd /c "conda run -n helao python launch.py %PREFIX% --no-hot-reload > "%LAUNCHLOG%" 2>&1"
+
+echo [golden] waiting for TEC port 8008
+set "UP=0"
+for /l %%i in (1,1,90) do (
+  call conda run -n helao python -c "import socket,sys; sys.exit(0 if socket.socket().connect_ex(('127.0.0.1',8008))==0 else 1)" 2>nul
+  if !errorlevel! equ 0 ( set "UP=1" & goto :got_port )
+  REM sleep ~2s via ping; `timeout` errors when stdin is not an interactive console
+  ping -n 3 -w 1000 127.0.0.1 >nul
+)
+:got_port
+if not "%UP%"=="1" (
+  echo [golden] FAIL %PREFIX% port 8008 never came up; launch tail:
+  powershell -NoProfile -Command "if (Test-Path '%LAUNCHLOG%') { Get-Content -Tail 40 '%LAUNCHLOG%' }"
+  call :kill_one
+  exit /b 2
+)
+REM settle ~3s (ping, not timeout, to survive redirected stdin) -- also gives
+REM the poller a moment to complete its first (lazy-connect) get_data() call
+REM before golden_capture_tec.py's verify_device_open checks /get_status.
+ping -n 4 -w 1000 127.0.0.1 >nul
+
+echo [golden] capturing record_tec -^> %CAPOUT%
+call conda run -n helao python -m helao.hexagon.tests.smoke.golden_capture_tec --config-prefix %PREFIX% --root "%CAPROOT%" --out "%CAPOUT%" > "%OUTDIR%\%PREFIX%.capture.log" 2>&1
+set "CAPTURE_RC=!errorlevel!"
+type "%OUTDIR%\%PREFIX%.capture.log"
+
+echo [golden] killing %PREFIX%
+call :kill_one
+REM Let the MeCom serial session release before the next launch reopens it --
+REM killing the python server does not instantly guarantee the OS-level
+REM serial port handle is torn down. ~5s margin between our two sequential
+REM captures.
+ping -n 6 -w 1000 127.0.0.1 >nul
+
+if not "%CAPTURE_RC%"=="0" (
+  echo [golden] FAIL %PREFIX% capture rc=%CAPTURE_RC%
+  exit /b 2
+)
+exit /b 0
+
+REM ---------------------------------------------------------------------------
+:kill_one
+REM 0) GRACEFUL shutdown FIRST so the TEC driver's shutdown() runs:
+REM MeerstetterTEC.async_shutdown() disables the control loop (safe state)
+REM then closes the MeCom serial session. A hard kill skips this. Best-effort
+REM (server dies mid-response); then wait for release.
+call conda run -n helao python "%~dp0graceful_shutdown.py" 8008
+ping -n 5 -w 1000 127.0.0.1 >nul
+REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
+call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
+REM matching its command line -- precise, so it can never hit this console.
+REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can
+REM cascade through a shared conhost.exe and close the main window.
+REM The match includes " --no-hot-reload" so "tecgold" cannot match
+REM "tecgoldhex" (no space follows "tecgold" in that cmdline).
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*launch.py %PREFIX% --no-hot-reload*' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+goto :eof
+
+REM ---------------------------------------------------------------------------
+:fail
+popd
+echo [golden] ABORTED -- a launch/capture step failed; see logs in %OUTDIR%
+echo [golden] ABORTED -- see %OUTDIR%\*.launch.log / *.capture.log> "%OUTDIR%\golden_result.txt"
+pause
+exit /b 2

--- a/helao/hexagon/tests/smoke/test_golden_capture_andor.py
+++ b/helao/hexagon/tests/smoke/test_golden_capture_andor.py
@@ -1,0 +1,231 @@
+"""Linux unit tests for golden_capture_andor.py's PURE logic (no server, no HTTP).
+
+Exercises only:
+  - the PARITY_TOPS snapshot copy + provenance.yml round-trip (``snapshot``)
+  - the masked-column set (tick_time / elapsed_time_s / ch_NNNN are masked; the
+    deterministic header `wl` is NOT)
+  - the data-derived meta-key mask (action_params.action_path)
+  - the shared (gamry-authored, imported here) ``settle`` helper, applied to an
+    andor-shaped RUNS_DIAG tree
+
+The real-hardware POST to ``/ANDOR/acquire`` is NOT exercised here -- that only
+runs at-station with the Andor camera + spectrograph attached (see
+golden_capture_andor.py / andor_diff.bat docstrings).
+
+Written as plain assert-based ``test_*`` functions with no ``import pytest``
+(mirrors test_golden_capture_spec.py -- this repo's conda ``helao`` env does not
+currently have the pytest package installed), so this module is runnable two
+ways:
+
+    conda run -n helao python -m pytest helao/hexagon/tests/smoke/test_golden_capture_andor.py -q
+    conda run -n helao python -m helao.hexagon.tests.smoke.test_golden_capture_andor
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from harness.manifest import ProvenanceManifest
+
+from helao.hexagon.tests.smoke.golden_capture import settle
+from helao.hexagon.tests.smoke.golden_capture_andor import (
+    ANDOR_ACT_YML_MASKED_META_KEYS,
+    ANDOR_HLO_COLUMNS,
+    ANDOR_MASKED_HLO_COLUMNS,
+    N_PIXELS,
+    SCENARIO,
+    snapshot,
+)
+
+
+def test_masked_columns_cover_all_live_channels_but_not_header_wl():
+    cols = set(ANDOR_MASKED_HLO_COLUMNS["*.hlo"])
+    # every live/hardware-derived column is masked: the time column (driver's
+    # tick_time + the endpoint-declared elapsed_time_s alias) and every pixel...
+    assert "tick_time" in cols
+    assert "elapsed_time_s" in cols
+    assert "ch_0000" in cols
+    assert f"ch_{N_PIXELS - 1:04}" in cols
+    # ...one per pixel, plus the two time-column names
+    assert len(ANDOR_HLO_COLUMNS) == N_PIXELS + 2
+    # the deterministic pixel->wavelength header key is NOT a masked body column
+    # (it lives in the .hlo HEADER and is compared unmasked -- a diff there is a
+    # real regression).
+    assert "wl" not in cols
+
+
+def test_action_path_is_masked_via_meta_keys():
+    # AndorAcquire writes the per-run action_output_dir into action_params as
+    # action_path; normalize_meta does not §5.1-normalize a non-_output_dir key,
+    # so it must be value-masked to keep parity clean.
+    assert ANDOR_ACT_YML_MASKED_META_KEYS != {}
+    keys = ANDOR_ACT_YML_MASKED_META_KEYS["*-act.yml"]
+    assert "action_params.action_path" in keys
+
+
+def test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_FINISHED" / "x").mkdir(parents=True)
+        (root / "RUNS_FINISHED" / "x" / "a-act.yml").write_text("file_type: action\n")
+        # include a .hlo too (the full happy path: metadata + spectrum stream)
+        (root / "RUNS_FINISHED" / "x" / "acquire-0.hlo").write_text(
+            "hlo_version: x\n%%\n"
+        )
+        (root / "LOGS").mkdir(parents=True)
+        (root / "LOGS" / "ANDOR.log").write_text("not captured")
+
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="andorgold",
+            duration=1.0,
+            external_trigger=False,
+        )
+
+        assert (out / "root" / "RUNS_FINISHED" / "x" / "a-act.yml").exists()
+        assert not (out / "root" / "LOGS").exists()  # non-parity top excluded
+        assert (out / "provenance.yml").exists()
+
+        manifest = ProvenanceManifest.load(out)
+        assert manifest.scenario == SCENARIO
+        assert manifest.config_prefix == "andorgold"
+        assert manifest.config_path.replace("\\", "/").endswith(
+            "helao/deploy/hte/configs/andorgold.yml"
+        )
+        assert manifest.masked_hlo_columns == ANDOR_MASKED_HLO_COLUMNS
+        # the per-run action_params.action_path is masked via masked_meta_keys
+        assert manifest.masked_meta_keys == ANDOR_ACT_YML_MASKED_META_KEYS
+        # poll-paced stream -> a non-zero row-count tolerance is recorded
+        assert manifest.hlo_row_count_tolerance.get("*.hlo", 0) > 0
+
+
+def _write_action(root: Path, status: str = "finished", with_hlo: bool = True) -> Path:
+    """A RUNS_DIAG tree with one manual action -act.yml at ``status`` (+ .hlo)."""
+    d = root / "RUNS_DIAG" / "25.28" / "0716" / "0__0__ANDOR__acquire"
+    d.mkdir(parents=True)
+    (d / "250716.131421-act.yml").write_text(
+        f"file_type: action\naction_status:\n  - {status}\n"
+    )
+    if with_hlo:
+        (d / "acquire-0.hlo").write_text("hlo_version: x\n%%\n")
+    return d
+
+
+def test_snapshot_refuses_to_overwrite_existing_out_dir():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="andorgold",
+            duration=1.0,
+            external_trigger=False,
+        )
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="andorgold",
+                duration=1.0,
+                external_trigger=False,
+            )
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError(
+                "snapshot() should refuse to overwrite an existing out_dir"
+            )
+
+
+def test_snapshot_refuses_empty_capture():
+    """The false-PASS guard: a root with no -act.yml/.hlo must NOT be captured
+    (an empty golden set compares to nothing and passes parity vacuously)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_DIAG").mkdir(parents=True)  # present but empty (no data)
+        out = Path(td) / "golden" / "run1"
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="andorgold",
+                duration=1.0,
+                external_trigger=False,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("snapshot() must refuse an empty (no-output) capture")
+        assert not out.exists()  # nothing written on refusal
+
+
+def test_settle_returns_once_action_artifacts_are_complete_and_stable():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        settle(root, settle_polls=2, poll_s=0.01, timeout_s=5.0)
+
+
+def test_settle_times_out_when_no_artifacts_are_written():
+    """The action never wrote output (errored / no data): settle must raise,
+    not silently return -- this is what prevents the empty-capture false PASS."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        root.mkdir()  # empty root, nothing ever written
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() should time out when no artifacts appear")
+
+
+def test_settle_does_not_return_while_action_active():
+    """-act.yml exists at init with status 'active' (base.py:1029). settle must
+    NOT return on file existence -- else it snapshots + kills the server
+    mid-acquisition."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="active", with_hlo=False)  # still running
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() must not return while status is 'active'")
+
+
+ALL_TESTS = [
+    test_masked_columns_cover_all_live_channels_but_not_header_wl,
+    test_action_path_is_masked_via_meta_keys,
+    test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance,
+    test_snapshot_refuses_to_overwrite_existing_out_dir,
+    test_snapshot_refuses_empty_capture,
+    test_settle_returns_once_action_artifacts_are_complete_and_stable,
+    test_settle_times_out_when_no_artifacts_are_written,
+    test_settle_does_not_return_while_action_active,
+]
+
+
+def main() -> int:
+    failures = 0
+    for fn in ALL_TESTS:
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 -- report every failure, keep going
+            failures += 1
+            print(f"FAIL {fn.__name__}: {exc}")
+        else:
+            print(f"PASS {fn.__name__}")
+    print(f"{len(ALL_TESTS) - failures}/{len(ALL_TESTS)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/test_golden_capture_biologic.py
+++ b/helao/hexagon/tests/smoke/test_golden_capture_biologic.py
@@ -1,0 +1,247 @@
+"""Linux unit tests for golden_capture_biologic.py's PURE logic (no server, no HTTP).
+
+Exercises only:
+  - the PARITY_TOPS snapshot copy + provenance.yml round-trip (``snapshot``),
+    including the run_OCV masked_hlo_columns + masked_meta_keys manifest fields
+  - the shared (gamry-authored, imported here) ``settle`` helper, applied to a
+    biologic-shaped RUNS_DIAG tree
+
+The real-hardware POST to ``/BIOLOGIC/run_OCV`` (and ``verify_device_open``'s
+``/get_status`` probe) is NOT exercised here -- that only runs at-station (see
+golden_capture_biologic.py / biologic_diff.bat docstrings). ``easy_biologic``
+imports only on Windows, but this module never imports the driver -- only the
+pure capture logic -- so it runs on Linux.
+
+Written as plain assert-based ``test_*`` functions with no ``import pytest``
+(mirrors ``test_golden_capture_galil.py`` -- this repo's conda ``helao`` env
+does not currently have the pytest package installed), so this module is
+runnable two ways:
+
+    conda run -n helao python -m pytest helao/hexagon/tests/smoke/test_golden_capture_biologic.py -q
+    conda run -n helao python -m helao.hexagon.tests.smoke.test_golden_capture_biologic
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from harness.manifest import ProvenanceManifest
+
+from helao.hexagon.tests.smoke.golden_capture import settle
+from helao.hexagon.tests.smoke.golden_capture_biologic import (
+    OCV_ACT_YML_MASKED_META_KEYS,
+    OCV_HLO_COLUMNS,
+    OCV_HLO_ROW_COUNT_TOLERANCE,
+    OCV_MASKED_HLO_COLUMNS,
+    SCENARIO,
+    snapshot,
+)
+
+
+def test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_FINISHED" / "x").mkdir(parents=True)
+        (root / "RUNS_FINISHED" / "x" / "a-act.yml").write_text("file_type: action\n")
+        # include a .hlo too (the full happy path: metadata + data file)
+        (root / "RUNS_FINISHED" / "x" / "run_OCV__OCV-0.hlo").write_text(
+            "hlo_version: x\n%%\n"
+        )
+        (root / "LOGS").mkdir(parents=True)
+        (root / "LOGS" / "BIOLOGIC.log").write_text("not captured")
+
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="biologicgold",
+            tval_s=3.0,
+            acq_s=0.1,
+            channel=0,
+        )
+
+        assert (out / "root" / "RUNS_FINISHED" / "x" / "a-act.yml").exists()
+        assert not (out / "root" / "LOGS").exists()  # non-parity top excluded
+        assert (out / "provenance.yml").exists()
+
+        manifest = ProvenanceManifest.load(out)
+        assert manifest.scenario == SCENARIO
+        assert manifest.config_prefix == "biologicgold"
+        assert manifest.config_path.replace("\\", "/").endswith(
+            "helao/deploy/hte/configs/biologicgold.yml"
+        )
+        assert manifest.masked_hlo_columns == OCV_MASKED_HLO_COLUMNS
+        assert manifest.hlo_row_count_tolerance == OCV_HLO_ROW_COUNT_TOLERANCE
+        assert manifest.masked_meta_keys == OCV_ACT_YML_MASKED_META_KEYS
+        assert set(OCV_HLO_COLUMNS) == set(manifest.masked_hlo_columns["*OCV*.hlo"])
+        # "channel" (constant = requested channel index) is deterministic and
+        # must NOT be masked; only live measurement/device-state columns are.
+        assert "channel" not in manifest.masked_hlo_columns["*OCV*.hlo"]
+        # the live per-segment CurrentValues columns and the remapped data
+        # columns ARE masked (spot-check a few of each).
+        for col in ("t_s", "Ewe_V", "_State", "_Ewe", "_I", "_OptPos"):
+            assert col in manifest.masked_hlo_columns["*OCV*.hlo"]
+
+
+def test_masked_meta_keys_cover_the_ocv_post_exec_summary_leaves():
+    """The data-derived -act.yml action_params (t_s/Ewe_V trailing means +
+    has_bubble) written by BiologicExec._post_exec must be masked so two
+    independent real captures diff clean on those values only. I_A__mean_final
+    is intentionally NOT masked: OCV emits no I_A column, so _post_exec never
+    writes it."""
+    keys = OCV_ACT_YML_MASKED_META_KEYS["*-act.yml"]
+    assert "action_params.t_s__mean_final" in keys
+    assert "action_params.Ewe_V__mean_final" in keys
+    assert "action_params.has_bubble" in keys
+    assert "action_params.I_A__mean_final" not in keys
+
+
+def _write_action(root: Path, status: str = "finished", with_hlo: bool = True) -> Path:
+    """A RUNS_DIAG tree with one manual run_OCV -act.yml at ``status`` (+ .hlo)."""
+    d = root / "RUNS_DIAG" / "25.28" / "0716" / "0__0__BIOLOGIC__run_OCV"
+    d.mkdir(parents=True)
+    (d / "250716.131421-act.yml").write_text(
+        f"file_type: action\naction_status:\n  - {status}\n"
+    )
+    if with_hlo:
+        (d / "run_OCV__OCV-0.hlo").write_text("hlo_version: x\n%%\n")
+    return d
+
+
+def test_snapshot_refuses_to_overwrite_existing_out_dir():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="biologicgold",
+            tval_s=3.0,
+            acq_s=0.1,
+            channel=0,
+        )
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="biologicgold",
+                tval_s=3.0,
+                acq_s=0.1,
+                channel=0,
+            )
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError(
+                "snapshot() should refuse to overwrite an existing out_dir"
+            )
+
+
+def test_snapshot_refuses_empty_capture():
+    """The false-PASS guard: a root with no -act.yml/.hlo must NOT be captured
+    (an empty golden set compares to nothing and passes parity vacuously)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_DIAG").mkdir(parents=True)  # present but empty (no data)
+        out = Path(td) / "golden" / "run1"
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="biologicgold",
+                tval_s=3.0,
+                acq_s=0.1,
+                channel=0,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("snapshot() must refuse an empty (no-output) capture")
+        assert not out.exists()  # nothing written on refusal
+
+
+def test_settle_returns_once_action_artifacts_are_complete_and_stable():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        settle(root, settle_polls=2, poll_s=0.01, timeout_s=5.0)
+
+
+def test_settle_times_out_when_no_artifacts_are_written():
+    """The action never wrote output (errored / no data): settle must raise,
+    not silently return -- this is what prevents the empty-capture false PASS."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        root.mkdir()  # empty root, nothing ever written
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() should time out when no artifacts appear")
+
+
+def test_settle_does_not_return_while_action_active():
+    """-act.yml exists at init with status 'active' (base.py:1029). settle must
+    NOT return on file existence -- else it snapshots + kills the server
+    mid-measurement."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="active", with_hlo=False)  # still running
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() must not return while status is 'active'")
+
+
+def test_snapshot_succeeds_with_terminal_act_yml_only():
+    """snapshot captures a finished -act.yml-only tree (warns about the missing
+    .hlo but does not refuse -- the -act.yml is still a real parity comparison)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=False)
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="biologicgold",
+            tval_s=3.0,
+            acq_s=0.1,
+            channel=0,
+        )
+        assert (out / "provenance.yml").exists()
+
+
+ALL_TESTS = [
+    test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance,
+    test_masked_meta_keys_cover_the_ocv_post_exec_summary_leaves,
+    test_snapshot_refuses_to_overwrite_existing_out_dir,
+    test_snapshot_refuses_empty_capture,
+    test_settle_returns_once_action_artifacts_are_complete_and_stable,
+    test_settle_times_out_when_no_artifacts_are_written,
+    test_settle_does_not_return_while_action_active,
+    test_snapshot_succeeds_with_terminal_act_yml_only,
+]
+
+
+def main() -> int:
+    failures = 0
+    for fn in ALL_TESTS:
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 -- report every failure, keep going
+            failures += 1
+            print(f"FAIL {fn.__name__}: {exc}")
+        else:
+            print(f"PASS {fn.__name__}")
+    print(f"{len(ALL_TESTS) - failures}/{len(ALL_TESTS)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/test_golden_capture_co2.py
+++ b/helao/hexagon/tests/smoke/test_golden_capture_co2.py
@@ -1,0 +1,229 @@
+"""Linux unit tests for golden_capture_co2.py's PURE logic (no server, no HTTP).
+
+Exercises only:
+  - the PARITY_TOPS snapshot copy + provenance.yml round-trip (``snapshot``)
+  - the masked-column set (co2_ppm / epoch_s are masked) and the masked
+    meta-key set (action_params.mean_co2_ppm is masked)
+  - the shared (gamry-authored, imported here) ``settle`` helper, applied to a
+    co2-shaped RUNS_DIAG tree
+
+The real-hardware POST to ``/CO2SENSOR/acquire_co2`` is NOT exercised here --
+that only runs at-station with the SprintIR sensor attached on COM12 (see
+golden_capture_co2.py / co2_diff.bat docstrings).
+
+Written as plain assert-based ``test_*`` functions with no ``import pytest``
+(mirrors test_golden_capture_spec.py -- this repo's conda ``helao`` env does
+not currently have the pytest package installed), so this module is runnable
+two ways:
+
+    conda run -n helao python -m pytest helao/hexagon/tests/smoke/test_golden_capture_co2.py -q
+    conda run -n helao python -m helao.hexagon.tests.smoke.test_golden_capture_co2
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from harness.manifest import ProvenanceManifest
+
+from helao.hexagon.tests.smoke.golden_capture import settle
+from helao.hexagon.tests.smoke.golden_capture_co2 import (
+    CO2_ACT_YML_MASKED_META_KEYS,
+    CO2_HLO_COLUMNS,
+    CO2_HLO_ROW_COUNT_TOLERANCE,
+    CO2_MASKED_HLO_COLUMNS,
+    SCENARIO,
+    snapshot,
+)
+
+
+def test_masked_columns_cover_the_live_channels():
+    cols = set(CO2_MASKED_HLO_COLUMNS["*.hlo"])
+    # both live/hardware-derived columns are masked...
+    assert "co2_ppm" in cols
+    assert "epoch_s" in cols
+    # ...and nothing else (exactly the two data columns the executor emits)
+    assert cols == {"co2_ppm", "epoch_s"}
+    assert len(CO2_HLO_COLUMNS) == 2
+
+
+def test_poll_paced_row_count_tolerance_is_nonzero():
+    # The executor is poll-paced over a wall-clock duration, so the row count
+    # jitters run-to-run -- a nonzero tolerance is required (unlike spec's exact
+    # single-shot count). Anything <=0 would false-fail a legitimate capture.
+    assert CO2_HLO_ROW_COUNT_TOLERANCE["*.hlo"] >= 1
+    assert CO2_HLO_ROW_COUNT_TOLERANCE["*.hlo.json*"] >= 1
+
+
+def test_data_derived_mean_is_masked_in_act_yml():
+    # CO2MonExec._post_exec writes mean_co2_ppm (data-derived) back into
+    # action_params -- it MUST be masked or parity false-fails between captures.
+    keys = CO2_ACT_YML_MASKED_META_KEYS["*-act.yml"]
+    assert "action_params.mean_co2_ppm" in keys
+
+
+def test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_FINISHED" / "x").mkdir(parents=True)
+        (root / "RUNS_FINISHED" / "x" / "a-act.yml").write_text("file_type: action\n")
+        # include a .hlo too (the full happy path: metadata + stream file)
+        (root / "RUNS_FINISHED" / "x" / "acquire_co2-0.hlo").write_text(
+            "hlo_version: x\n%%\n"
+        )
+        (root / "LOGS").mkdir(parents=True)
+        (root / "LOGS" / "CO2SENSOR.log").write_text("not captured")
+
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="co2gold",
+            duration=3.0,
+            acquisition_rate=0.2,
+        )
+
+        assert (out / "root" / "RUNS_FINISHED" / "x" / "a-act.yml").exists()
+        assert not (out / "root" / "LOGS").exists()  # non-parity top excluded
+        assert (out / "provenance.yml").exists()
+
+        manifest = ProvenanceManifest.load(out)
+        assert manifest.scenario == SCENARIO
+        assert manifest.config_prefix == "co2gold"
+        assert manifest.config_path.replace("\\", "/").endswith(
+            "helao/deploy/hte/configs/co2gold.yml"
+        )
+        assert manifest.masked_hlo_columns == CO2_MASKED_HLO_COLUMNS
+        assert manifest.hlo_row_count_tolerance == CO2_HLO_ROW_COUNT_TOLERANCE
+        assert manifest.masked_meta_keys == CO2_ACT_YML_MASKED_META_KEYS
+
+
+def _write_action(root: Path, status: str = "finished", with_hlo: bool = True) -> Path:
+    """A RUNS_DIAG tree with one manual action -act.yml at ``status`` (+ .hlo)."""
+    d = root / "RUNS_DIAG" / "25.28" / "0716" / "0__0__CO2SENSOR__acquire_co2"
+    d.mkdir(parents=True)
+    (d / "250716.131421-act.yml").write_text(
+        f"file_type: action\naction_status:\n  - {status}\n"
+    )
+    if with_hlo:
+        (d / "acquire_co2-0.hlo").write_text("hlo_version: x\n%%\n")
+    return d
+
+
+def test_snapshot_refuses_to_overwrite_existing_out_dir():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="co2gold",
+            duration=3.0,
+            acquisition_rate=0.2,
+        )
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="co2gold",
+                duration=3.0,
+                acquisition_rate=0.2,
+            )
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError(
+                "snapshot() should refuse to overwrite an existing out_dir"
+            )
+
+
+def test_snapshot_refuses_empty_capture():
+    """The false-PASS guard: a root with no -act.yml/.hlo must NOT be captured
+    (an empty golden set compares to nothing and passes parity vacuously)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_DIAG").mkdir(parents=True)  # present but empty (no data)
+        out = Path(td) / "golden" / "run1"
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="co2gold",
+                duration=3.0,
+                acquisition_rate=0.2,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("snapshot() must refuse an empty (no-output) capture")
+        assert not out.exists()  # nothing written on refusal
+
+
+def test_settle_returns_once_action_artifacts_are_complete_and_stable():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        settle(root, settle_polls=2, poll_s=0.01, timeout_s=5.0)
+
+
+def test_settle_times_out_when_no_artifacts_are_written():
+    """The action never wrote output (errored / no data): settle must raise,
+    not silently return -- this is what prevents the empty-capture false PASS."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        root.mkdir()  # empty root, nothing ever written
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() should time out when no artifacts appear")
+
+
+def test_settle_does_not_return_while_action_active():
+    """-act.yml exists at init with status 'active' (base.py:1029). settle must
+    NOT return on file existence -- else it snapshots + kills the server
+    mid-acquisition."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="active", with_hlo=False)  # still running
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() must not return while status is 'active'")
+
+
+ALL_TESTS = [
+    test_masked_columns_cover_the_live_channels,
+    test_poll_paced_row_count_tolerance_is_nonzero,
+    test_data_derived_mean_is_masked_in_act_yml,
+    test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance,
+    test_snapshot_refuses_to_overwrite_existing_out_dir,
+    test_snapshot_refuses_empty_capture,
+    test_settle_returns_once_action_artifacts_are_complete_and_stable,
+    test_settle_times_out_when_no_artifacts_are_written,
+    test_settle_does_not_return_while_action_active,
+]
+
+
+def main() -> int:
+    failures = 0
+    for fn in ALL_TESTS:
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 -- report every failure, keep going
+            failures += 1
+            print(f"FAIL {fn.__name__}: {exc}")
+        else:
+            print(f"PASS {fn.__name__}")
+    print(f"{len(ALL_TESTS) - failures}/{len(ALL_TESTS)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/test_golden_capture_mfc.py
+++ b/helao/hexagon/tests/smoke/test_golden_capture_mfc.py
@@ -1,0 +1,238 @@
+"""Linux unit tests for golden_capture_mfc.py's PURE logic (no server, no HTTP).
+
+Exercises only:
+  - the PARITY_TOPS snapshot copy + provenance.yml round-trip (``snapshot``)
+  - the masked-column set (the live sensor/clock columns are masked; the
+    config-deterministic categorical columns gas/control_point are NOT)
+  - the masked_meta_keys lever (action_params.total_scc is masked)
+  - the shared (gamry-authored, imported here) ``settle`` helper, applied to an
+    mfc-shaped RUNS_DIAG tree
+
+The real-hardware POST to ``/MFC/acquire_flowrate`` is NOT exercised here --
+that only runs at-station with the Alicat MFC attached on COM9 (see
+golden_capture_mfc.py / mfc_diff.bat docstrings).
+
+Written as plain assert-based ``test_*`` functions with no ``import pytest``
+(mirrors test_golden_capture_spec.py -- this repo's conda ``helao`` env does not
+currently have the pytest package installed), so this module is runnable two
+ways:
+
+    conda run -n helao python -m pytest helao/hexagon/tests/smoke/test_golden_capture_mfc.py -q
+    conda run -n helao python -m helao.hexagon.tests.smoke.test_golden_capture_mfc
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from harness.manifest import ProvenanceManifest
+
+from helao.hexagon.tests.smoke.golden_capture import settle
+from helao.hexagon.tests.smoke.golden_capture_mfc import (
+    DEVICE_NAME,
+    MFC_ACT_YML_MASKED_META_KEYS,
+    MFC_HLO_COLUMNS,
+    MFC_MASKED_HLO_COLUMNS,
+    SCENARIO,
+    snapshot,
+)
+
+
+def test_masked_columns_cover_live_telemetry_but_not_deterministic_categoricals():
+    cols = set(MFC_MASKED_HLO_COLUMNS["*.hlo"])
+    # every live/hardware-derived sensor + clock column is masked...
+    assert "epoch_s" in cols
+    assert "acquire_time" in cols
+    assert "pressure" in cols
+    assert "temperature" in cols
+    assert "volumetric_flow" in cols
+    assert "mass_flow" in cols
+    assert "setpoint" in cols
+    # ...including the totalizer-only column (harmless no-op mask elsewhere)
+    assert "total flow" in cols
+    # the config-deterministic categorical columns are NOT masked -- they are the
+    # deterministic anchors (the .hlo analogue of spec's `wl`); a diff there is a
+    # real regression.
+    assert "gas" not in cols
+    assert "control_point" not in cols
+    # both fnmatch patterns carry the identical column set
+    assert MFC_MASKED_HLO_COLUMNS["*.hlo.json*"] == MFC_HLO_COLUMNS
+
+
+def test_masked_meta_keys_mask_total_scc():
+    # MfcExec._post_exec writes the data-derived action_params.total_scc back
+    # into -act.yml; it must be masked (the meta-side analogue of a live column).
+    keys = MFC_ACT_YML_MASKED_META_KEYS["*-act.yml"]
+    assert "action_params.total_scc" in keys
+
+
+def test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_FINISHED" / "x").mkdir(parents=True)
+        (root / "RUNS_FINISHED" / "x" / "a-act.yml").write_text("file_type: action\n")
+        # include a .hlo too (the full happy path: metadata + telemetry file)
+        (root / "RUNS_FINISHED" / "x" / "acquire_flowrate-0.hlo").write_text(
+            "hlo_version: x\n%%\n"
+        )
+        (root / "LOGS").mkdir(parents=True)
+        (root / "LOGS" / "MFC.log").write_text("not captured")
+
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="mfcgold",
+            device_name=DEVICE_NAME,
+            duration=2.0,
+            acquisition_rate=0.2,
+        )
+
+        assert (out / "root" / "RUNS_FINISHED" / "x" / "a-act.yml").exists()
+        assert not (out / "root" / "LOGS").exists()  # non-parity top excluded
+        assert (out / "provenance.yml").exists()
+
+        manifest = ProvenanceManifest.load(out)
+        assert manifest.scenario == SCENARIO
+        assert manifest.config_prefix == "mfcgold"
+        assert manifest.config_path.replace("\\", "/").endswith(
+            "helao/deploy/hte/configs/mfcgold.yml"
+        )
+        assert manifest.masked_hlo_columns == MFC_MASKED_HLO_COLUMNS
+        # the one data-derived summary that acquire_flowrate lands in -act.yml
+        assert manifest.masked_meta_keys == MFC_ACT_YML_MASKED_META_KEYS
+        # poll-paced stream -> a non-empty row-count tolerance was recorded
+        assert manifest.hlo_row_count_tolerance
+
+
+def _write_action(root: Path, status: str = "finished", with_hlo: bool = True) -> Path:
+    """A RUNS_DIAG tree with one manual action -act.yml at ``status`` (+ .hlo)."""
+    d = root / "RUNS_DIAG" / "25.28" / "0716" / "0__0__MFC__acquire_flowrate"
+    d.mkdir(parents=True)
+    (d / "250716.131421-act.yml").write_text(
+        f"file_type: action\naction_status:\n  - {status}\n"
+    )
+    if with_hlo:
+        (d / "acquire_flowrate-0.hlo").write_text("hlo_version: x\n%%\n")
+    return d
+
+
+def test_snapshot_refuses_to_overwrite_existing_out_dir():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="mfcgold",
+            device_name=DEVICE_NAME,
+            duration=2.0,
+            acquisition_rate=0.2,
+        )
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="mfcgold",
+                device_name=DEVICE_NAME,
+                duration=2.0,
+                acquisition_rate=0.2,
+            )
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError(
+                "snapshot() should refuse to overwrite an existing out_dir"
+            )
+
+
+def test_snapshot_refuses_empty_capture():
+    """The false-PASS guard: a root with no -act.yml/.hlo must NOT be captured
+    (an empty golden set compares to nothing and passes parity vacuously)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_DIAG").mkdir(parents=True)  # present but empty (no data)
+        out = Path(td) / "golden" / "run1"
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="mfcgold",
+                device_name=DEVICE_NAME,
+                duration=2.0,
+                acquisition_rate=0.2,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("snapshot() must refuse an empty (no-output) capture")
+        assert not out.exists()  # nothing written on refusal
+
+
+def test_settle_returns_once_action_artifacts_are_complete_and_stable():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        settle(root, settle_polls=2, poll_s=0.01, timeout_s=5.0)
+
+
+def test_settle_times_out_when_no_artifacts_are_written():
+    """The action never wrote output (errored / no data): settle must raise,
+    not silently return -- this is what prevents the empty-capture false PASS."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        root.mkdir()  # empty root, nothing ever written
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() should time out when no artifacts appear")
+
+
+def test_settle_does_not_return_while_action_active():
+    """-act.yml exists at init with status 'active' (base.py:1029). settle must
+    NOT return on file existence -- else it snapshots + kills the server
+    mid-acquisition."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="active", with_hlo=False)  # still running
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() must not return while status is 'active'")
+
+
+ALL_TESTS = [
+    test_masked_columns_cover_live_telemetry_but_not_deterministic_categoricals,
+    test_masked_meta_keys_mask_total_scc,
+    test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance,
+    test_snapshot_refuses_to_overwrite_existing_out_dir,
+    test_snapshot_refuses_empty_capture,
+    test_settle_returns_once_action_artifacts_are_complete_and_stable,
+    test_settle_times_out_when_no_artifacts_are_written,
+    test_settle_does_not_return_while_action_active,
+]
+
+
+def main() -> int:
+    failures = 0
+    for fn in ALL_TESTS:
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 -- report every failure, keep going
+            failures += 1
+            print(f"FAIL {fn.__name__}: {exc}")
+        else:
+            print(f"PASS {fn.__name__}")
+    print(f"{len(ALL_TESTS) - failures}/{len(ALL_TESTS)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/test_golden_capture_syringe.py
+++ b/helao/hexagon/tests/smoke/test_golden_capture_syringe.py
@@ -1,0 +1,198 @@
+"""Linux unit tests for golden_capture_syringe.py's PURE logic (no server, no HTTP).
+
+Exercises only:
+  - the PARITY_TOPS snapshot copy + provenance.yml round-trip (``snapshot``),
+    including the explicit MASKING=NONE decision (both masked_hlo_columns and
+    masked_meta_keys are empty because get_present_volume writes a
+    config-deterministic value -- 0.0 on a fresh idle pump -- not a live device
+    reading; masking it would only weaken the parity check)
+  - the shared (gamry-authored, imported here) ``settle`` helper, applied to a
+    syringe-shaped RUNS_DIAG tree
+
+The (hardware-independent) POST to ``/WORKSYRINGE/get_present_volume`` (and
+``check_device_open``'s ``/get_status`` probe) is NOT exercised here -- that
+only runs against a launched server (see golden_capture_syringe.py /
+syringe_diff.bat docstrings).
+
+Written as plain assert-based ``test_*`` functions with no ``import pytest``
+(mirrors ``test_golden_capture_galil.py`` -- this repo's conda ``helao`` env
+does not currently have the pytest package installed), so this module is
+runnable two ways:
+
+    conda run -n helao python -m pytest helao/hexagon/tests/smoke/test_golden_capture_syringe.py -q
+    conda run -n helao python -m helao.hexagon.tests.smoke.test_golden_capture_syringe
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from harness.manifest import ProvenanceManifest
+
+from helao.hexagon.tests.smoke.golden_capture import settle
+from helao.hexagon.tests.smoke.golden_capture_syringe import (
+    SCENARIO,
+    SYRVOL_MASKED_HLO_COLUMNS,
+    SYRVOL_MASKED_META_KEYS,
+    snapshot,
+)
+
+
+def test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_FINISHED" / "x").mkdir(parents=True)
+        (root / "RUNS_FINISHED" / "x" / "a-act.yml").write_text("file_type: action\n")
+        # include a .hlo too (the full happy path: metadata + data file --
+        # get_present_volume ALWAYS enqueues one data row)
+        (root / "RUNS_FINISHED" / "x" / "get_present_volume-0.hlo").write_text(
+            "hlo_version: x\n%%\n"
+        )
+        (root / "LOGS").mkdir(parents=True)
+        (root / "LOGS" / "WORKSYRINGE.log").write_text("not captured")
+
+        out = Path(td) / "golden" / "run1"
+        snapshot(root=root, out_dir=out, config_prefix="syringegold")
+
+        assert (out / "root" / "RUNS_FINISHED" / "x" / "a-act.yml").exists()
+        assert not (out / "root" / "LOGS").exists()  # non-parity top excluded
+        assert (out / "provenance.yml").exists()
+
+        manifest = ProvenanceManifest.load(out)
+        assert manifest.scenario == SCENARIO
+        assert manifest.config_prefix == "syringegold"
+        assert manifest.config_path.replace("\\", "/").endswith(
+            "helao/deploy/hte/configs/syringegold.yml"
+        )
+        # MASKING = NONE is the load-bearing decision for this scenario: the
+        # present_volume_ul value is config-deterministic on a fresh idle pump
+        # (0.0), NOT a live/nondeterministic device reading, so nothing is
+        # masked. A future edit that adds masking must consciously flip this.
+        assert manifest.masked_hlo_columns == {}
+        assert manifest.masked_meta_keys == {}
+        assert SYRVOL_MASKED_HLO_COLUMNS == {}
+        assert SYRVOL_MASKED_META_KEYS == {}
+
+
+def _write_action(root: Path, status: str = "finished", with_hlo: bool = True) -> Path:
+    """A RUNS_DIAG tree with one manual action -act.yml at ``status`` (+ .hlo)."""
+    d = root / "RUNS_DIAG" / "25.28" / "0716" / "0__0__WORKSYRINGE__get_present_volume"
+    d.mkdir(parents=True)
+    (d / "250716.131421-act.yml").write_text(
+        f"file_type: action\naction_status:\n  - {status}\n"
+    )
+    if with_hlo:
+        (d / "get_present_volume-0.hlo").write_text("hlo_version: x\n%%\n")
+    return d
+
+
+def test_snapshot_refuses_to_overwrite_existing_out_dir():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        out = Path(td) / "golden" / "run1"
+        snapshot(root=root, out_dir=out, config_prefix="syringegold")
+        try:
+            snapshot(root=root, out_dir=out, config_prefix="syringegold")
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError(
+                "snapshot() should refuse to overwrite an existing out_dir"
+            )
+
+
+def test_snapshot_refuses_empty_capture():
+    """The false-PASS guard: a root with no -act.yml/.hlo must NOT be captured
+    (an empty golden set compares to nothing and passes parity vacuously)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_DIAG").mkdir(parents=True)  # present but empty (no data)
+        out = Path(td) / "golden" / "run1"
+        try:
+            snapshot(root=root, out_dir=out, config_prefix="syringegold")
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("snapshot() must refuse an empty (no-output) capture")
+        assert not out.exists()  # nothing written on refusal
+
+
+def test_settle_returns_once_action_artifacts_are_complete_and_stable():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        settle(root, settle_polls=2, poll_s=0.01, timeout_s=5.0)
+
+
+def test_settle_times_out_when_no_artifacts_are_written():
+    """The action never wrote output (errored / no data): settle must raise,
+    not silently return -- this is what prevents the empty-capture false PASS."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        root.mkdir()  # empty root, nothing ever written
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() should time out when no artifacts appear")
+
+
+def test_settle_does_not_return_while_action_active():
+    """-act.yml exists at init with status 'active' (base.py:1029). settle
+    must NOT return on file existence -- else it snapshots + kills the
+    server mid-query."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="active", with_hlo=False)  # still running
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() must not return while status is 'active'")
+
+
+def test_snapshot_succeeds_with_terminal_act_yml_only():
+    """snapshot captures a finished -act.yml-only tree (warns about the missing
+    .hlo but does not refuse -- the -act.yml is still a real parity comparison).
+    For get_present_volume a .hlo IS normally expected, so the warning matters,
+    but its absence is not a hard failure."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=False)
+        out = Path(td) / "golden" / "run1"
+        snapshot(root=root, out_dir=out, config_prefix="syringegold")
+        assert (out / "provenance.yml").exists()
+
+
+ALL_TESTS = [
+    test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance,
+    test_snapshot_refuses_to_overwrite_existing_out_dir,
+    test_snapshot_refuses_empty_capture,
+    test_settle_returns_once_action_artifacts_are_complete_and_stable,
+    test_settle_times_out_when_no_artifacts_are_written,
+    test_settle_does_not_return_while_action_active,
+    test_snapshot_succeeds_with_terminal_act_yml_only,
+]
+
+
+def main() -> int:
+    failures = 0
+    for fn in ALL_TESTS:
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 -- report every failure, keep going
+            failures += 1
+            print(f"FAIL {fn.__name__}: {exc}")
+        else:
+            print(f"PASS {fn.__name__}")
+    print(f"{len(ALL_TESTS) - failures}/{len(ALL_TESTS)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/test_golden_capture_tec.py
+++ b/helao/hexagon/tests/smoke/test_golden_capture_tec.py
@@ -1,0 +1,219 @@
+"""Linux unit tests for golden_capture_tec.py's PURE logic (no server, no HTTP).
+
+Exercises only:
+  - the PARITY_TOPS snapshot copy + provenance.yml round-trip (``snapshot``)
+  - the shared (gamry-authored, imported here) ``settle`` helper, applied to
+    a tec-shaped RUNS_DIAG tree
+
+The real-hardware POST to ``/TEC/record_tec`` (and ``verify_device_open``'s
+``/get_status`` probe) is NOT exercised here -- that only runs at-station
+(see golden_capture_tec.py / tec_diff.bat docstrings).
+
+Written as plain assert-based ``test_*`` functions with no ``import pytest``
+(mirrors ``test_golden_capture.py`` / ``test_golden_capture_galil.py`` --
+this repo's conda ``helao`` env does not currently have the pytest package
+installed), so this module is runnable two ways:
+
+    conda run -n helao python -m pytest helao/hexagon/tests/smoke/test_golden_capture_tec.py -q
+    conda run -n helao python -m helao.hexagon.tests.smoke.test_golden_capture_tec
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from harness.manifest import ProvenanceManifest
+
+from helao.hexagon.tests.smoke.golden_capture import settle
+from helao.hexagon.tests.smoke.golden_capture_tec import (
+    TEC_HLO_COLUMNS,
+    TEC_HLO_ROW_COUNT_TOLERANCE,
+    TEC_MASKED_HLO_COLUMNS,
+    SCENARIO,
+    snapshot,
+)
+
+
+def test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_FINISHED" / "x").mkdir(parents=True)
+        (root / "RUNS_FINISHED" / "x" / "a-act.yml").write_text("file_type: action\n")
+        # include a .hlo too (the full happy path: metadata + data file)
+        (root / "RUNS_FINISHED" / "x" / "record_tec-0.hlo").write_text(
+            "hlo_version: x\n%%\n"
+        )
+        (root / "LOGS").mkdir(parents=True)
+        (root / "LOGS" / "TEC.log").write_text("not captured")
+
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="tecgold",
+            duration_s=3.0,
+            acquisition_rate=0.2,
+        )
+
+        assert (out / "root" / "RUNS_FINISHED" / "x" / "a-act.yml").exists()
+        assert not (out / "root" / "LOGS").exists()  # non-parity top excluded
+        assert (out / "provenance.yml").exists()
+
+        manifest = ProvenanceManifest.load(out)
+        assert manifest.scenario == SCENARIO
+        assert manifest.config_prefix == "tecgold"
+        assert manifest.config_path.replace("\\", "/").endswith(
+            "helao/deploy/hte/configs/tecgold.yml"
+        )
+        assert manifest.masked_hlo_columns == TEC_MASKED_HLO_COLUMNS
+        assert manifest.hlo_row_count_tolerance == TEC_HLO_ROW_COUNT_TOLERANCE
+        assert set(TEC_HLO_COLUMNS) == set(
+            manifest.masked_hlo_columns["*record_tec*.hlo"]
+        )
+
+
+def _write_action(root: Path, status: str = "finished", with_hlo: bool = True) -> Path:
+    """A RUNS_DIAG tree with one manual action -act.yml at ``status`` (+ .hlo)."""
+    d = root / "RUNS_DIAG" / "25.28" / "0716" / "0__0__TEC__record_tec"
+    d.mkdir(parents=True)
+    (d / "250716.131421-act.yml").write_text(
+        f"file_type: action\naction_status:\n  - {status}\n"
+    )
+    if with_hlo:
+        (d / "record_tec-0.hlo").write_text("hlo_version: x\n%%\n")
+    return d
+
+
+def test_snapshot_refuses_to_overwrite_existing_out_dir():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="tecgold",
+            duration_s=3.0,
+            acquisition_rate=0.2,
+        )
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="tecgold",
+                duration_s=3.0,
+                acquisition_rate=0.2,
+            )
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError(
+                "snapshot() should refuse to overwrite an existing out_dir"
+            )
+
+
+def test_snapshot_refuses_empty_capture():
+    """The false-PASS guard: a root with no -act.yml/.hlo must NOT be captured
+    (an empty golden set compares to nothing and passes parity vacuously)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        (root / "RUNS_DIAG").mkdir(parents=True)  # present but empty (no data)
+        out = Path(td) / "golden" / "run1"
+        try:
+            snapshot(
+                root=root,
+                out_dir=out,
+                config_prefix="tecgold",
+                duration_s=3.0,
+                acquisition_rate=0.2,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("snapshot() must refuse an empty (no-output) capture")
+        assert not out.exists()  # nothing written on refusal
+
+
+def test_settle_returns_once_action_artifacts_are_complete_and_stable():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=True)
+        settle(root, settle_polls=2, poll_s=0.01, timeout_s=5.0)
+
+
+def test_settle_times_out_when_no_artifacts_are_written():
+    """The action never wrote output (errored / no data): settle must raise,
+    not silently return -- this is what prevents the empty-capture false PASS."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        root.mkdir()  # empty root, nothing ever written
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() should time out when no artifacts appear")
+
+
+def test_settle_does_not_return_while_action_active():
+    """-act.yml exists at init with status 'active' (base.py:1029). settle
+    must NOT return on file existence -- else it snapshots + kills the
+    server mid-recording."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="active", with_hlo=False)  # still running
+        try:
+            settle(root, settle_polls=2, poll_s=0.01, timeout_s=0.05)
+        except TimeoutError:
+            pass
+        else:
+            raise AssertionError("settle() must not return while status is 'active'")
+
+
+def test_snapshot_succeeds_with_terminal_act_yml_only():
+    """snapshot captures a finished -act.yml-only tree (warns about the
+    missing .hlo but does not refuse -- the -act.yml is still a real parity
+    comparison)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "captroot"
+        _write_action(root, status="finished", with_hlo=False)
+        out = Path(td) / "golden" / "run1"
+        snapshot(
+            root=root,
+            out_dir=out,
+            config_prefix="tecgold",
+            duration_s=3.0,
+            acquisition_rate=0.2,
+        )
+        assert (out / "provenance.yml").exists()
+
+
+ALL_TESTS = [
+    test_snapshot_copies_parity_tops_and_writes_roundtrippable_provenance,
+    test_snapshot_refuses_to_overwrite_existing_out_dir,
+    test_snapshot_refuses_empty_capture,
+    test_settle_returns_once_action_artifacts_are_complete_and_stable,
+    test_settle_times_out_when_no_artifacts_are_written,
+    test_settle_does_not_return_while_action_active,
+    test_snapshot_succeeds_with_terminal_act_yml_only,
+]
+
+
+def main() -> int:
+    failures = 0
+    for fn in ALL_TESTS:
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 -- report every failure, keep going
+            failures += 1
+            print(f"FAIL {fn.__name__}: {exc}")
+        else:
+            print(f"PASS {fn.__name__}")
+    print(f"{len(ALL_TESTS) - failures}/{len(ALL_TESTS)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/wait_ports_free.py
+++ b/helao/hexagon/tests/smoke/wait_ports_free.py
@@ -1,0 +1,104 @@
+"""Poll until the given TCP ports (and their RPC siblings, port+10000) are FREE.
+
+Pre-launch guard for the ``*_canary.bat`` / ``*_diff.bat`` station smoke
+scripts. Before launching a server group onto a fixed port, refuse to proceed
+while a stale binder -- a leftover server or ZMQ RPC listener from a previous
+leg or a prior canary/diff run -- still owns the HTTP port or its co-located
+RPC port (HTTP + 10000, see ``helao.core.rpc.derive_rpc_port``).
+
+Why this matters: if the RPC port is still held, the freshly launched server
+cannot bind it and falls back to the ``0.0.0.0`` wildcard, while the STALE
+binder keeps ``127.0.0.1:<rpc>``. The capture's RPC-first action dispatch then
+reaches the stale binder -- the call is ACK'd but the action never runs on the
+live server -- so nothing is written and the capture hangs (``settle`` waits
+out its full timeout for an ``-act.yml`` that never appears). The ``:kill_one``
+teardown already waits for release AFTER a leg; this guard closes the gap
+BEFORE a leg, where a binder left by the *previous* script/leg would otherwise
+go uncaught.
+
+For each HTTP port given, both ``<port>`` and ``<port> + 10000`` are checked.
+Exits 0 once all are free; exits 2 if any is still bound after ``--timeout``
+seconds, naming the stuck port(s) so the operator can kill the holder
+(``netstat -ano | findstr <port>``).
+
+Usage: ``python wait_ports_free.py <http_port> [<http_port> ...]``
+"""
+
+from __future__ import annotations
+
+import argparse
+import socket
+import sys
+import time
+
+RPC_OFFSET = 10000
+
+
+def _bound(port: int, host: str = "127.0.0.1", timeout: float = 0.5) -> bool:
+    """True if a TCP connect to ``host:port`` succeeds (something is listening)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(timeout)
+        return s.connect_ex((host, port)) == 0
+
+
+def wait_ports_free(
+    http_ports: list[int],
+    host: str = "127.0.0.1",
+    timeout: float = 30.0,
+    poll: float = 1.0,
+    _sleep=time.sleep,
+    _clock=time.monotonic,
+) -> list[int]:
+    """Poll until every ``port`` and ``port + RPC_OFFSET`` is free.
+
+    Returns the list of ports STILL BOUND when the timeout elapsed (empty list
+    means all released). ``_sleep`` / ``_clock`` are injectable for testing.
+    """
+    targets: list[int] = []
+    for p in http_ports:
+        targets.append(p)
+        rpc = p + RPC_OFFSET
+        # real HELAO HTTP ports are ~8xxx so the RPC sibling is ~18xxx (in range);
+        # only add the sibling when it is a valid TCP port so a stray argument can
+        # never crash the guard.
+        if rpc <= 65535:
+            targets.append(rpc)
+    t0 = _clock()
+    while True:
+        stuck = [p for p in targets if _bound(p, host)]
+        if not stuck:
+            return []
+        if _clock() - t0 >= timeout:
+            return stuck
+        _sleep(poll)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(prog="wait_ports_free.py", description=__doc__)
+    ap.add_argument(
+        "ports",
+        nargs="+",
+        type=int,
+        help="HTTP port(s); the RPC sibling port+10000 is also checked",
+    )
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--timeout", type=float, default=30.0)
+    ap.add_argument("--poll", type=float, default=1.0)
+    a = ap.parse_args(argv)
+
+    all_targets = [p for port in a.ports for p in (port, port + RPC_OFFSET)]
+    stuck = wait_ports_free(a.ports, host=a.host, timeout=a.timeout, poll=a.poll)
+    if not stuck:
+        print(f"[wait_ports_free] ports free: {all_targets}")
+        return 0
+    print(
+        f"[wait_ports_free] STILL BOUND after {a.timeout:g}s: {stuck} -- a stale "
+        f"server/RPC listener owns these; kill it (netstat -ano | findstr "
+        f"{stuck[0]}) and retry",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## P3a hexagon canary harness — hte hardware families + dispatch fixes

Adds the at-station hexagon parity smoke tests (openapi-surface canary + runtime golden-diff) for the hte hardware action-server families, plus the framework dispatch fixes those at-station runs surfaced.

### Canaries by family
- **Station-validated green:** andor, biologic, spec, cam, galil (motion), galilio (io), gamry, syringe, kmotor (openapi-only), ni (openapi-only).
- **Built, pending next live station** (additive; touch no shared code): **co2, diapump, mfc**.
- **Built, off the hardware list** (hardware non-functional / not carried forward → structural parity only, no at-station gate): **tec** (both tiers), **power_supply** (openapi-only).
- Openapi-only where every action perturbs hardware (ni/kmotor/power_supply); runtime golden-diff where a safe non-perturbing read exists (record_tec, run_OCV, acquire, query_positions, ...).

### Framework fixes (general — benefit production dispatch, not just canaries)
- `fix(rpc)` **timeout-collision** (`4d11afe3`): an action param literally named `timeout` (ANDOR/acquire) collided with `RPCClient.call`'s own `timeout` kwarg → `TypeError` before any I/O. `RPCClient.call`/`RPCSyncClient.call` gain a collision-proof `args=` payload; all 4 dispatch sites use it.
- `fix(dispatcher)` **yarl bool query** (`73084268`): HTTP fallback passed a `bool` param to aiohttp/yarl → `TypeError` swallowed as escalating retry sleeps (the andor "hang"). `_query_safe` coerces bool→`"true"`/`"false"`, drops None.
- `fix(hexagon)` **Windows selector loop** (`e05a85da`): the standalone golden-capture client forces a SelectorEventLoop so its zmq.asyncio RPC socket works without the Proactor warning.

### Smoke infra
- `wait_ports_free.py` + a pre-launch HTTP/RPC port-free guard in all 22 canary/diff bats (a stale binder from a prior leg/run made the fresh server fall back to the wildcard while the RPC-first dispatch hit the stale binder → silent capture hang).
- Real station hardware params ported into runtime canary configs (a wrong/absent device address fails connect() at startup; the openapi canary passes regardless, so only the runtime diff catches it — biologic/kmotor/tec precedent).
- `--no-capture-output` + `python -u` on the andor capture and flushed stage breadcrumbs (conda run otherwise buffers a hung capture's log to empty).

### Tests
- `unit_test_dispatcher` 26/26 (incl. end-to-end RPC action-dispatch coverage: ACTION_CTX populated, `timeout`/bool params round-trip, down-peer falls back promptly).
- `run_unit_tests.py` 35/35 modules PASS.
- All hexagon configs `PREFLIGHT OK`.

### Out of scope
PAL (4-way special-split) — continues on a fresh dev branch. co2/diapump/mfc at-station validation also continues post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnSSF8Rm7U9Jo3ejUS3sNE
