### PR TITLE
feat(hexagon): generic config-driven action graft (fast: graft) for private deployments

### DIFF
--- a/helao/deploy/hexagon/servers/action/graft.py
+++ b/helao/deploy/hexagon/servers/action/graft.py
@@ -1,0 +1,64 @@
+"""Generic config-driven hexagon action-server graft (P3-private, decision A).
+
+The per-server hexagon shims in this package (gamry_server2.py, spec_server.py,
+...) each HARDCODE their `LEGACY_MODULE = "helao.deploy.<dep>.servers.action.
+<mod>"`. That is fine for the public `hte`/`test` deployments, but a shim for a
+PRIVATE nested deployment would have to name `helao.deploy.<private>...` in this
+public parent repo — which is forbidden (private deployment repos are never
+named in parent-tracked code).
+
+This generic shim removes that coupling: it names NOTHING. The private module
+path lives ONLY in the private deployment's own config (inside the private
+repo), under a top-level per-server `legacy_module:` key. A private hexagon
+canary config therefore reads:
+
+    SOMEKEY:
+      host: 127.0.0.1
+      port: 8xxx
+      group: action
+      fast: graft                 # <- resolves to THIS module, names nothing
+      deployment: hexagon
+      legacy_module: helao.deploy.<private>.servers.action.<module>   # private
+      params: { ...verbatim original server params... }
+
+The launcher resolves `deployment: hexagon` + `fast: graft` to
+`helao.deploy.hexagon.servers.action.graft.makeApp`, which looks up the config's
+`legacy_module` and delegates to the same `makeActionApp(server_key,
+legacy_module)` factory every hardcoded shim uses — identical graft (fail-loud
+wiring, co-located RPC, native write/WS graft), just with the legacy target
+sourced from config instead of a hardcoded string. Public deployments may use
+this too, but keep using their explicit per-server shims for readability.
+
+`legacy_module` is a top-level server key (sibling of `fast:`), NOT a `params:`
+entry, so the wrapped legacy `makeApp` sees its original `params` unchanged.
+"""
+
+from helao.helpers.config_loader import CONFIG
+from helao.hexagon.app.factory import makeActionApp
+
+__all__ = ["makeApp"]
+
+
+def makeApp(server_key):
+    """Build a hexagon-grafted action app for ``server_key``.
+
+    Reads the legacy target from ``CONFIG['servers'][server_key]['legacy_module']``
+    (fail loud with a clear message if absent — a `fast: graft` server MUST
+    declare it) and delegates to the shared ``makeActionApp`` factory.
+    """
+    if CONFIG is None:
+        raise RuntimeError(
+            "config_loader.CONFIG is not installed; graft.makeApp must run "
+            "after the launcher has loaded the config"
+        )
+    scfg = CONFIG["servers"][server_key]
+    legacy_module = scfg.get("legacy_module")
+    if not legacy_module:
+        raise KeyError(
+            f"server '{server_key}' uses `fast: graft` but declares no "
+            "`legacy_module:` key. Add a top-level `legacy_module: "
+            "helao.deploy.<deployment>.servers.action.<module>` to its config "
+            "block so the generic hexagon graft knows which legacy makeApp to "
+            "wrap."
+        )
+    return makeActionApp(server_key, legacy_module)

--- a/helao/deploy/hte/configs/samplegraft.yml
+++ b/helao/deploy/hte/configs/samplegraft.yml
@@ -1,0 +1,32 @@
+# VALIDATION config for the generic config-driven hexagon graft (decision A):
+# same as samplehex.yml but SAMPLE routes through the GENERIC `fast: graft`
+# shim + a top-level `legacy_module:` key, instead of the hardcoded
+# helao/deploy/hexagon/servers/action/sample_server.py shim. Proves the generic
+# graft yields a byte-identical action surface to the hardcoded shim (and thus
+# to legacy sample.yml). Linux-runnable (Archive driver, no hardware). Not a
+# production config — a mechanism proof for the private-deployment graft.
+dummy: true
+simulation: true
+run_type: sample_server
+root: /tmp/INST_hlo_sample
+servers:
+  SAMPLE:
+    host: 127.0.0.1
+    port: 8008
+    group: action
+    fast: graft
+    deployment: hexagon
+    legacy_module: helao.deploy.hte.servers.action.sample_server
+    params:
+      positions:
+        custom:
+          cell1_we: cell
+  ACTVIS:
+    host: 127.0.0.1
+    port: 5001
+    group: visualizer
+    bokeh: action_visualizer
+    deployment: hexagon
+    params:
+      doc_name: 'SAMPLE Visualizer'
+      launch_browser: true

--- a/helao/hexagon/preflight.py
+++ b/helao/hexagon/preflight.py
@@ -68,6 +68,22 @@ def _server_module(server: dict) -> Optional[str]:
     return server.get("fast") or server.get("bokeh")
 
 
+def _checklist_module(server: dict) -> Optional[str]:
+    """The module a server's endpoint checklist is keyed by.
+
+    Normally the `fast`/`bokeh` module basename, but a `fast: graft` server
+    (the generic config-driven hexagon graft, helao/deploy/hexagon/servers/
+    action/graft.py) wraps the module named by its top-level `legacy_module:`
+    key, so its checklist is keyed by that legacy module's basename, not by the
+    generic shim name "graft".
+    """
+    module = _server_module(server)
+    if module == "graft":
+        legacy = server.get("legacy_module")
+        return legacy.rsplit(".", 1)[-1] if legacy else None
+    return module
+
+
 def _config_sanity(servers: dict) -> list[str]:
     issues: list[str] = []
     hostports: dict[tuple, str] = {}
@@ -112,7 +128,7 @@ def _checklist_presence(servers: dict, checklist_dir: Optional[Path]) -> list[st
     for key, s in servers.items():
         if s.get("deployment") != HEXAGON or s.get("group") != "action":
             continue
-        module = _server_module(s)
+        module = _checklist_module(s)
         if module and not (checklist_dir / f"{module}.json").exists():
             issues.append(
                 f"{key}: frozen endpoint checklist missing for '{module}' "

--- a/helao/hexagon/tests/test_preflight.py
+++ b/helao/hexagon/tests/test_preflight.py
@@ -72,3 +72,23 @@ def test_library_collision_overridable():
         "allow_shadow": True,
     }
     assert preflight._library_collisions(cfg) == []
+
+
+def test_samplegraft_generic_graft_passes():
+    """The generic config-driven graft (fast: graft + legacy_module) passes
+    every offline gate — its checklist resolves from the legacy module."""
+    assert preflight.preflight_config("samplegraft") == []
+
+
+def test_checklist_module_resolves_graft_from_legacy_module():
+    """fast: graft keys its checklist by the legacy_module basename, not by the
+    generic shim name 'graft'."""
+    graft_srv = {
+        "fast": "graft",
+        "legacy_module": "helao.deploy.hte.servers.action.sample_server",
+    }
+    assert preflight._checklist_module(graft_srv) == "sample_server"
+    # a graft server missing legacy_module resolves to None (no checklist name)
+    assert preflight._checklist_module({"fast": "graft"}) is None
+    # ordinary servers still key by their fast/bokeh module
+    assert preflight._checklist_module({"fast": "gamry_server2"}) == "gamry_server2"


### PR DESCRIPTION
Adds a single **generic** hexagon action shim so a private nested deployment can use `deployment: hexagon` without any parent-repo file naming the private repo (decision A).

## Problem
The per-server hexagon shims hardcode `LEGACY_MODULE = "helao.deploy.<dep>.servers.action.<mod>"`. Fine for public `hte`/`test`, but a shim for a private server would `import helao.deploy.<private>…` in this public repo — forbidden.

## Mechanism (names nothing private)
- `helao/deploy/hexagon/servers/action/graft.py`: `makeApp(server_key)` reads `CONFIG['servers'][server_key]['legacy_module']` (fail-loud if absent) and delegates to the same `makeActionApp(server_key, legacy_module)` factory every hardcoded shim uses. The private module path lives **only** in the private deployment's own config (inside the private repo), as a top-level `legacy_module:` key. A private hex config reads `fast: graft` + `deployment: hexagon` + `legacy_module: helao.deploy.<private>…`.
- `preflight.py`: `fast: graft` servers key their endpoint-checklist by the `legacy_module` basename, not the generic name `graft`.
- `samplegraft.yml`: Linux mechanism-proof config.
- `test_preflight.py`: +2 tests.

## Validation
**End-to-end on Linux:** legacy `sample` vs graft-based `samplegraft` `/openapi.json` = **51 routes / 54 schemas IDENTICAL** — the generic graft is byte-identical to the hardcoded shim. Full preflight suite **10 passed**.

Unblocks privacy-clean hexagon canaries for the lila/mea/priv nested deployments (hex configs use `fast: graft` + a private `legacy_module:` that never leaves the private repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)