### PR TITLE
feat(hexagon): private-aware checklist dir in preflight

### DIFF
--- a/helao/hexagon/preflight.py
+++ b/helao/hexagon/preflight.py
@@ -84,6 +84,26 @@ def _checklist_module(server: dict) -> Optional[str]:
     return module
 
 
+def _checklist_dir(deployment: Optional[str]) -> Optional[Path]:
+    """Where a deployment's frozen endpoint checklists live.
+
+    A PRIVATE nested deployment keeps its checklists INSIDE its own repo
+    (helao/deploy/<dep>/tests/checklists/) — the public parent cannot host a
+    directory named after a private deployment. The public deployments (hte,
+    test) keep theirs centrally under helao/hexagon/tests/checklists/<dep>/.
+    Prefer the in-repo location when it exists, else the central one; the path
+    is BUILT from the resolved deployment at runtime, so this parent source
+    names nothing private.
+    """
+    if not deployment:
+        return None
+    in_repo = REPO_ROOT / "helao" / "deploy" / deployment / "tests" / "checklists"
+    if in_repo.exists():
+        return in_repo
+    central = CHECKLIST_ROOT / deployment
+    return central if central.exists() else None
+
+
 def _config_sanity(servers: dict) -> list[str]:
     issues: list[str] = []
     hostports: dict[tuple, str] = {}
@@ -184,7 +204,7 @@ def preflight_config(config: str) -> list[str]:
     cfg = read_config(config)
     servers = cfg.get("servers", {})
     deployment = _config_deployment(config)
-    checklist_dir = (CHECKLIST_ROOT / deployment) if deployment else None
+    checklist_dir = _checklist_dir(deployment)
     issues: list[str] = []
     issues += _config_sanity(servers)
     issues += _shim_completeness(servers)

--- a/helao/hexagon/tests/test_preflight.py
+++ b/helao/hexagon/tests/test_preflight.py
@@ -92,3 +92,18 @@ def test_checklist_module_resolves_graft_from_legacy_module():
     assert preflight._checklist_module({"fast": "graft"}) is None
     # ordinary servers still key by their fast/bokeh module
     assert preflight._checklist_module({"fast": "gamry_server2"}) == "gamry_server2"
+
+
+def test_checklist_dir_prefers_private_in_repo_then_central():
+    """A private deployment's checklists live in its own repo
+    (helao/deploy/<dep>/tests/checklists); hte/test use the central
+    helao/hexagon/tests/checklists/<dep>. Unknown/None -> None."""
+    hte = preflight._checklist_dir("hte")
+    assert hte is not None and hte.parts[-3:] == ("tests", "checklists", "hte")
+    assert "hexagon" in hte.parts  # central location
+    priv = preflight._checklist_dir("priv")
+    if priv is not None:  # present when the priv nested repo is checked out
+        assert priv.parts[-3:] == ("priv", "tests", "checklists")
+        assert "deploy" in priv.parts and "hexagon" not in priv.parts  # in-repo
+    assert preflight._checklist_dir(None) is None
+    assert preflight._checklist_dir("no_such_deployment") is None


### PR DESCRIPTION
Follow-up to the generic graft (#192). Fixes the one integration gap noted in the private-deployment overnight run.

## Problem
preflight's endpoint-checklist gate resolved the checklist dir as `CHECKLIST_ROOT/<deployment>` only — for a private nested deployment that's `helao/hexagon/tests/checklists/<private>`, a parent path named after a private repo (forbidden). So the gate silently skipped (dir absent) and never enforced a private hexagon config's checklists.

## Fix
`_checklist_dir(deployment)` now prefers the deployment's **own in-repo** location `helao/deploy/<dep>/tests/checklists/` when present (where a private deployment keeps its frozen checklists), falling back to the central `helao/hexagon/tests/checklists/<dep>/` for public hte/test. The path is built from the resolved deployment at runtime, so this parent source names nothing private.

## Effect
Private `fast: graft` hexagon configs now have their frozen-checklist gate **enforced** against the checklists inside their own repo (a missing checklist fails preflight). hte/test unchanged.

Validated: full preflight suite **11 passed**; private hex `batchhex`/`robotarmhex`/`pstathex` + hte `gamryhex`/`samplegraft` all `PREFLIGHT OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)