### PR TITLE
fix(hexagon/core): P3a station-validation fixes — poller lifecycle, driver hardening, smoke infra

### DIFF
--- a/helao/core/drivers/helao_driver.py
+++ b/helao/core/drivers/helao_driver.py
@@ -12,6 +12,7 @@ from abc import ABC, abstractmethod
 from enum import StrEnum
 from datetime import datetime
 from dataclasses import dataclass, field
+from typing import Any
 
 from helao.helpers import helao_logging as logging
 
@@ -160,6 +161,11 @@ class DriverPoller:
     last_update: datetime
     live_dict: dict
     polling: bool
+    poll_signal_task: "asyncio.Task[None]"
+    polling_task: "asyncio.Task[None]"
+    # the owning Base (set by BaseAPI after construction); Any avoids a
+    # core->servers import cycle and keeps `await _base_hook.put_lbuf(...)` typed
+    _base_hook: Any
 
     def __init__(self, driver: HelaoDriver, wait_time: float = 0.05) -> None:
         """Bind to ``driver`` and start the signal and polling background tasks.
@@ -195,13 +201,34 @@ class DriverPoller:
             LOGGER.info("waiting for polling loop to stop")
             await asyncio.sleep(0.1)
 
-    async def _poll_signal_loop(self):
+    async def stop(self) -> None:
+        """Cancel the background poll loops and await their teardown.
+
+        MUST be called BEFORE disconnecting the driver on shutdown. The poll
+        loop runs ``while True`` and is never otherwise cancelled, so once the
+        driver's ``disconnect()`` closes its serial/handle the loop would keep
+        calling ``get_data`` on a dead device -- spamming errors until the event
+        loop is torn down at process exit. ``_stop_polling`` only pauses the
+        loop (``polling=False``); this fully cancels the tasks. Idempotent.
+        """
+        self.polling = False
+        pending = [
+            t for t in (self.polling_task, self.poll_signal_task) if not t.done()
+        ]
+        for task in pending:
+            task.cancel()
+        if pending:
+            # gather(return_exceptions=True) swallows the CancelledError raised
+            # in each task and waits for all of them to finish unwinding.
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    async def _poll_signal_loop(self) -> None:
         """Background loop that updates ``self.polling`` from the signal queue."""
         while True:
             self.polling = await self.poll_signalq.get()
             LOGGER.info("polling signal received")
 
-    async def _poll_sensor_loop(self):
+    async def _poll_sensor_loop(self) -> None:
         """Background loop that calls :meth:`get_data` and updates ``live_dict``.
 
         While ``polling`` is true, the driver is polled every ``wait_time``

--- a/helao/core/drivers/helao_driver.py
+++ b/helao/core/drivers/helao_driver.py
@@ -219,8 +219,20 @@ class DriverPoller:
             task.cancel()
         if pending:
             # gather(return_exceptions=True) swallows the CancelledError raised
-            # in each task and waits for all of them to finish unwinding.
-            await asyncio.gather(*pending, return_exceptions=True)
+            # in each task. Bound the await: a task stuck in a BLOCKING sync
+            # get_data() (e.g. a driver serial read with no timeout) cannot
+            # process the cancellation until it next hits an await, so without a
+            # timeout this would hang shutdown. If they don't unwind in time,
+            # proceed -- the tasks die when the loop tears down at process exit.
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*pending, return_exceptions=True), timeout=5.0
+                )
+            except asyncio.TimeoutError:
+                LOGGER.warning(
+                    "poller task(s) did not stop within 5s (likely blocked in a "
+                    "synchronous get_data); proceeding with shutdown"
+                )
 
     async def _poll_signal_loop(self) -> None:
         """Background loop that updates ``self.polling`` from the signal queue."""

--- a/helao/core/servers/base_api.py
+++ b/helao/core/servers/base_api.py
@@ -810,6 +810,14 @@ class BaseAPI(HelaoFastAPI):
             LOGGER.info("action shutdown")
             await self.base.shutdown()
 
+            # Stop the poll loop BEFORE disconnecting the driver. The poller runs
+            # while True and is not otherwise cancelled, so if it keeps polling
+            # after driver.shutdown()/disconnect() closes the device it calls
+            # get_data() on a dead handle and spams errors until process exit.
+            if isinstance(self.poller, DriverPoller):
+                LOGGER.info("stopping driver poller before disconnect")
+                await self.poller.stop()
+
             shutdown = getattr(self.driver, "shutdown", None)
             async_shutdown = getattr(self.driver, "async_shutdown", None)
 

--- a/helao/deploy/hte/configs/andor.yml
+++ b/helao/deploy/hte/configs/andor.yml
@@ -20,7 +20,7 @@
 dummy: true
 simulation: true
 run_type: andor_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   ANDOR:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/andorhex.yml
+++ b/helao/deploy/hte/configs/andorhex.yml
@@ -10,7 +10,7 @@
 dummy: true
 simulation: true
 run_type: andor_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   ANDOR:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/biologic.yml
+++ b/helao/deploy/hte/configs/biologic.yml
@@ -19,13 +19,14 @@
 dummy: true
 simulation: true
 run_type: biologic_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   BIOLOGIC:
     host: 127.0.0.1
     port: 8016
     group: action
     fast: biologic_server
+    action_vis: biologic_vis
     params:
       allow_no_sample: true
       address: 192.168.200.100

--- a/helao/deploy/hte/configs/biologicgold.yml
+++ b/helao/deploy/hte/configs/biologicgold.yml
@@ -18,6 +18,7 @@ servers:
     port: 8016
     group: action
     fast: biologic_server
+    action_vis: biologic_vis
     params:
       allow_no_sample: true
       address: 192.168.200.100

--- a/helao/deploy/hte/configs/biologicgoldhex.yml
+++ b/helao/deploy/hte/configs/biologicgoldhex.yml
@@ -22,6 +22,7 @@ servers:
     group: action
     fast: biologic_server
     deployment: hexagon
+    action_vis: biologic_vis
     params:
       allow_no_sample: true
       address: 192.168.200.100

--- a/helao/deploy/hte/configs/biologichex.yml
+++ b/helao/deploy/hte/configs/biologichex.yml
@@ -7,7 +7,7 @@
 dummy: true
 simulation: true
 run_type: biologic_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   BIOLOGIC:
     host: 127.0.0.1
@@ -15,6 +15,7 @@ servers:
     group: action
     fast: biologic_server
     deployment: hexagon
+    action_vis: biologic_vis
     params:
       allow_no_sample: true
       address: 192.168.200.100

--- a/helao/deploy/hte/configs/cam.yml
+++ b/helao/deploy/hte/configs/cam.yml
@@ -18,7 +18,7 @@
 dummy: true
 simulation: true
 run_type: cam_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   CAM:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/camhex.yml
+++ b/helao/deploy/hte/configs/camhex.yml
@@ -8,7 +8,7 @@
 dummy: true
 simulation: true
 run_type: cam_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   CAM:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/co2.yml
+++ b/helao/deploy/hte/configs/co2.yml
@@ -11,13 +11,14 @@
 dummy: true
 simulation: true
 run_type: co2sensor_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   CO2SENSOR:
     host: 127.0.0.1
     port: 8012
     group: action
     fast: co2sensor_server
+    live_vis: co2_vis
     params:
       port: COM12
       start_margin: 0
@@ -25,7 +26,7 @@ servers:
     host: 127.0.0.1
     port: 5001
     group: visualizer
-    bokeh: action_visualizer
+    bokeh: live_visualizer
     params:
       doc_name: 'CO2 Visualizer'
       launch_browser: true

--- a/helao/deploy/hte/configs/co2gold.yml
+++ b/helao/deploy/hte/configs/co2gold.yml
@@ -17,6 +17,7 @@ servers:
     port: 8012
     group: action
     fast: co2sensor_server
+    live_vis: co2_vis
     params:
       port: COM12
       start_margin: 0
@@ -24,7 +25,7 @@ servers:
     host: 127.0.0.1
     port: 5001
     group: visualizer
-    bokeh: action_visualizer
+    bokeh: live_visualizer
     params:
       doc_name: 'CO2 Visualizer'
       launch_browser: true

--- a/helao/deploy/hte/configs/co2goldhex.yml
+++ b/helao/deploy/hte/configs/co2goldhex.yml
@@ -22,6 +22,7 @@ servers:
     group: action
     fast: co2sensor_server
     deployment: hexagon
+    live_vis: co2_vis
     params:
       port: COM12
       start_margin: 0
@@ -29,7 +30,7 @@ servers:
     host: 127.0.0.1
     port: 5001
     group: visualizer
-    bokeh: action_visualizer
+    bokeh: live_visualizer
     deployment: hexagon
     params:
       doc_name: 'CO2 Visualizer'

--- a/helao/deploy/hte/configs/co2hex.yml
+++ b/helao/deploy/hte/configs/co2hex.yml
@@ -7,7 +7,7 @@
 dummy: true
 simulation: true
 run_type: co2sensor_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   CO2SENSOR:
     host: 127.0.0.1
@@ -15,6 +15,7 @@ servers:
     group: action
     fast: co2sensor_server
     deployment: hexagon
+    live_vis: co2_vis
     params:
       port: COM12
       start_margin: 0
@@ -22,7 +23,7 @@ servers:
     host: 127.0.0.1
     port: 5001
     group: visualizer
-    bokeh: action_visualizer
+    bokeh: live_visualizer
     deployment: hexagon
     params:
       doc_name: 'CO2 Visualizer'

--- a/helao/deploy/hte/configs/diapump.yml
+++ b/helao/deploy/hte/configs/diapump.yml
@@ -15,7 +15,7 @@
 dummy: true
 simulation: true
 run_type: diapump_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   DOSEPUMP:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/diapumphex.yml
+++ b/helao/deploy/hte/configs/diapumphex.yml
@@ -13,7 +13,7 @@
 dummy: true
 simulation: true
 run_type: diapump_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   DOSEPUMP:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/galil.yml
+++ b/helao/deploy/hte/configs/galil.yml
@@ -11,7 +11,7 @@
 dummy: true
 simulation: true
 run_type: galil_motion
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   MOTOR:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/galilhex.yml
+++ b/helao/deploy/hte/configs/galilhex.yml
@@ -8,7 +8,7 @@
 dummy: true
 simulation: true
 run_type: galil_motion
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   MOTOR:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/galilio.yml
+++ b/helao/deploy/hte/configs/galilio.yml
@@ -11,13 +11,14 @@
 dummy: true
 simulation: true
 run_type: galil_io
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   IO:
     host: 127.0.0.1
     port: 8005
     group: action
     fast: galil_io
+    live_vis: pressure_vis
     params:
       galil_ip_str: 192.168.200.234
       dev_di:
@@ -35,7 +36,7 @@ servers:
     host: 127.0.0.1
     port: 5001
     group: visualizer
-    bokeh: action_visualizer
+    bokeh: live_visualizer
     params:
       doc_name: 'IO Visualizer'
       launch_browser: true

--- a/helao/deploy/hte/configs/galiliogold.yml
+++ b/helao/deploy/hte/configs/galiliogold.yml
@@ -18,6 +18,7 @@ servers:
     port: 8005
     group: action
     fast: galil_io
+    live_vis: pressure_vis
     params:
       galil_ip_str: 192.168.200.234
       dev_di:
@@ -35,7 +36,7 @@ servers:
     host: 127.0.0.1
     port: 5001
     group: visualizer
-    bokeh: action_visualizer
+    bokeh: live_visualizer
     params:
       doc_name: 'IO Visualizer'
       launch_browser: true

--- a/helao/deploy/hte/configs/galiliogoldhex.yml
+++ b/helao/deploy/hte/configs/galiliogoldhex.yml
@@ -23,6 +23,7 @@ servers:
     group: action
     fast: galil_io
     deployment: hexagon
+    live_vis: pressure_vis
     params:
       galil_ip_str: 192.168.200.234
       dev_di:
@@ -40,7 +41,7 @@ servers:
     host: 127.0.0.1
     port: 5001
     group: visualizer
-    bokeh: action_visualizer
+    bokeh: live_visualizer
     deployment: hexagon
     params:
       doc_name: 'IO Visualizer'

--- a/helao/deploy/hte/configs/galiliohex.yml
+++ b/helao/deploy/hte/configs/galiliohex.yml
@@ -8,7 +8,7 @@
 dummy: true
 simulation: true
 run_type: galil_io
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   IO:
     host: 127.0.0.1
@@ -16,6 +16,7 @@ servers:
     group: action
     fast: galil_io
     deployment: hexagon
+    live_vis: pressure_vis
     params:
       galil_ip_str: 192.168.200.234
       dev_di:
@@ -33,7 +34,7 @@ servers:
     host: 127.0.0.1
     port: 5001
     group: visualizer
-    bokeh: action_visualizer
+    bokeh: live_visualizer
     deployment: hexagon
     params:
       doc_name: 'IO Visualizer'

--- a/helao/deploy/hte/configs/gamry.yml
+++ b/helao/deploy/hte/configs/gamry.yml
@@ -1,7 +1,7 @@
 dummy: true
 simulation: true
 run_type: gamry
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 alert_config_path: C:\INST_hlo\USER_CONFIG\alert_gamry.yml
 servers:
   PSTAT:

--- a/helao/deploy/hte/configs/gamryhex.yml
+++ b/helao/deploy/hte/configs/gamryhex.yml
@@ -7,7 +7,7 @@
 dummy: true
 simulation: true
 run_type: gamry
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 alert_config_path: C:\INST_hlo\USER_CONFIG\alert_gamry.yml
 servers:
   PSTAT:

--- a/helao/deploy/hte/configs/kmotor.yml
+++ b/helao/deploy/hte/configs/kmotor.yml
@@ -33,7 +33,7 @@
 dummy: true
 simulation: true
 run_type: kinesis_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   KMOTOR:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/kmotorhex.yml
+++ b/helao/deploy/hte/configs/kmotorhex.yml
@@ -16,7 +16,7 @@
 dummy: true
 simulation: true
 run_type: kinesis_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   KMOTOR:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/mfc.yml
+++ b/helao/deploy/hte/configs/mfc.yml
@@ -23,13 +23,14 @@
 dummy: true
 simulation: true
 run_type: mfc_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   MFC:
     host: 127.0.0.1
     port: 8009
     group: action
     fast: mfc_server
+    live_vis: mfc_vis
     params:
       devices:
         CO2:
@@ -40,7 +41,7 @@ servers:
     host: 127.0.0.1
     port: 5001
     group: visualizer
-    bokeh: action_visualizer
+    bokeh: live_visualizer
     params:
       doc_name: 'MFC Visualizer'
       launch_browser: true

--- a/helao/deploy/hte/configs/mfc.yml
+++ b/helao/deploy/hte/configs/mfc.yml
@@ -1,11 +1,15 @@
 # STANDALONE mfc_server canary config (P3a special-split, MFC). Mirrors
 # galil.yml/gamry.yml/spec.yml's 2-server shape (one action server + one
 # action_visualizer) so an at-station openapi/runtime golden diff can compare
-# legacy vs hexagon like-for-like without pulling in the full ccsi1 station
+# legacy vs hexagon like-for-like without pulling in the full ccsi station
 # (ORCH, IO, NI, SAMPLE, DB, syringes, CO2SENSOR, N2MFC, ...). The MFC params
-# (devices CO2 -> COM9/unit_id A, co2_server_name) are copied VERBATIM from
-# ccsi1.yml's MFC block so acquire_flowrate registers identically. This is an
-# Alicat mass flow controller (pyserial over COM9) -- WINDOWS-ONLY hardware.
+# (devices CO2 -> unit_id A, co2_server_name) mirror the station's real MFC
+# block so acquire_flowrate registers identically. IMPORTANT: the device COM
+# port is STATION-SPECIFIC (ccsi1 = COM9, ccsi2 = COM6); this config is set to
+# COM6 for the ccsi2 station -- point it at the real MFC COM port of whatever
+# station you validate at, or the runtime acquire_flowrate poller opens a dead
+# port and the capture hangs (openapi canary passes regardless). This is an
+# Alicat mass flow controller (pyserial over that COM port) -- WINDOWS-ONLY.
 # NOTE: co2_server_name points at CO2SENSOR, which is NOT in this 2-server
 # canary, so the maintain_concentration endpoints are (deterministically, on
 # BOTH legacy and hexagon) not registered -- acquire_flowrate/acquire_pressure/
@@ -13,7 +17,7 @@
 # AliCatMFC.__init__ does NO device I/O (dev_mfcs is built from config alone)
 # and connect() failures are caught, so the server BOOTS and serves
 # /openapi.json even with no Alicat attached; a data-producing action
-# (acquire_flowrate) additionally requires the real MFC on COM9 (see
+# (acquire_flowrate) additionally requires the real MFC on COM6 (see
 # mfc_diff.bat / golden_capture_mfc.py).
 dummy: true
 simulation: true
@@ -28,7 +32,7 @@ servers:
     params:
       devices:
         CO2:
-          port: COM9
+          port: COM6
           unit_id: A
       co2_server_name: CO2SENSOR
   ACTVIS:

--- a/helao/deploy/hte/configs/mfc.yml
+++ b/helao/deploy/hte/configs/mfc.yml
@@ -5,19 +5,20 @@
 # (ORCH, IO, NI, SAMPLE, DB, syringes, CO2SENSOR, N2MFC, ...). The MFC params
 # (devices CO2 -> unit_id A, co2_server_name) mirror the station's real MFC
 # block so acquire_flowrate registers identically. IMPORTANT: the device COM
-# port is STATION-SPECIFIC (ccsi1 = COM9, ccsi2 = COM6); this config is set to
-# COM6 for the ccsi2 station -- point it at the real MFC COM port of whatever
+# port is STATION-SPECIFIC (ccsi1 = COM9, ccsi2 = COM4); this config is set to
+# COM4 for the ccsi2 station -- point it at the real MFC COM port of whatever
 # station you validate at, or the runtime acquire_flowrate poller opens a dead
 # port and the capture hangs (openapi canary passes regardless). This is an
 # Alicat mass flow controller (pyserial over that COM port) -- WINDOWS-ONLY.
 # NOTE: co2_server_name points at CO2SENSOR, which is NOT in this 2-server
 # canary, so the maintain_concentration endpoints are (deterministically, on
 # BOTH legacy and hexagon) not registered -- acquire_flowrate/acquire_pressure/
-# set_*/hold_* still register whenever a device is declared. Unlike gamry,
-# AliCatMFC.__init__ does NO device I/O (dev_mfcs is built from config alone)
-# and connect() failures are caught, so the server BOOTS and serves
-# /openapi.json even with no Alicat attached; a data-producing action
-# (acquire_flowrate) additionally requires the real MFC on COM6 (see
+# set_*/hold_* still register whenever a device is declared. AliCatMFC.__init__
+# opens the Alicat serial via connect(), but connect() failures are caught, so
+# the server still BOOTS and serves /openapi.json even with no Alicat attached
+# (the openapi canary passes regardless); a data-producing action
+# (acquire_flowrate) additionally requires the real MFC on COM4 -- a wrong COM
+# now fails the action fast (MfcExec fail-fast guard) instead of hanging (see
 # mfc_diff.bat / golden_capture_mfc.py).
 dummy: true
 simulation: true
@@ -32,7 +33,7 @@ servers:
     params:
       devices:
         CO2:
-          port: COM6
+          port: COM4
           unit_id: A
       co2_server_name: CO2SENSOR
   ACTVIS:

--- a/helao/deploy/hte/configs/mfc.yml
+++ b/helao/deploy/hte/configs/mfc.yml
@@ -5,8 +5,8 @@
 # (ORCH, IO, NI, SAMPLE, DB, syringes, CO2SENSOR, N2MFC, ...). The MFC params
 # (devices CO2 -> unit_id A, co2_server_name) mirror the station's real MFC
 # block so acquire_flowrate registers identically. IMPORTANT: the device COM
-# port is STATION-SPECIFIC (ccsi1 = COM9, ccsi2 = COM4); this config is set to
-# COM4 for the ccsi2 station -- point it at the real MFC COM port of whatever
+# port is STATION-SPECIFIC (ccsi1 = COM9, ccsi2 = COM6); this config is set to
+# COM6 for the ccsi2 station -- point it at the real MFC COM port of whatever
 # station you validate at, or the runtime acquire_flowrate poller opens a dead
 # port and the capture hangs (openapi canary passes regardless). This is an
 # Alicat mass flow controller (pyserial over that COM port) -- WINDOWS-ONLY.
@@ -17,7 +17,7 @@
 # opens the Alicat serial via connect(), but connect() failures are caught, so
 # the server still BOOTS and serves /openapi.json even with no Alicat attached
 # (the openapi canary passes regardless); a data-producing action
-# (acquire_flowrate) additionally requires the real MFC on COM4 -- a wrong COM
+# (acquire_flowrate) additionally requires the real MFC on COM6 -- a wrong COM
 # now fails the action fast (MfcExec fail-fast guard) instead of hanging (see
 # mfc_diff.bat / golden_capture_mfc.py).
 dummy: true
@@ -33,7 +33,7 @@ servers:
     params:
       devices:
         CO2:
-          port: COM4
+          port: COM6
           unit_id: A
       co2_server_name: CO2SENSOR
   ACTVIS:

--- a/helao/deploy/hte/configs/mfcgold.yml
+++ b/helao/deploy/hte/configs/mfcgold.yml
@@ -19,6 +19,7 @@ servers:
     port: 8009
     group: action
     fast: mfc_server
+    live_vis: mfc_vis
     params:
       devices:
         CO2:
@@ -29,7 +30,7 @@ servers:
     host: 127.0.0.1
     port: 5001
     group: visualizer
-    bokeh: action_visualizer
+    bokeh: live_visualizer
     params:
       doc_name: 'MFC Visualizer'
       launch_browser: true

--- a/helao/deploy/hte/configs/mfcgold.yml
+++ b/helao/deploy/hte/configs/mfcgold.yml
@@ -7,7 +7,7 @@
 # REAL-HARDWARE capture (see golden_capture_mfc.py docstring) -- acquire_flowrate
 # with flowrate_sccm=None only READS live telemetry (it never opens the valve
 # or commands flow; it ends by holding the valve CLOSED), but the Alicat MFC
-# must be attached on COM6 for the poller to buffer data and the capture to
+# must be attached on COM4 for the poller to buffer data and the capture to
 # produce a .hlo.
 dummy: true
 simulation: true
@@ -22,7 +22,7 @@ servers:
     params:
       devices:
         CO2:
-          port: COM6
+          port: COM4
           unit_id: A
       co2_server_name: CO2SENSOR
   ACTVIS:

--- a/helao/deploy/hte/configs/mfcgold.yml
+++ b/helao/deploy/hte/configs/mfcgold.yml
@@ -7,7 +7,7 @@
 # REAL-HARDWARE capture (see golden_capture_mfc.py docstring) -- acquire_flowrate
 # with flowrate_sccm=None only READS live telemetry (it never opens the valve
 # or commands flow; it ends by holding the valve CLOSED), but the Alicat MFC
-# must be attached on COM9 for the poller to buffer data and the capture to
+# must be attached on COM6 for the poller to buffer data and the capture to
 # produce a .hlo.
 dummy: true
 simulation: true
@@ -22,7 +22,7 @@ servers:
     params:
       devices:
         CO2:
-          port: COM9
+          port: COM6
           unit_id: A
       co2_server_name: CO2SENSOR
   ACTVIS:

--- a/helao/deploy/hte/configs/mfcgold.yml
+++ b/helao/deploy/hte/configs/mfcgold.yml
@@ -7,7 +7,7 @@
 # REAL-HARDWARE capture (see golden_capture_mfc.py docstring) -- acquire_flowrate
 # with flowrate_sccm=None only READS live telemetry (it never opens the valve
 # or commands flow; it ends by holding the valve CLOSED), but the Alicat MFC
-# must be attached on COM4 for the poller to buffer data and the capture to
+# must be attached on COM6 for the poller to buffer data and the capture to
 # produce a .hlo.
 dummy: true
 simulation: true
@@ -22,7 +22,7 @@ servers:
     params:
       devices:
         CO2:
-          port: COM4
+          port: COM6
           unit_id: A
       co2_server_name: CO2SENSOR
   ACTVIS:

--- a/helao/deploy/hte/configs/mfcgoldhex.yml
+++ b/helao/deploy/hte/configs/mfcgoldhex.yml
@@ -9,7 +9,7 @@
 # diff compares like-for-like. This is a REAL-HARDWARE capture (see
 # golden_capture_mfc.py docstring) -- acquire_flowrate with flowrate_sccm=None
 # only READS live telemetry (never opens the valve or commands flow; ends by
-# holding the valve CLOSED), but the Alicat MFC must be attached on COM4 for
+# holding the valve CLOSED), but the Alicat MFC must be attached on COM6 for
 # the poller to buffer data and the capture to produce a .hlo.
 dummy: true
 simulation: true
@@ -25,7 +25,7 @@ servers:
     params:
       devices:
         CO2:
-          port: COM4
+          port: COM6
           unit_id: A
       co2_server_name: CO2SENSOR
   ACTVIS:

--- a/helao/deploy/hte/configs/mfcgoldhex.yml
+++ b/helao/deploy/hte/configs/mfcgoldhex.yml
@@ -9,7 +9,7 @@
 # diff compares like-for-like. This is a REAL-HARDWARE capture (see
 # golden_capture_mfc.py docstring) -- acquire_flowrate with flowrate_sccm=None
 # only READS live telemetry (never opens the valve or commands flow; ends by
-# holding the valve CLOSED), but the Alicat MFC must be attached on COM6 for
+# holding the valve CLOSED), but the Alicat MFC must be attached on COM4 for
 # the poller to buffer data and the capture to produce a .hlo.
 dummy: true
 simulation: true
@@ -25,7 +25,7 @@ servers:
     params:
       devices:
         CO2:
-          port: COM6
+          port: COM4
           unit_id: A
       co2_server_name: CO2SENSOR
   ACTVIS:

--- a/helao/deploy/hte/configs/mfcgoldhex.yml
+++ b/helao/deploy/hte/configs/mfcgoldhex.yml
@@ -22,6 +22,7 @@ servers:
     group: action
     fast: mfc_server
     deployment: hexagon
+    live_vis: mfc_vis
     params:
       devices:
         CO2:
@@ -32,7 +33,7 @@ servers:
     host: 127.0.0.1
     port: 5001
     group: visualizer
-    bokeh: action_visualizer
+    bokeh: live_visualizer
     deployment: hexagon
     params:
       doc_name: 'MFC Visualizer'

--- a/helao/deploy/hte/configs/mfcgoldhex.yml
+++ b/helao/deploy/hte/configs/mfcgoldhex.yml
@@ -9,7 +9,7 @@
 # diff compares like-for-like. This is a REAL-HARDWARE capture (see
 # golden_capture_mfc.py docstring) -- acquire_flowrate with flowrate_sccm=None
 # only READS live telemetry (never opens the valve or commands flow; ends by
-# holding the valve CLOSED), but the Alicat MFC must be attached on COM9 for
+# holding the valve CLOSED), but the Alicat MFC must be attached on COM6 for
 # the poller to buffer data and the capture to produce a .hlo.
 dummy: true
 simulation: true
@@ -25,7 +25,7 @@ servers:
     params:
       devices:
         CO2:
-          port: COM9
+          port: COM6
           unit_id: A
       co2_server_name: CO2SENSOR
   ACTVIS:

--- a/helao/deploy/hte/configs/mfchex.yml
+++ b/helao/deploy/hte/configs/mfchex.yml
@@ -1,7 +1,7 @@
 # HEXAGON CANARY for the mfc_server station (P3a special-split). Copy of
 # mfc.yml with `deployment: hexagon` flipping MFC (mfc_server) and ACTVIS
 # (action_visualizer) onto the hexagon factory -- run AT-STATION (Windows,
-# Alicat MFC on COM4). mfc.yml stays legacy for rollback; the cut-over is ONLY
+# Alicat MFC on COM6). mfc.yml stays legacy for rollback; the cut-over is ONLY
 # the two `deployment: hexagon` keys. Ports/root/params match mfc.yml so an
 # on-station openapi/golden diff compares like-for-like.
 dummy: true
@@ -18,7 +18,7 @@ servers:
     params:
       devices:
         CO2:
-          port: COM4
+          port: COM6
           unit_id: A
       co2_server_name: CO2SENSOR
   ACTVIS:

--- a/helao/deploy/hte/configs/mfchex.yml
+++ b/helao/deploy/hte/configs/mfchex.yml
@@ -1,7 +1,7 @@
 # HEXAGON CANARY for the mfc_server station (P3a special-split). Copy of
 # mfc.yml with `deployment: hexagon` flipping MFC (mfc_server) and ACTVIS
 # (action_visualizer) onto the hexagon factory -- run AT-STATION (Windows,
-# Alicat MFC on COM9). mfc.yml stays legacy for rollback; the cut-over is ONLY
+# Alicat MFC on COM6). mfc.yml stays legacy for rollback; the cut-over is ONLY
 # the two `deployment: hexagon` keys. Ports/root/params match mfc.yml so an
 # on-station openapi/golden diff compares like-for-like.
 dummy: true
@@ -18,7 +18,7 @@ servers:
     params:
       devices:
         CO2:
-          port: COM9
+          port: COM6
           unit_id: A
       co2_server_name: CO2SENSOR
   ACTVIS:

--- a/helao/deploy/hte/configs/mfchex.yml
+++ b/helao/deploy/hte/configs/mfchex.yml
@@ -7,7 +7,7 @@
 dummy: true
 simulation: true
 run_type: mfc_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   MFC:
     host: 127.0.0.1
@@ -15,6 +15,7 @@ servers:
     group: action
     fast: mfc_server
     deployment: hexagon
+    live_vis: mfc_vis
     params:
       devices:
         CO2:
@@ -25,7 +26,7 @@ servers:
     host: 127.0.0.1
     port: 5001
     group: visualizer
-    bokeh: action_visualizer
+    bokeh: live_visualizer
     deployment: hexagon
     params:
       doc_name: 'MFC Visualizer'

--- a/helao/deploy/hte/configs/mfchex.yml
+++ b/helao/deploy/hte/configs/mfchex.yml
@@ -1,7 +1,7 @@
 # HEXAGON CANARY for the mfc_server station (P3a special-split). Copy of
 # mfc.yml with `deployment: hexagon` flipping MFC (mfc_server) and ACTVIS
 # (action_visualizer) onto the hexagon factory -- run AT-STATION (Windows,
-# Alicat MFC on COM6). mfc.yml stays legacy for rollback; the cut-over is ONLY
+# Alicat MFC on COM4). mfc.yml stays legacy for rollback; the cut-over is ONLY
 # the two `deployment: hexagon` keys. Ports/root/params match mfc.yml so an
 # on-station openapi/golden diff compares like-for-like.
 dummy: true
@@ -18,7 +18,7 @@ servers:
     params:
       devices:
         CO2:
-          port: COM6
+          port: COM4
           unit_id: A
       co2_server_name: CO2SENSOR
   ACTVIS:

--- a/helao/deploy/hte/configs/ni.yml
+++ b/helao/deploy/hte/configs/ni.yml
@@ -24,13 +24,14 @@
 dummy: true
 simulation: true
 run_type: nidaqmx_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   NI:
     host: 127.0.0.1
     port: 8006
     group: action
     fast: nidaqmx_server
+    action_vis: nidaqmx_vis
     params:
       dev_gasvalve:
         1A: cDAQ1Mod1/port0/line0

--- a/helao/deploy/hte/configs/nihex.yml
+++ b/helao/deploy/hte/configs/nihex.yml
@@ -14,7 +14,7 @@
 dummy: true
 simulation: true
 run_type: nidaqmx_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   NI:
     host: 127.0.0.1
@@ -22,6 +22,7 @@ servers:
     group: action
     fast: nidaqmx_server
     deployment: hexagon
+    action_vis: nidaqmx_vis
     params:
       dev_gasvalve:
         1A: cDAQ1Mod1/port0/line0

--- a/helao/deploy/hte/configs/powersupply.yml
+++ b/helao/deploy/hte/configs/powersupply.yml
@@ -24,7 +24,7 @@
 dummy: true
 simulation: true
 run_type: power_supply
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   POWER_SUPPLY:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/powersupplyhex.yml
+++ b/helao/deploy/hte/configs/powersupplyhex.yml
@@ -17,7 +17,7 @@
 dummy: true
 simulation: true
 run_type: power_supply
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   POWER_SUPPLY:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/spec.yml
+++ b/helao/deploy/hte/configs/spec.yml
@@ -12,13 +12,14 @@
 dummy: true
 simulation: true
 run_type: spec_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   SPEC:
     host: 127.0.0.1
     port: 8011
     group: action
     fast: spec_server
+    action_vis: spec_vis
     params:
       dev_num: 0
       lib_path: C:\Spectral Products\SM32ProForUSB\SDK Examples\DLL\x64\stdcall\SPdbUSBm.dll

--- a/helao/deploy/hte/configs/specgold.yml
+++ b/helao/deploy/hte/configs/specgold.yml
@@ -17,6 +17,7 @@ servers:
     port: 8011
     group: action
     fast: spec_server
+    action_vis: spec_vis
     params:
       dev_num: 0
       lib_path: C:\Spectral Products\SM32ProForUSB\SDK Examples\DLL\x64\stdcall\SPdbUSBm.dll

--- a/helao/deploy/hte/configs/specgoldhex.yml
+++ b/helao/deploy/hte/configs/specgoldhex.yml
@@ -21,6 +21,7 @@ servers:
     group: action
     fast: spec_server
     deployment: hexagon
+    action_vis: spec_vis
     params:
       dev_num: 0
       lib_path: C:\Spectral Products\SM32ProForUSB\SDK Examples\DLL\x64\stdcall\SPdbUSBm.dll

--- a/helao/deploy/hte/configs/spechex.yml
+++ b/helao/deploy/hte/configs/spechex.yml
@@ -7,7 +7,7 @@
 dummy: true
 simulation: true
 run_type: spec_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   SPEC:
     host: 127.0.0.1
@@ -15,6 +15,7 @@ servers:
     group: action
     fast: spec_server
     deployment: hexagon
+    action_vis: spec_vis
     params:
       dev_num: 0
       lib_path: C:\Spectral Products\SM32ProForUSB\SDK Examples\DLL\x64\stdcall\SPdbUSBm.dll

--- a/helao/deploy/hte/configs/syringe.yml
+++ b/helao/deploy/hte/configs/syringe.yml
@@ -19,7 +19,7 @@
 dummy: true
 simulation: true
 run_type: syringe_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   WORKSYRINGE:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/syringehex.yml
+++ b/helao/deploy/hte/configs/syringehex.yml
@@ -8,7 +8,7 @@
 dummy: true
 simulation: true
 run_type: syringe_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   WORKSYRINGE:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/tec.yml
+++ b/helao/deploy/hte/configs/tec.yml
@@ -18,7 +18,7 @@
 dummy: true
 simulation: true
 run_type: tec_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   TEC:
     host: 127.0.0.1

--- a/helao/deploy/hte/configs/techex.yml
+++ b/helao/deploy/hte/configs/techex.yml
@@ -8,7 +8,7 @@
 dummy: true
 simulation: true
 run_type: tec_server
-root: C:\INST_hlo
+root: C:\INST_hlo_golden
 servers:
   TEC:
     host: 127.0.0.1

--- a/helao/deploy/hte/drivers/mfc/alicat_driver.py
+++ b/helao/deploy/hte/drivers/mfc/alicat_driver.py
@@ -78,6 +78,16 @@ class AliCatMFC(HelaoDriver):
 
         self.polling = True
         self.last_state = "unknown"
+        # Open the Alicat serial connections at construction. BaseAPI builds the
+        # AliCatMFCPoller immediately after the driver and the poller AUTO-STARTS
+        # its poll loop in __init__ -- but BaseAPI never calls connect(), so
+        # deferring the serial open left self.fcs empty: the poller produced no
+        # data, the live buffer key never appeared, and acquire_flowrate's
+        # MfcExec._poll (get_lbuf) never advanced -> the capture hung. Connect
+        # here (like the biologic/andor/SprintIR drivers) so the controllers are
+        # open before the first poll; a bad/absent port logs a clear
+        # "connect failed" instead. get_data() already no-ops on empty fcs.
+        self.connect()
 
     def connect(self) -> DriverResponse:
         """Open every configured Alicat and query its gas/identity registers.
@@ -230,13 +240,12 @@ class AliCatMFC(HelaoDriver):
         except Exception as e:
             LOGGER.info(f"Exception occured on get_status() {e}. Resetting MFC.")
             self.make_fc_instance(device_name, self.config_dict["devices"][device_name])
-            self.fcs[device_name]._set_control_point(
-                self.fcs_last_mode[device_name], 5
-            )
+            self.fcs[device_name]._set_control_point(self.fcs_last_mode[device_name], 5)
             LOGGER.info("MFC connection restored")
             return None
         if all(
-            x in resp_dict for x in ("mass_flow", "pressure", "setpoint", "control_point")
+            x in resp_dict
+            for x in ("mass_flow", "pressure", "setpoint", "control_point")
         ):
             self.fcs_last_mode[device_name] = resp_dict["control_point"]
             return resp_dict
@@ -1092,12 +1101,8 @@ class FlowMeter(object):
             IOError: When `self.open` is False.
         """
         if not self.open:
-            raise IOError(
-                "The FlowController with address {} and \
-                          port {} is not open".format(
-                    self.address, self.port
-                )
-            )
+            raise IOError("The FlowController with address {} and \
+                          port {} is not open".format(self.address, self.port))
 
     def get_status(self, retries=5) -> dict:
         """Read the current device state.

--- a/helao/deploy/hte/drivers/mfc/alicat_driver.py
+++ b/helao/deploy/hte/drivers/mfc/alicat_driver.py
@@ -509,8 +509,34 @@ class MfcExec(Executor):
         LOGGER.info("MfcExec initialized.")
         self.duration = self.active.action.action_params.get("duration", -1)
 
+    def _device_not_connected_error(self) -> Optional[dict]:
+        """Fail-fast terminal error when this exec's MFC device isn't connected.
+
+        A failed ``AliCatMFC.connect()`` (e.g. a wrong/absent COM port) leaves
+        the driver's ``fcs`` empty, so the poller never populates the live
+        buffer and ``_poll``'s ``get_lbuf(device_name)`` would ``KeyError``
+        mid-loop -- and because that escaped before the action was finalized,
+        the ``-act.yml`` never reached a terminal status and a golden capture /
+        caller hung waiting out its timeout. Returning a non-``none`` error from
+        ``_pre_exec`` makes ``action_loop_task`` ``finish()`` the action
+        ``errored`` immediately, with a clear reason, instead. Returns ``None``
+        when the device is connected.
+        """
+        fcs = getattr(self.active.driver, "fcs", {}) or {}
+        if self.device_name not in fcs:
+            LOGGER.error(
+                f"MFC device {self.device_name!r} is not connected "
+                f"(driver.fcs={list(fcs)}); check the device COM port and power. "
+                "Aborting action (fail-fast)."
+            )
+            return {"error": ErrorCodes.critical_error}
+        return None
+
     async def _pre_exec(self) -> dict:
         """Set the flow rate (and ramp) for the configured device."""
+        guard = self._device_not_connected_error()
+        if guard is not None:
+            return guard
         LOGGER.info("MfcExec running setup methods.")
         self.flowrate_sccm = self.active.action.action_params.get("flowrate_sccm", None)
         self.ramp_sccm_sec = self.active.action.action_params.get("ramp_sccm_sec", 0)
@@ -586,6 +612,9 @@ class PfcExec(MfcExec):
 
     async def _pre_exec(self) -> dict:
         """Set the target pressure (and ramp) on the configured device."""
+        guard = self._device_not_connected_error()
+        if guard is not None:
+            return guard
         LOGGER.info("PfcExec running setup methods.")
         self.pressure_psia = self.active.action.action_params.get("pressure_psia", None)
         self.ramp_psi_sec = self.active.action.action_params.get("ramp_psi_sec", 0)
@@ -653,6 +682,9 @@ class MfcConstPresExec(MfcExec):
 
     async def _pre_exec(self) -> dict:
         """Set the refill flow rate on the device before the loop starts."""
+        guard = self._device_not_connected_error()
+        if guard is not None:
+            return guard
         LOGGER.info("MfcConstPresExec running setup methods.")
         rate_resp = await self.active.driver.set_flowrate(
             device_name=self.device_name,
@@ -806,6 +838,9 @@ class MfcConstConcExec(MfcExec):
 
     async def _pre_exec(self) -> dict:
         """Set the refill flow rate on the device before the loop starts."""
+        guard = self._device_not_connected_error()
+        if guard is not None:
+            return guard
         LOGGER.info("MfcConstConcExec running setup methods.")
         rate_resp = await self.active.driver.set_flowrate(
             device_name=self.device_name,

--- a/helao/deploy/hte/drivers/pump/legato_driver.py
+++ b/helao/deploy/hte/drivers/pump/legato_driver.py
@@ -29,7 +29,6 @@ from helao.core.drivers.helao_driver import (
     DriverPoller,
 )
 
-
 """ Notes:
 
 Setup serial connection with pyserial module:
@@ -91,6 +90,14 @@ ulmap = {
     "ul": 1.0,
     "ml": 1000.0,
 }
+
+
+# Upper bound on the "\x11" end-of-response re-read loop in send()/_send_sync().
+# A non-responding or disconnected pump must not loop there forever holding
+# com_lock (which would deadlock every other command, including safe_state on
+# shutdown). Normal responses complete in milliseconds; this only caps the
+# pathological case.
+_POLL_READ_TIMEOUT_S = 5.0
 
 
 class KDS100(HelaoDriver):
@@ -228,16 +235,24 @@ class KDS100(HelaoDriver):
         while self.com_lock:
             await asyncio.sleep(0.1)
         self.com_lock = True
-        self.sio.write(command_str)
-        self.sio.flush()
-        resp = [x.strip() for x in self.sio.readlines() if x.strip()]
-        # look for "\x11" end of response character when POLL is on
-        if resp:
-            while not resp[-1].endswith("\x11"):
-                time.sleep(0.1)  # wait 100 msec and re-read, response
-                newlines = [x.strip() for x in self.sio.readlines() if x.strip()]
-                resp += newlines
-        self.com_lock = False
+        try:
+            self.sio.write(command_str)
+            self.sio.flush()
+            resp = [x.strip() for x in self.sio.readlines() if x.strip()]
+            # Re-read until the "\x11" end-of-response marker (POLL mode), but
+            # BOUND it: a non-responding/disconnected pump would otherwise loop
+            # here forever while holding com_lock. `await` (not time.sleep) so
+            # the event loop keeps running during the wait.
+            if resp:
+                deadline = time.time() + _POLL_READ_TIMEOUT_S
+                while not resp[-1].endswith("\x11") and time.time() < deadline:
+                    await asyncio.sleep(0.1)
+                    newlines = [x.strip() for x in self.sio.readlines() if x.strip()]
+                    resp += newlines
+        finally:
+            # ALWAYS release the lock -- a leak here would deadlock every
+            # subsequent command (and safe_state on shutdown).
+            self.com_lock = False
         return resp
 
     def _send_sync(self, pump_name: str, cmd: str) -> list:
@@ -262,15 +277,21 @@ class KDS100(HelaoDriver):
         while self.com_lock:
             time.sleep(0.1)
         self.com_lock = True
-        self.sio.write(command_str)
-        self.sio.flush()
-        resp = [x.strip() for x in self.sio.readlines() if x.strip()]
-        if resp:
-            while not resp[-1].endswith("\x11"):
-                time.sleep(0.1)
-                newlines = [x.strip() for x in self.sio.readlines() if x.strip()]
-                resp += newlines
-        self.com_lock = False
+        try:
+            self.sio.write(command_str)
+            self.sio.flush()
+            resp = [x.strip() for x in self.sio.readlines() if x.strip()]
+            # BOUND the "\x11" re-read (see send()): a non-responding pump must
+            # not loop forever holding com_lock. Sync sleep -- the poller calls
+            # this synchronously via get_data().
+            if resp:
+                deadline = time.time() + _POLL_READ_TIMEOUT_S
+                while not resp[-1].endswith("\x11") and time.time() < deadline:
+                    time.sleep(0.1)
+                    newlines = [x.strip() for x in self.sio.readlines() if x.strip()]
+                    resp += newlines
+        finally:
+            self.com_lock = False
         return resp
 
     def update_status_from_response(self, response):

--- a/helao/deploy/hte/drivers/sensor/sprintir_driver.py
+++ b/helao/deploy/hte/drivers/sensor/sprintir_driver.py
@@ -67,6 +67,14 @@ class SprintIR(HelaoDriver):
         self.last_rec_time = 0
         self.recording_duration = 0
         self.recording_rate = 0.1  # seconds per acquisition
+        # Open the serial port at construction. BaseAPI builds the DriverPoller
+        # (SprintIRPoller) immediately after the driver and the poller AUTO-STARTS
+        # its poll loop in __init__ -- but BaseAPI never calls connect(), so
+        # deferring the serial open left self.com=None and the poller spammed
+        # "'NoneType' object has no attribute 'flush'" every cycle. Connecting
+        # here (like the biologic/andor drivers) opens the port before the first
+        # poll; a bad/absent port logs a clear "connect failed" instead.
+        self.connect()
 
     def connect(self) -> DriverResponse:
         """Open the serial port, set polling mode, and read firmware scaling.
@@ -195,6 +203,8 @@ class SprintIR(HelaoDriver):
             Tuple ``(cmd_resp, aux_resp)`` of lines beginning with the command
             character versus everything else.
         """
+        if self.com is None:
+            raise RuntimeError("SprintIR serial port is not connected")
         if not command_str.endswith("\r\n"):
             command_str = command_str + "\r\n"
         self.com.write(command_str.encode("utf8"))
@@ -224,6 +234,8 @@ class SprintIR(HelaoDriver):
             The latest filtered CO2 value as a string, or ``False`` if no
             valid reading was found.
         """
+        if self.com is None:
+            raise RuntimeError("SprintIR serial port is not connected")
         self.com.flush()
         lines, _ = self.send("Z")
         for line in lines[::-1]:
@@ -236,6 +248,8 @@ class SprintIR(HelaoDriver):
 
     def reset_polling_mode(self) -> None:
         """Re-issue the polling-mode command (used after consecutive blank reads)."""
+        if self.com is None:
+            return
         self.com.write(b"K 2\r\n")
 
 

--- a/helao/hexagon/tests/smoke/andor_canary.bat
+++ b/helao/hexagon/tests/smoke/andor_canary.bat
@@ -152,10 +152,14 @@ REM 0) GRACEFUL shutdown FIRST so the AndorDriver's shutdown() runs:
 REM AndorDriver.shutdown() disconnects the camera (cam.close()), releasing the
 REM vendor SDK handle. A hard kill skips this and may leave the device claimed
 REM for the next launch -- best-effort (server dies mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8011
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/andor_canary.bat
+++ b/helao/hexagon/tests/smoke/andor_canary.bat
@@ -32,7 +32,7 @@ REM   outdir default %TEMP%\andor_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\andor_canary"
 

--- a/helao/hexagon/tests/smoke/andor_diff.bat
+++ b/helao/hexagon/tests/smoke/andor_diff.bat
@@ -205,10 +205,14 @@ REM 0) GRACEFUL shutdown FIRST so the AndorDriver's shutdown() runs:
 REM AndorDriver.shutdown() disconnects the camera (cam.close()), releasing the
 REM vendor SDK handle. A hard kill skips this and may leave the device claimed
 REM for the next launch. Best-effort (server dies mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%CAPROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8011
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit this console.
 REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can

--- a/helao/hexagon/tests/smoke/biologic_canary.bat
+++ b/helao/hexagon/tests/smoke/biologic_canary.bat
@@ -33,7 +33,7 @@ REM   outdir default %TEMP%\biologic_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\biologic_canary"
 

--- a/helao/hexagon/tests/smoke/biologic_canary.bat
+++ b/helao/hexagon/tests/smoke/biologic_canary.bat
@@ -155,10 +155,14 @@ REM easy_biologic TCP connection (clearing connection_raised so the next launch
 REM can reconnect). A hard kill skips this and may leave the instrument's
 REM connection claimed for the next launch -- best-effort (server dies
 REM mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8016
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/biologic_diff.bat
+++ b/helao/hexagon/tests/smoke/biologic_diff.bat
@@ -199,10 +199,14 @@ REM easy_biologic TCP connection (clearing connection_raised so the next launch
 REM can reconnect). A hard kill skips this and may leave the instrument's
 REM connection claimed for the next launch. Best-effort (server dies
 REM mid-response); then wait for release.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%CAPROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8016
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit this console.
 REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can

--- a/helao/hexagon/tests/smoke/cam_canary.bat
+++ b/helao/hexagon/tests/smoke/cam_canary.bat
@@ -156,10 +156,14 @@ REM 0) GRACEFUL shutdown FIRST so the cam driver's shutdown() runs cleanly.
 REM AxisCam holds no persistent hardware handle (HTTP-per-frame), but this
 REM matches every other canary's kill sequence -- best-effort (server dies
 REM mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8013
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/cam_canary.bat
+++ b/helao/hexagon/tests/smoke/cam_canary.bat
@@ -36,7 +36,7 @@ REM   outdir default %TEMP%\cam_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\cam_canary"
 

--- a/helao/hexagon/tests/smoke/cam_diff.bat
+++ b/helao/hexagon/tests/smoke/cam_diff.bat
@@ -192,10 +192,14 @@ REM 0) GRACEFUL shutdown FIRST so the cam driver's shutdown() runs cleanly.
 REM AxisCam holds no persistent hardware handle (HTTP-per-frame), but this
 REM matches every other canary's kill sequence -- best-effort (server dies
 REM mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%CAPROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8013
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit this console.
 REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/co2_canary.bat
+++ b/helao/hexagon/tests/smoke/co2_canary.bat
@@ -32,7 +32,7 @@ REM   outdir default %TEMP%\co2_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\co2_canary"
 

--- a/helao/hexagon/tests/smoke/co2_canary.bat
+++ b/helao/hexagon/tests/smoke/co2_canary.bat
@@ -152,10 +152,14 @@ REM 0) GRACEFUL shutdown FIRST so the SprintIR driver's shutdown() runs:
 REM SprintIR.shutdown() closes the serial port (COM12). A hard kill skips this
 REM and may leave the port claimed for the next launch -- best-effort (server
 REM dies mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8012
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/co2_diff.bat
+++ b/helao/hexagon/tests/smoke/co2_diff.bat
@@ -194,10 +194,14 @@ REM 0) GRACEFUL shutdown FIRST so the SprintIR driver's shutdown() runs:
 REM SprintIR.shutdown() closes the serial port (COM12). A hard kill skips this
 REM and may leave the port claimed for the next launch.
 REM Best-effort (server dies mid-response); then wait for release.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%CAPROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8012
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit this console.
 REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can

--- a/helao/hexagon/tests/smoke/diapump_canary.bat
+++ b/helao/hexagon/tests/smoke/diapump_canary.bat
@@ -33,7 +33,7 @@ REM   outdir default %TEMP%\diapump_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\diapump_canary"
 

--- a/helao/hexagon/tests/smoke/diapump_canary.bat
+++ b/helao/hexagon/tests/smoke/diapump_canary.bat
@@ -153,10 +153,14 @@ REM 0) GRACEFUL shutdown FIRST so the diapump driver's shutdown() runs cleanly.
 REM The dosing pump holds a serial COM handle in a real deployment; graceful
 REM shutdown lets the driver release it. Best-effort (server may die
 REM mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8016
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/galil_canary.bat
+++ b/helao/hexagon/tests/smoke/galil_canary.bat
@@ -34,7 +34,7 @@ REM   outdir default %TEMP%\galil_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\galil_canary"
 

--- a/helao/hexagon/tests/smoke/galil_canary.bat
+++ b/helao/hexagon/tests/smoke/galil_canary.bat
@@ -155,10 +155,14 @@ REM Galil.shutdown() calls self.g.GClose() (releases the gclib TCP connection
 REM to the controller). A hard kill skips this and may leave the controller
 REM holding a stale connection slot -- best-effort (server dies mid-response);
 REM then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8003
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/galil_diff.bat
+++ b/helao/hexagon/tests/smoke/galil_diff.bat
@@ -195,10 +195,14 @@ REM 0) GRACEFUL shutdown FIRST so the galil driver's shutdown() runs:
 REM Galil.shutdown() calls self.g.GClose() (releases the gclib TCP connection
 REM to the controller) and cancels the aligner IO task. A hard kill skips
 REM this. Best-effort (server dies mid-response); then wait for release.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%CAPROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8003
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit this console.
 REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can

--- a/helao/hexagon/tests/smoke/galilio_canary.bat
+++ b/helao/hexagon/tests/smoke/galilio_canary.bat
@@ -160,10 +160,14 @@ REM Galil.shutdown() calls self.g.GClose() (releases the gclib TCP connection
 REM to the controller). A hard kill skips this and may leave the controller
 REM holding a stale connection slot -- best-effort (server dies mid-response);
 REM then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8005
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/galilio_canary.bat
+++ b/helao/hexagon/tests/smoke/galilio_canary.bat
@@ -39,7 +39,7 @@ REM   outdir default %TEMP%\galilio_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\galilio_canary"
 

--- a/helao/hexagon/tests/smoke/galilio_diff.bat
+++ b/helao/hexagon/tests/smoke/galilio_diff.bat
@@ -196,10 +196,14 @@ REM 0) GRACEFUL shutdown FIRST so the galil driver's shutdown() runs:
 REM Galil.shutdown() calls self.g.GClose() (releases the gclib TCP connection
 REM to the controller). A hard kill skips this. Best-effort (server dies
 REM mid-response); then wait for release.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%CAPROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8005
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit this console.
 REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can

--- a/helao/hexagon/tests/smoke/gamryhex_canary.bat
+++ b/helao/hexagon/tests/smoke/gamryhex_canary.bat
@@ -154,10 +154,14 @@ REM disconnect() closes the pstat (releases the GamryCOM device) and
 REM kill_gamrycom() terminates GamryCOM.exe. A hard kill skips this and LEAKS
 REM the device lock -> a later gamry launch fails 'CGamryPstat - In use by
 REM another script'. Best-effort (server dies mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8001
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/gamryhex_canary.bat
+++ b/helao/hexagon/tests/smoke/gamryhex_canary.bat
@@ -33,7 +33,7 @@ REM   outdir default %TEMP%\gamryhex_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\gamryhex_canary"
 

--- a/helao/hexagon/tests/smoke/golden_capture_mfc.py
+++ b/helao/hexagon/tests/smoke/golden_capture_mfc.py
@@ -12,9 +12,9 @@ only. (One difference from gamry: ``AliCatMFC.__init__`` does NO device I/O and
 ``connect()`` exceptions are caught, so the server still BOOTS + serves
 /openapi.json with no MFC attached -- that is what the openapi mfc_canary.bat
 relies on. This RUNTIME capture, however, needs the live device: with no Alicat
-on COM4 the poller buffers nothing and ``MfcExec._poll`` errors reading an empty
+on COM6 the poller buffers nothing and ``MfcExec._poll`` errors reading an empty
 live buffer.) So this capture rig is an AT-STATION, REAL-HARDWARE gate: the
-Alicat MFC must be attached on COM4 for ``acquire_flowrate`` to produce data.
+Alicat MFC must be attached on COM6 for ``acquire_flowrate`` to produce data.
 
 SAFETY -- why acquire_flowrate is the non-perturbing choice
 -----------------------------------------------------------
@@ -113,7 +113,7 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 CONFIG_DIR = REPO_ROOT / "helao" / "deploy" / "hte" / "configs"
 
 # The single MFC device declared in the mfc*.yml MFC block (ccsi1.yml verbatim:
-# devices: {CO2: {port: COM4, unit_id: A}}). devices[0] == "CO2" is the endpoint
+# devices: {CO2: {port: COM6, unit_id: A}}). devices[0] == "CO2" is the endpoint
 # default for device_name; passed explicitly here so both captures target the
 # same controller deterministically.
 DEVICE_NAME = "CO2"
@@ -220,14 +220,14 @@ def snapshot(
             f"[golden_capture_mfc] WARNING: {len(errored)} action(s) ERRORED "
             f"and were still captured: {errored}. An errored run is NOT a valid "
             "parity baseline. Check the -act.yml error fields and the MFC log "
-            "before trusting a PASS (e.g. no Alicat on COM4 -> empty live buffer)."
+            "before trusting a PASS (e.g. no Alicat on COM6 -> empty live buffer)."
         )
     if not hlos:
         print(
             f"[golden_capture_mfc] WARNING: no .hlo captured under {root} -- "
             "acquire_flowrate produced no telemetry data file. Parity will "
             "compare -act.yml metadata only, NOT the hlo data-write path. Verify "
-            "the Alicat MFC is attached on COM4 and the poller is buffering data."
+            "the Alicat MFC is attached on COM6 and the poller is buffering data."
         )
     out_root = out_dir / "root"
     out_root.mkdir(parents=True)
@@ -240,7 +240,7 @@ def snapshot(
     ).stdout.strip()
     config_path = CONFIG_DIR / f"{config_prefix}.yml"
     combined_notes = (
-        "REAL-HARDWARE acquire_flowrate capture (Alicat MFC attached on COM4); "
+        "REAL-HARDWARE acquire_flowrate capture (Alicat MFC attached on COM6); "
         "NOT a simulation -- AliCatMFC has no sim/dummy data path. Dispatched "
         "with flowrate_sccm=None so the MFC valve is NEVER opened and NO flow is "
         "commanded (pure telemetry read; ends valve-closed). The .hlo body "

--- a/helao/hexagon/tests/smoke/golden_capture_mfc.py
+++ b/helao/hexagon/tests/smoke/golden_capture_mfc.py
@@ -12,9 +12,9 @@ only. (One difference from gamry: ``AliCatMFC.__init__`` does NO device I/O and
 ``connect()`` exceptions are caught, so the server still BOOTS + serves
 /openapi.json with no MFC attached -- that is what the openapi mfc_canary.bat
 relies on. This RUNTIME capture, however, needs the live device: with no Alicat
-on COM9 the poller buffers nothing and ``MfcExec._poll`` errors reading an empty
+on COM4 the poller buffers nothing and ``MfcExec._poll`` errors reading an empty
 live buffer.) So this capture rig is an AT-STATION, REAL-HARDWARE gate: the
-Alicat MFC must be attached on COM9 for ``acquire_flowrate`` to produce data.
+Alicat MFC must be attached on COM4 for ``acquire_flowrate`` to produce data.
 
 SAFETY -- why acquire_flowrate is the non-perturbing choice
 -----------------------------------------------------------
@@ -113,7 +113,7 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 CONFIG_DIR = REPO_ROOT / "helao" / "deploy" / "hte" / "configs"
 
 # The single MFC device declared in the mfc*.yml MFC block (ccsi1.yml verbatim:
-# devices: {CO2: {port: COM9, unit_id: A}}). devices[0] == "CO2" is the endpoint
+# devices: {CO2: {port: COM4, unit_id: A}}). devices[0] == "CO2" is the endpoint
 # default for device_name; passed explicitly here so both captures target the
 # same controller deterministically.
 DEVICE_NAME = "CO2"
@@ -220,14 +220,14 @@ def snapshot(
             f"[golden_capture_mfc] WARNING: {len(errored)} action(s) ERRORED "
             f"and were still captured: {errored}. An errored run is NOT a valid "
             "parity baseline. Check the -act.yml error fields and the MFC log "
-            "before trusting a PASS (e.g. no Alicat on COM9 -> empty live buffer)."
+            "before trusting a PASS (e.g. no Alicat on COM4 -> empty live buffer)."
         )
     if not hlos:
         print(
             f"[golden_capture_mfc] WARNING: no .hlo captured under {root} -- "
             "acquire_flowrate produced no telemetry data file. Parity will "
             "compare -act.yml metadata only, NOT the hlo data-write path. Verify "
-            "the Alicat MFC is attached on COM9 and the poller is buffering data."
+            "the Alicat MFC is attached on COM4 and the poller is buffering data."
         )
     out_root = out_dir / "root"
     out_root.mkdir(parents=True)
@@ -240,7 +240,7 @@ def snapshot(
     ).stdout.strip()
     config_path = CONFIG_DIR / f"{config_prefix}.yml"
     combined_notes = (
-        "REAL-HARDWARE acquire_flowrate capture (Alicat MFC attached on COM9); "
+        "REAL-HARDWARE acquire_flowrate capture (Alicat MFC attached on COM4); "
         "NOT a simulation -- AliCatMFC has no sim/dummy data path. Dispatched "
         "with flowrate_sccm=None so the MFC valve is NEVER opened and NO flow is "
         "commanded (pure telemetry read; ends valve-closed). The .hlo body "

--- a/helao/hexagon/tests/smoke/golden_diff.bat
+++ b/helao/hexagon/tests/smoke/golden_diff.bat
@@ -194,10 +194,14 @@ REM disconnect() closes the pstat (releases the exclusive GamryCOM device) and
 REM kill_gamrycom() terminates GamryCOM.exe. A hard kill skips this and LEAKS
 REM the device lock -> the next launch fails 'CGamryPstat - In use by another
 REM script'. Best-effort (server dies mid-response); then wait for release.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%CAPROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8001
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit this console.
 REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can

--- a/helao/hexagon/tests/smoke/kill_group.py
+++ b/helao/hexagon/tests/smoke/kill_group.py
@@ -1,6 +1,33 @@
-"""Terminate a launched goldenhex group via its pid pickle (the same
-STATES/pids_<prefix>_<extraopt>.pck contract launch.py maintains)."""
+"""Snapshot + terminate a launched HELAO group (its pid-pickle servers PLUS the
+launch.py monitor that owns the console window).
 
+Two-phase so the PIDs are captured BEFORE a graceful ``/shutdown`` perturbs the
+group and BEFORE launch.py's own ``Pidd.close()`` can remove the pickle
+(launch.py:394 removes ``STATES/pids_<prefix>_.pck`` once all servers are down):
+
+    kill_group.py <root> <prefix> --snapshot <file>   # read PIDs -> <file>, no kill
+    kill_group.py --from-snapshot <file>              # terminate the snapshotted PIDs
+
+Legacy one-shot (read pickle + kill now) still works:
+
+    kill_group.py <root> <prefix>
+
+Why also kill the launch.py monitor: the pickle records only the child servers,
+so terminating those leaves the ``launch.py`` process (and its ``start "..."``
+console window) alive. We find it by command line at snapshot time and kill it
+by PID, which closes the window without the fragility of a post-hoc WMI/taskkill
+command-line match.
+
+Path-robustness: a station's launch may write the pickle under a root that
+differs from the arg passed here (e.g. an extra ``\\TEST`` segment), which made
+the exact ``<root>/STATES/...`` lookup miss. If the exact path is absent we glob
+for ``pids_<prefix>_*.pck`` under the root and its parent.
+"""
+
+import argparse
+import glob
+import json
+import os
 import pickle
 import sys
 import time
@@ -8,28 +35,119 @@ import time
 import psutil
 
 
-def main(root: str, prefix: str = "goldenhex") -> int:
-    pck = f"{root}/STATES/pids_{prefix}_.pck"
-    try:
-        pidd = pickle.load(open(pck, "rb"))
-    except FileNotFoundError:
-        print(f"no pid pickle at {pck}; nothing to kill")
-        return 0
+def _find_pickle(root: str, prefix: str):
+    """Locate the group's pid pickle, tolerating a root/path mismatch."""
+    exact = os.path.join(root, "STATES", f"pids_{prefix}_.pck")
+    if os.path.exists(exact):
+        return exact
+    for base in (root, os.path.dirname(root.rstrip("/\\"))):
+        if not base:
+            continue
+        hits = glob.glob(
+            os.path.join(base, "**", f"pids_{prefix}_*.pck"), recursive=True
+        )
+        if hits:
+            return sorted(hits)[0]
+    return None
+
+
+def _launcher_pid(prefix: str):
+    """PID of the ``launch.py <prefix> --no-hot-reload`` monitor, or None."""
+    needle = f"launch.py {prefix} --no-hot-reload"
+    for p in psutil.process_iter(["pid", "cmdline"]):
+        try:
+            cmdline = " ".join(p.info.get("cmdline") or [])
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        if needle in cmdline:
+            return p.info["pid"]
+    return None
+
+
+def _collect(root: str, prefix: str) -> dict:
+    """Map of label -> pid for the group's servers plus its launch.py monitor."""
+    pids: dict = {}
+    pck = _find_pickle(root, prefix)
+    if pck is None:
+        print(f"no pid pickle for prefix '{prefix}' under {root}")
+    else:
+        try:
+            pidd = pickle.load(open(pck, "rb"))
+            for key, entry in pidd.items():
+                pid = entry.get("pid") if isinstance(entry, dict) else None
+                if pid:
+                    pids[str(key)] = pid
+        except Exception as exc:  # noqa: BLE001 -- best-effort teardown
+            print(f"could not read {pck}: {exc}")
+    launcher = _launcher_pid(prefix)
+    if launcher:
+        pids["__launcher__"] = launcher
+    return pids
+
+
+def _kill(pids: dict) -> None:
+    """Terminate then SIGKILL the given pids (servers first is fine here)."""
     procs = []
-    for key, entry in pidd.items():
-        pid = entry.get("pid") if isinstance(entry, dict) else None
+    for label, pid in pids.items():
         if pid and psutil.pid_exists(pid):
-            p = psutil.Process(pid)
-            print(f"terminating {key} (pid {pid})")
+            try:
+                p = psutil.Process(pid)
+            except psutil.NoSuchProcess:
+                continue
+            print(f"terminating {label} (pid {pid})")
             p.terminate()
             procs.append(p)
     _gone, alive = psutil.wait_procs(procs, timeout=10)
     for p in alive:
         print(f"SIGKILL {p.pid}")
-        p.kill()
+        try:
+            p.kill()
+        except psutil.NoSuchProcess:
+            pass
     time.sleep(1)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="snapshot/kill a launched HELAO group")
+    ap.add_argument("root", nargs="?")
+    ap.add_argument("prefix", nargs="?", default="goldenhex")
+    ap.add_argument(
+        "--snapshot", help="write collected PIDs to this JSON file (no kill)"
+    )
+    ap.add_argument(
+        "--from-snapshot", help="terminate the PIDs recorded in this JSON file"
+    )
+    a = ap.parse_args(argv)
+
+    if a.from_snapshot:
+        try:
+            pids = json.load(open(a.from_snapshot))
+        except (OSError, ValueError) as exc:
+            print(f"no snapshot to kill ({a.from_snapshot}): {exc}")
+            return 0
+        _kill(pids)
+        return 0
+
+    if a.root is None:
+        print(
+            "usage: kill_group.py <root> <prefix> "
+            "[--snapshot FILE | --from-snapshot FILE]"
+        )
+        return 2
+
+    pids = _collect(a.root, a.prefix)
+    if a.snapshot:
+        with open(a.snapshot, "w") as f:
+            json.dump(pids, f)
+        print(f"snapshot {pids} -> {a.snapshot}")
+        return 0
+
+    if not pids:
+        print(f"nothing to kill for prefix '{a.prefix}'")
+        return 0
+    _kill(pids)
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1], sys.argv[2] if len(sys.argv) > 2 else "goldenhex"))
+    sys.exit(main())

--- a/helao/hexagon/tests/smoke/kmotor_canary.bat
+++ b/helao/hexagon/tests/smoke/kmotor_canary.bat
@@ -45,7 +45,7 @@ REM   outdir default %TEMP%\kmotor_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\kmotor_canary"
 

--- a/helao/hexagon/tests/smoke/kmotor_canary.bat
+++ b/helao/hexagon/tests/smoke/kmotor_canary.bat
@@ -166,10 +166,14 @@ REM KinesisMotor.disconnect() calls kmotor.close() for every configured axis
 REM (releases the pylablib handle on the Thorlabs device). A hard kill skips
 REM this and may leave the device's USB/serial handle reserved for the next
 REM launch -- best-effort (server dies mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8015
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/mfc_canary.bat
+++ b/helao/hexagon/tests/smoke/mfc_canary.bat
@@ -155,10 +155,14 @@ REM it stops polling, closes all valves (safe state -- no gas flow), then closes
 REM every serial connection, releasing the COM port for the next launch. A hard
 REM kill skips this and may leave the COM port claimed / a valve latched --
 REM best-effort (server dies mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8009
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/mfc_canary.bat
+++ b/helao/hexagon/tests/smoke/mfc_canary.bat
@@ -34,7 +34,7 @@ REM   outdir default %TEMP%\mfc_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\mfc_canary"
 

--- a/helao/hexagon/tests/smoke/mfc_diff.bat
+++ b/helao/hexagon/tests/smoke/mfc_diff.bat
@@ -198,10 +198,14 @@ REM it stops polling, closes all valves (safe state -- no gas flow), then closes
 REM every serial connection, releasing the COM port for the next launch. A hard
 REM kill skips this and may leave COM9 claimed / a valve latched.
 REM Best-effort (server dies mid-response); then wait for release.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%CAPROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8009
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit this console.
 REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can

--- a/helao/hexagon/tests/smoke/ni_canary.bat
+++ b/helao/hexagon/tests/smoke/ni_canary.bat
@@ -156,10 +156,14 @@ REM cNIMAX.shutdown()/disconnect() closes the NI-DAQmx tasks it opened on the
 REM cDAQ chassis. A hard kill skips this and may leave a task reserved on a
 REM channel for the next launch -- best-effort (server dies mid-response); then
 REM wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8006
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/ni_canary.bat
+++ b/helao/hexagon/tests/smoke/ni_canary.bat
@@ -35,7 +35,7 @@ REM   outdir default %TEMP%\ni_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\ni_canary"
 

--- a/helao/hexagon/tests/smoke/powersupply_canary.bat
+++ b/helao/hexagon/tests/smoke/powersupply_canary.bat
@@ -40,7 +40,7 @@ REM   outdir default %TEMP%\powersupply_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\powersupply_canary"
 

--- a/helao/hexagon/tests/smoke/powersupply_canary.bat
+++ b/helao/hexagon/tests/smoke/powersupply_canary.bat
@@ -161,10 +161,14 @@ REM the `/stop_private` handler (power_supply_server.py) calls
 REM app.driver.disconnect(), which closes the pyvisa instrument + resource
 REM manager. A hard kill skips this and may leave the VISA resource claimed
 REM for the next launch -- best-effort (server dies mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8002
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/spec_canary.bat
+++ b/helao/hexagon/tests/smoke/spec_canary.bat
@@ -32,7 +32,7 @@ REM   outdir default %TEMP%\spec_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\spec_canary"
 

--- a/helao/hexagon/tests/smoke/spec_canary.bat
+++ b/helao/hexagon/tests/smoke/spec_canary.bat
@@ -152,10 +152,14 @@ REM 0) GRACEFUL shutdown FIRST so the SM303 driver's shutdown() runs:
 REM SM303.shutdown() releases the vendor SPdbUSBm.dll device handle. A hard kill
 REM skips this and may leave the device claimed for the next launch --
 REM best-effort (server dies mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8011
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/spec_diff.bat
+++ b/helao/hexagon/tests/smoke/spec_diff.bat
@@ -194,10 +194,14 @@ REM 0) GRACEFUL shutdown FIRST so the SM303 driver's shutdown() runs:
 REM SM303.shutdown() releases the vendor SPdbUSBm.dll device handle. A hard kill
 REM skips this and may leave the device claimed for the next launch.
 REM Best-effort (server dies mid-response); then wait for release.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%CAPROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8011
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit this console.
 REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can

--- a/helao/hexagon/tests/smoke/syringe_canary.bat
+++ b/helao/hexagon/tests/smoke/syringe_canary.bat
@@ -156,10 +156,14 @@ REM async_shutdown() returns the pump to a safe idle state and closes the
 REM pyserial COM5 handle. A hard kill skips this and may leave the serial port
 REM claimed for the next launch -- best-effort (server dies mid-response); then
 REM wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8013
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/syringe_canary.bat
+++ b/helao/hexagon/tests/smoke/syringe_canary.bat
@@ -35,7 +35,7 @@ REM   outdir default %TEMP%\syringe_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\syringe_canary"
 

--- a/helao/hexagon/tests/smoke/syringe_diff.bat
+++ b/helao/hexagon/tests/smoke/syringe_diff.bat
@@ -196,10 +196,14 @@ REM async_shutdown() returns the pump to a safe idle state and closes the
 REM pyserial COM5 handle. A hard kill skips this and may leave the serial port
 REM claimed for the next launch. Best-effort (server dies mid-response); then
 REM wait for release.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%CAPROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8013
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit this console.
 REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can

--- a/helao/hexagon/tests/smoke/tec_canary.bat
+++ b/helao/hexagon/tests/smoke/tec_canary.bat
@@ -155,10 +155,14 @@ REM MeerstetterTEC.async_shutdown() disables the control loop (safe state)
 REM then closes the MeCom serial session. A hard kill skips this and may leave
 REM the serial port held for the next launch -- best-effort (server dies
 REM mid-response); then wait.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%ROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8008
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%ROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit the canary console.
 REM `taskkill /T /F` by window title was removed: /T tree-kills and can cascade

--- a/helao/hexagon/tests/smoke/tec_canary.bat
+++ b/helao/hexagon/tests/smoke/tec_canary.bat
@@ -34,7 +34,7 @@ REM   outdir default %TEMP%\tec_canary
 REM ---------------------------------------------------------------------------
 
 set "ROOT=%~1"
-if "%ROOT%"=="" set "ROOT=C:\INST_hlo"
+if "%ROOT%"=="" set "ROOT=C:\INST_hlo_golden"
 set "OUTDIR=%~2"
 if "%OUTDIR%"=="" set "OUTDIR=%TEMP%\tec_canary"
 

--- a/helao/hexagon/tests/smoke/tec_diff.bat
+++ b/helao/hexagon/tests/smoke/tec_diff.bat
@@ -201,10 +201,14 @@ REM 0) GRACEFUL shutdown FIRST so the TEC driver's shutdown() runs:
 REM MeerstetterTEC.async_shutdown() disables the control loop (safe state)
 REM then closes the MeCom serial session. A hard kill skips this. Best-effort
 REM (server dies mid-response); then wait for release.
+REM Snapshot the group's PIDs (servers + launch.py monitor) BEFORE the
+REM graceful /shutdown, so teardown / a removed pickle can't defeat the
+REM kill and the launch.py console window is closed by PID (see kill_group.py).
+call conda run -n helao python "%~dp0kill_group.py" "%CAPROOT%" "%PREFIX%" --snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 call conda run -n helao python "%~dp0graceful_shutdown.py" 8008
 ping -n 5 -w 1000 127.0.0.1 >nul
 REM 1) kill the action/vis servers via their pid pickle (any that didn't exit).
-call conda run -n helao python helao\hexagon\tests\smoke\kill_group.py "%CAPROOT%" "%PREFIX%"
+call conda run -n helao python "%~dp0kill_group.py" --from-snapshot "%TEMP%\helao_pids_%PREFIX%.json"
 REM 2) kill the launch.py monitor (+ its conda/cmd wrapper) for THIS prefix by
 REM matching its command line -- precise, so it can never hit this console.
 REM `taskkill /T /F` by window title is NEVER used: /T tree-kills and can


### PR DESCRIPTION
## P3a station-validation fixes — poller lifecycle, driver hardening, smoke infra

Fixes surfaced while validating the hte hardware canaries at stations (co2/diapump/mfc/syringe on ccsi2). All station-independent driver/framework fixes plus canary-infra polish. Correctness of the P3a canaries is unchanged (openapi diff / golden parity); these fix at-station runnability, shutdown, and observability.

### Poller lifecycle (core — affects every poller-backed server)
- **connect in `__init__`** (`0dd3394c` SprintIR, `aac0e195` AliCatMFC): `BaseAPI` never calls `driver.connect()` and `DriverPoller` auto-starts its poll loop on construction, so a driver that deferred its device open to `connect()` left the handle unset — the poller then spun on a `None`/empty handle (SprintIR spammed `NoneType ... 'flush'`; the MFC poller produced no data so `acquire_flowrate`'s `get_lbuf` never advanced and the capture hung). Open the device in `__init__`, matching biologic/andor.
- **stop poller before disconnect** (`9ee8ccbd`): `shutdown_event` disconnected the driver without stopping the poller, so it kept calling `get_data()` on a closed device. Added `DriverPoller.stop()` (cancel + bounded `gather`) and call it before `driver.shutdown()`.

### Driver hardening
- **MFC fail-fast** (`76fc09f4`): an unconnected MFC device made `MfcExec._poll` `KeyError` mid-loop with no terminal `-act.yml`, hanging the capture. `_pre_exec` now returns a terminal error immediately with a clear "device not connected; check COM port".
- **KDS100 syringe serial** (`5daf352b`): `send`/`_send_sync` had an unbounded `\x11` re-read loop and leaked `com_lock` on exception, deadlocking `/shutdown` (read-timeout). Wrapped in try/finally + bounded the re-read; also bounded `poller.stop()` so a blocking sync `get_data` can't hang shutdown.

### Smoke infra
- **kill_group snapshot/window** (`bd7bc365`): snapshot PIDs before `/shutdown` (immune to teardown race), kill the `launch.py` monitor by PID (closes the console window), glob the pid pickle (tolerates a root mismatch).
- **canary visualizers** (`6ecd5b35`): wire `action_vis`/`live_vis` per family (mfc/co2/galilio → `live_vis` + `live_visualizer`) so the launched vis isn't empty.
- **canary root** (`6ecd5b35`): `*_canary.bat` + legacy/hex configs reroot production `C:\INST_hlo` → throwaway `C:\INST_hlo_golden`, matching `*_diff`.

### Config
- **mfc COM port** (`c4eaa51e`/`5c21cb9c`/`a7339aef`): net value is `COM6` (matches ccsi2.yml). The interim COM4 commit + revert reflect a transient USB-hub fault during debugging, now resolved.

Verified: `run_unit_tests` overall PASS (35 modules); `test_preflight` 11 passed; all touched hexagon configs PREFLIGHT OK; `helao_driver.py` pyright clean. At-station: co2/diapump/mfc/syringe green.

Out of scope (continues on a new branch): PAL 4-way special-split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnSSF8Rm7U9Jo3ejUS3sNE
