### PR TITLE
fix(hte): legato/KDS100 tolerates unconnected pump on shutdown

### DIFF
--- a/helao/deploy/hte/drivers/pump/legato_driver.py
+++ b/helao/deploy/hte/drivers/pump/legato_driver.py
@@ -226,8 +226,15 @@ class KDS100(HelaoDriver):
             cmd: Pump command string; a trailing carriage return is added if missing.
 
         Returns:
-            List of non-empty response lines stripped of whitespace.
+            List of non-empty response lines stripped of whitespace. Empty when
+            the serial connection is not open (``self.sio is None``).
         """
+        if self.sio is None:
+            LOGGER.warning(
+                f"cannot send '{cmd.strip()}' to '{pump_name}': "
+                "syringe pump not connected (sio is None)"
+            )
+            return []
         if not cmd.endswith("\r"):
             cmd = cmd + "\r"
         addr = self.config_dict["pumps"][pump_name]["address"]
@@ -268,8 +275,17 @@ class KDS100(HelaoDriver):
             cmd: Pump command string; a trailing carriage return is added if missing.
 
         Returns:
-            List of non-empty response lines stripped of whitespace.
+            List of non-empty response lines stripped of whitespace. Empty when
+            the serial connection is not open (``self.sio is None``) -- keeps
+            the background poller from crashing every cycle on an unconnected
+            pump.
         """
+        if self.sio is None:
+            LOGGER.warning(
+                f"cannot send '{cmd.strip()}' to '{pump_name}': "
+                "syringe pump not connected (sio is None)"
+            )
+            return []
         if not cmd.endswith("\r"):
             cmd = cmd + "\r"
         addr = self.config_dict["pumps"][pump_name]["address"]
@@ -494,7 +510,19 @@ class KDS100(HelaoDriver):
         Enables POLL mode, disables NVRAM writes, stops the pump, clears time
         and target volume counters, and applies the syringe diameter from
         configuration.
+
+        No-op when the serial connection was never opened (``self.sio is
+        None`` -- e.g. ``connect()`` failed because the pump's COM port is
+        absent at this station). Attempting the POLL/stop commands against a
+        closed port raised ``AttributeError: 'NoneType' object has no attribute
+        'write'`` on shutdown; skip cleanly so ``async_shutdown`` can still
+        reach ``disconnect()``.
         """
+        if self.sio is None:
+            LOGGER.warning(
+                "syringe pump not connected (sio is None); skipping safe_state"
+            )
+            return
         for plab, pdict in self.config_dict.get("pumps", {}).items():
             addr = pdict["address"]
             idle_resp = f"{addr:02}:\x11"

--- a/helao/deploy/hte/tests/test_legato_shutdown_noneguard.py
+++ b/helao/deploy/hte/tests/test_legato_shutdown_noneguard.py
@@ -1,0 +1,90 @@
+"""Standalone regression test: KDS100 syringe-pump shutdown with no connection.
+
+Reproduces and locks the fix for the shutdown crash observed at a station
+where a syringe pump's COM port was absent, so ``connect()`` left
+``self.sio is None``. On shutdown ``async_shutdown -> safe_state -> send``
+then did ``self.sio.write(...)`` and raised
+``AttributeError: 'NoneType' object has no attribute 'write'``.
+
+The driver must tolerate an unconnected pump gracefully: ``send``/``_send_sync``
+return ``[]`` (so the background poller and any action fail benignly rather
+than crashing), ``safe_state`` no-ops, and ``async_shutdown`` completes so the
+server can shut down cleanly.
+
+Run:  conda run -n helao python helao/deploy/hte/tests/test_legato_shutdown_noneguard.py
+"""
+
+import asyncio
+import sys
+
+from helao.deploy.hte.drivers.pump.legato_driver import KDS100
+
+
+def _make_unconnected() -> KDS100:
+    """Build a KDS100 whose serial connection was never opened (sio is None).
+
+    Bypasses ``__init__`` (which would need a real HelaoDriver/config setup)
+    and sets only the attributes the exercised methods touch -- mirroring the
+    post-``__init__``, pre/failed-``connect()`` state.
+    """
+    d = KDS100.__new__(KDS100)
+    d.com = None
+    d.sio = None
+    d.com_lock = False
+    d.polling = True
+    d.config_dict = {"pumps": {}}
+    return d
+
+
+def main() -> int:
+    failures = []
+
+    def check(cond: bool, msg: str) -> None:
+        if cond:
+            print(f"PASS: {msg}")
+        else:
+            print(f"FAIL: {msg}")
+            failures.append(msg)
+
+    d = _make_unconnected()
+
+    # send() on an unconnected pump returns [] instead of raising.
+    try:
+        resp = asyncio.run(d.send("cleansyringe", "poll on"))
+        check(resp == [], "send() returns [] when sio is None (no AttributeError)")
+    except Exception as exc:  # noqa: BLE001
+        check(False, f"send() must not raise when sio is None; raised {exc!r}")
+
+    # _send_sync() (the poller path) likewise returns [].
+    try:
+        sync_resp = d._send_sync("cleansyringe", "poll on")
+        check(sync_resp == [], "_send_sync() returns [] when sio is None")
+    except Exception as exc:  # noqa: BLE001
+        check(False, f"_send_sync() must not raise when sio is None; raised {exc!r}")
+
+    # safe_state() is a clean no-op (was where the shutdown crash originated).
+    try:
+        asyncio.run(d.safe_state())
+        check(True, "safe_state() no-ops when sio is None (no crash)")
+    except Exception as exc:  # noqa: BLE001
+        check(False, f"safe_state() must not raise when sio is None; raised {exc!r}")
+
+    # async_shutdown() completes end-to-end (safe_state skip + disconnect).
+    try:
+        asyncio.run(d.async_shutdown())
+        check(True, "async_shutdown() completes when sio is None")
+    except Exception as exc:  # noqa: BLE001
+        check(
+            False, f"async_shutdown() must not raise when sio is None; raised {exc!r}"
+        )
+
+    print("=" * 44)
+    if failures:
+        print(f"RESULT: FAIL ({len(failures)} check(s) failed)")
+        return 1
+    print("RESULT: PASS (all checks passed)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem
At a station where a syringe pump's COM port is absent, `KDS100.connect()` swallows the failed serial open and leaves `self.sio = None`. On shutdown, `async_shutdown → safe_state → send()` then executes `self.sio.write(...)` and crashes:

```
AttributeError: 'NoneType' object has no attribute 'write'
  legato_driver.py:239 in send  (self.sio.write(command_str))
  legato_driver.py:501 in safe_state
  legato_driver.py:208 in async_shutdown
```

A bare `send()` guard alone is insufficient — `safe_state` then hits `IndexError` on `poll_resp[-1]`.

## Fix
Three guards so an unconnected pump is tolerated gracefully:
- **`safe_state()`** — no-op + warn when `self.sio is None`, so `async_shutdown` still reaches the already-None-safe `disconnect()`.
- **`send()` / `_send_sync()`** — return `[]` + warn when `self.sio is None`, protecting the background poller (every `get_data` cycle) and any dispatched action from the same `AttributeError`.

Mirrors the existing fail-fast/None-guard posture for other station drivers (SprintIR CO2, AliCat MFC).

## Test
New standalone `helao/deploy/hte/tests/test_legato_shutdown_noneguard.py` — asserts `send`, `_send_sync`, `safe_state`, and `async_shutdown` are all benign when `sio is None`. 4/4 PASS; `run_unit_tests` exit 0; black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)