### PR TITLE
fix(launch): verify pids_*.pck PIDs are the actual server before skipping

### DIFF
--- a/helao/core/tests/test_launch_pid_verify.py
+++ b/helao/core/tests/test_launch_pid_verify.py
@@ -1,0 +1,158 @@
+"""Standalone regression test: launch.py verifies stale PIDs before skipping.
+
+Locks the fix for ``Pidd.list_active`` trusting ``psutil.pid_exists`` alone.
+A stale ``pids_<config>_.pck`` can hold a PID the OS has since reused for an
+unrelated process; ``pid_exists`` returns True for the reused PID, so the
+launcher would report the server "already running" and refuse to (re)start it.
+``_pid_is_server`` must confirm the PID is the actual launched helao server
+(launcher script + exact server-key token in the process cmdline).
+
+Run:  conda run -n helao python helao/core/tests/test_launch_pid_verify.py
+"""
+
+import logging as _logging
+import sys
+import tempfile
+
+import psutil
+
+import launch
+
+# launch.LAUNCH_LOGGER is only initialized inside main(); give Pidd a real
+# logger so its construction (which logs on a missing pickle) works here.
+launch.LAUNCH_LOGGER = _logging.getLogger("test_launch_pid_verify")
+
+
+class _FakeProc:
+    """Minimal psutil.Process stand-in for one scenario."""
+
+    def __init__(self, status, cmdline=None, cmdline_exc=None):
+        self._status = status
+        self._cmdline = cmdline or []
+        self._cmdline_exc = cmdline_exc
+
+    def status(self):
+        return self._status
+
+    def cmdline(self):
+        if self._cmdline_exc is not None:
+            raise self._cmdline_exc
+        return self._cmdline
+
+
+def _pidd():
+    """Build a Pidd against an empty tmp pickle (no real servers)."""
+    d = tempfile.mkdtemp()
+    return launch.Pidd(pidFile="pids_test_.pck", pidPath=d)
+
+
+def main() -> int:
+    failures = []
+
+    def check(cond, msg):
+        print(("PASS: " if cond else "FAIL: ") + msg)
+        if not cond:
+            failures.append(msg)
+
+    pidd = _pidd()
+    orig_pid_exists = psutil.pid_exists
+    orig_process = psutil.Process
+
+    def run_case(*, exists, proc, key="CLEANSYRINGE", pid=4242):
+        """Patch psutil for one case and return _pid_is_server(pid, key)."""
+        psutil.pid_exists = lambda *_: exists
+        psutil.Process = lambda *_: proc
+        try:
+            return pidd._pid_is_server(pid, key)
+        finally:
+            psutil.pid_exists = orig_pid_exists
+            psutil.Process = orig_process
+
+    # 1. Dead PID (pickle stale, process gone) -> not running -> will launch.
+    check(
+        run_case(exists=False, proc=None) is False,
+        "dead PID (pid_exists False) is not active",
+    )
+
+    # 2. Live PID reused by an UNRELATED process (the reported bug) -> not ours.
+    check(
+        run_case(
+            exists=True,
+            proc=_FakeProc("running", cmdline=["/usr/bin/some_other_daemon", "--x"]),
+        )
+        is False,
+        "reused PID with unrelated cmdline is NOT treated as the server",
+    )
+
+    # 3. Live PID that IS the launched fast server -> active.
+    check(
+        run_case(
+            exists=True,
+            proc=_FakeProc(
+                "running",
+                cmdline=["python", "fast_launcher.py", "adss3", "CLEANSYRINGE"],
+            ),
+        )
+        is True,
+        "live launched fast server (launcher + key in cmdline) is active",
+    )
+
+    # 3b. Live bokeh server likewise.
+    check(
+        run_case(
+            exists=True,
+            proc=_FakeProc(
+                "running",
+                cmdline=["python", "bokeh_launcher.py", "adss3", "CLEANSYRINGE"],
+            ),
+        )
+        is True,
+        "live launched bokeh server is active",
+    )
+
+    # 4. Right launcher but DIFFERENT server key (substring guard) -> not this one.
+    check(
+        run_case(
+            exists=True,
+            proc=_FakeProc(
+                "running",
+                cmdline=["python", "fast_launcher.py", "adss3", "WORKSYRINGE"],
+            ),
+        )
+        is False,
+        "another server's launcher process is not this server_key",
+    )
+
+    # 5. Zombie (unreaped, pid_exists still True) -> gone.
+    check(
+        run_case(
+            exists=True,
+            proc=_FakeProc(
+                psutil.STATUS_ZOMBIE,
+                cmdline=["python", "fast_launcher.py", "adss3", "CLEANSYRINGE"],
+            ),
+        )
+        is False,
+        "zombie process is not active",
+    )
+
+    # 6. cmdline() raises AccessDenied (another user's reused PID) -> not ours.
+    check(
+        run_case(
+            exists=True,
+            proc=_FakeProc("running", cmdline_exc=psutil.AccessDenied(4242)),
+        )
+        is False,
+        "AccessDenied on cmdline (foreign PID) is not active",
+    )
+
+    print("=" * 44)
+    if failures:
+        print(f"RESULT: FAIL ({len(failures)} check(s) failed)")
+        return 1
+    print("RESULT: PASS (all checks passed)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/launch.py
+++ b/launch.py
@@ -210,21 +210,55 @@ class Pidd:
                   information about a process, such as its PID, port, and host.
         """
         helaoPids = self.list_pids()
-        # print_message(LAUNCH_LOGGER, "launcher", helaoPids)
-        running = [tup for tup in helaoPids if psutil.pid_exists(tup[3])]
-        # active = []
-        # for tup in running:
-        #     pid = tup[3]
-        #     port = tup[2]
-        #     host = tup[1]
-        #     proc = psutil.Process(pid)
-        #     if proc.name() in self.PROC_NAMES:
-        #         connections = [
-        #             c for c in proc.connections("tcp4") if c.status == "LISTEN"
-        #         ]
-        #         if (host, port) in [(c.laddr.ip, c.laddr.port) for c in connections]:
-        #             active.append(tup)
-        return running
+        # Only count a PID as active if it is a LIVE process that is actually
+        # the launched helao server for that key. A stale pids_*.pck can hold a
+        # PID that the OS has since reused for an unrelated process;
+        # psutil.pid_exists() alone would then report it "running" and the
+        # launcher would refuse to (re)start a server that is in fact NOT
+        # running. _pid_is_server verifies process identity via cmdline.
+        return [tup for tup in helaoPids if self._pid_is_server(tup[3], tup[0])]
+
+    def _pid_is_server(self, pid, server_key):
+        """Return True only if ``pid`` is a live, non-zombie process that is the
+        launched helao server for ``server_key``.
+
+        Guards against a stale ``pids_*.pck`` whose recorded PID has since been
+        reused by an unrelated process: ``psutil.pid_exists`` returns True for
+        the reused PID, which would make the launcher skip a server that is not
+        actually running. Servers are spawned as
+        ``python {fast,bokeh}_launcher.py <config> <server_key>`` (see
+        :func:`launcher`), so requiring both the launcher script and the exact
+        ``server_key`` argv token in the process cmdline confirms identity
+        cross-platform, without needing socket/port permissions.
+
+        Args:
+            pid (int): PID recorded in the pids pickle.
+            server_key (str): Server key the PID is expected to belong to.
+
+        Returns:
+            bool: True if the PID is the live launched server, else False
+            (dead, a zombie, another user's reused PID, or an unrelated
+            process).
+        """
+        if not psutil.pid_exists(pid):
+            return False
+        try:
+            proc = psutil.Process(pid)
+            if proc.status() == psutil.STATUS_ZOMBIE:
+                return False
+            cmdline = proc.cmdline()
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            # gone, a zombie, or owned by another user (a reused PID) -> not ours
+            return False
+        launched_by = any(
+            launcher in arg
+            for arg in cmdline
+            for launcher in ("fast_launcher.py", "bokeh_launcher.py")
+        )
+        # server_key is passed as its own argv element, so list membership is an
+        # exact-token match (won't false-match a key that is a substring of a
+        # longer server key or of a path).
+        return launched_by and server_key in cmdline
 
     def _reap_child(self, k):
         """Reap the OS child for server ``k`` so a terminated process does not


### PR DESCRIPTION
`Pidd.list_active` trusted `psutil.pid_exists` alone. A stale `pids_<config>_.pck` can hold a PID the OS has since reused for an unrelated process; `pid_exists` then returns True and the launcher reports the server "already running", refusing to (re)start a server that is in fact **not** running.

- New `Pidd._pid_is_server(pid, server_key)`: a PID counts as active only when it is a **live, non-zombie** process whose cmdline contains the launcher script (`fast_launcher.py`/`bokeh_launcher.py`) **and** the exact `server_key` token — the form servers are actually spawned with.
- Exact-token match avoids substring false-positives; `NoSuchProcess`/`AccessDenied`/`ZombieProcess` all resolve to "not ours" so the server is (re)launched. Cross-platform, no socket permissions needed.
- Replaces the previously commented-out `connections()` LISTEN check (which matched `laddr.ip` against the config host and broke for servers binding `0.0.0.0`).

New standalone regression test `helao/core/tests/test_launch_pid_verify.py` — dead / reused / zombie / access-denied / wrong-key / live fast+bokeh scenarios (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)