### PR TITLE
test(hexagon): drop blank visualizer from no-vis hte canaries + launch full-path prefix fix

### DIFF
--- a/helao/deploy/hte/configs/analysis.yml
+++ b/helao/deploy/hte/configs/analysis.yml
@@ -23,10 +23,10 @@
 # missing module (not crash), but an empty list keeps the launched surface
 # deterministic and identical between legacy/hexagon.
 #
-# Mirrors sample.yml/dbpack.yml's 2-server shape (one action server + one
-# action_visualizer). Port 8014 matches every live ANA config (icpm1, xrfs1,
-# adss, adss3, ccsi1/2, clad); vis 5001 matches the repo-wide ACTVIS
-# convention (these standalone configs are never run concurrently).
+# This config is action-only: none of the live ANA configs (icpm1, xrfs1,
+# adss, adss3, ccsi1/2, clad) declare action_vis/live_vis for ANA, so a
+# visualizer panel here would only ever be blank. Port 8014 matches every
+# live ANA config.
 dummy: true
 simulation: true
 run_type: analysis_server
@@ -40,11 +40,3 @@ servers:
     params:
       local_only: true
       analyses: []
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'ANA Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/analysishex.yml
+++ b/helao/deploy/hte/configs/analysishex.yml
@@ -1,11 +1,11 @@
 # HEXAGON CANARY for the analysis_server station (P3a special-split). Copy of
-# analysis.yml with `deployment: hexagon` flipping ANA (analysis_server) and
-# ACTVIS (action_visualizer) onto the hexagon factory. analysis.yml stays
-# legacy for rollback; the cut-over is ONLY the two `deployment: hexagon`
-# keys. Ports/root/params match analysis.yml so an openapi diff compares
-# like-for-like. See analysis.yml for the Step-0 credentials/analyses-list
-# investigation and the why-deferred (needs seeded process data) runtime-diff
-# rationale.
+# analysis.yml with `deployment: hexagon` flipping ANA (analysis_server) onto
+# the hexagon factory. analysis.yml stays legacy for rollback; the cut-over
+# is ONLY the `deployment: hexagon` key. Action-only (see analysis.yml's
+# header -- no live ANA config declares a visualizer). Ports/root/params
+# match analysis.yml so an openapi diff compares like-for-like. See
+# analysis.yml for the Step-0 credentials/analyses-list investigation and the
+# why-deferred (needs seeded process data) runtime-diff rationale.
 dummy: true
 simulation: true
 run_type: analysis_server
@@ -20,12 +20,3 @@ servers:
     params:
       local_only: true
       analyses: []
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'ANA Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/andor.yml
+++ b/helao/deploy/hte/configs/andor.yml
@@ -1,7 +1,8 @@
-# STANDALONE andor_server canary config (P3a special-split, ANDOR). Mirrors
-# spec.yml/cam.yml's 2-server shape (one action server + one action_visualizer)
-# so an at-station openapi/runtime golden diff can compare legacy vs hexagon
-# like-for-like without pulling in the full hispec station (ORCH, VIS, DB, CALC,
+# STANDALONE andor_server canary config (P3a special-split, ANDOR). This config
+# is action-only: hispec.yml declares no action_vis/live_vis for ANDOR, so a
+# visualizer panel here would only ever be blank. It exists so an at-station
+# openapi/runtime golden diff can compare legacy vs hexagon like-for-like
+# without pulling in the full hispec station (ORCH, VIS, DB, CALC,
 # CAM...). The ANDOR params: (dev_id) is copied VERBATIM from hispec.yml's ANDOR
 # block so `acquire` registers identically. This is the Andor Zyla camera +
 # ATSpectrograph (vendor pyAndorSDK3 / pyAndorSpectrograph runtimes) --
@@ -29,11 +30,3 @@ servers:
     fast: andor_server
     params:
       dev_id: 0
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'ANDOR Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/andorgold.yml
+++ b/helao/deploy/hte/configs/andorgold.yml
@@ -20,11 +20,3 @@ servers:
     fast: andor_server
     params:
       dev_id: 0
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'ANDOR Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/andorgoldhex.yml
+++ b/helao/deploy/hte/configs/andorgoldhex.yml
@@ -1,6 +1,6 @@
 # CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of andorhex.yml (keeps
-# `deployment: hexagon` on ANDOR + ACTVIS -- the hexagon side of the runtime
-# golden diff) used solely by helao.hexagon.tests.smoke.golden_capture_andor /
+# `deployment: hexagon` on ANDOR -- the hexagon side of the runtime golden
+# diff) used solely by helao.hexagon.tests.smoke.golden_capture_andor /
 # andor_diff.bat to capture a runtime golden-master `acquire` tree. The ONLY
 # change from andorhex.yml is `root:`, pointed at a dedicated throwaway path so
 # the capture rig's assert_fresh() has a clean tree to start from and production
@@ -23,12 +23,3 @@ servers:
     deployment: hexagon
     params:
       dev_id: 0
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'ANDOR Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/andorhex.yml
+++ b/helao/deploy/hte/configs/andorhex.yml
@@ -1,12 +1,12 @@
 # HEXAGON CANARY for the andor_server station (P3a special-split). Copy of
-# andor.yml with `deployment: hexagon` flipping ANDOR (andor_server) and ACTVIS
-# (action_visualizer) onto the hexagon factory -- run AT-STATION
-# (Windows/pyAndorSDK3 + pyAndorSpectrograph). andor.yml stays legacy for
-# rollback; the cut-over is ONLY the two `deployment: hexagon` keys.
-# Ports/root/params match andor.yml so an on-station openapi/golden diff
-# compares like-for-like. TWO TIERS -- see andor.yml's header (openapi via
-# andor_canary.bat, runtime `acquire` golden diff via andor_diff.bat +
-# andorgold/andorgoldhex).
+# andor.yml with `deployment: hexagon` flipping ANDOR (andor_server) onto the
+# hexagon factory -- run AT-STATION (Windows/pyAndorSDK3 +
+# pyAndorSpectrograph). andor.yml stays legacy for rollback; the cut-over is
+# ONLY the `deployment: hexagon` key. Action-only (see andor.yml's header --
+# hispec.yml declares no visualizer for ANDOR). Ports/root/params match
+# andor.yml so an on-station openapi/golden diff compares like-for-like. TWO
+# TIERS -- see andor.yml's header (openapi via andor_canary.bat, runtime
+# `acquire` golden diff via andor_diff.bat + andorgold/andorgoldhex).
 dummy: true
 simulation: true
 run_type: andor_server
@@ -20,12 +20,3 @@ servers:
     deployment: hexagon
     params:
       dev_id: 0
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'ANDOR Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/cam.yml
+++ b/helao/deploy/hte/configs/cam.yml
@@ -1,7 +1,8 @@
-# STANDALONE cam_server canary config (P3a special-split, CAM). Mirrors
-# galil.yml/sample.yml's 2-server shape (one action server + one
-# action_visualizer) so an at-station openapi/runtime golden diff can compare
-# legacy vs hexagon like-for-like without pulling in the full eche10 station.
+# STANDALONE cam_server canary config (P3a special-split, CAM). This config is
+# action-only: eche10.yml declares no action_vis/live_vis for CAM, so a
+# visualizer panel here would only ever be blank. It exists so an at-station
+# openapi/runtime golden diff can compare legacy vs hexagon like-for-like
+# without pulling in the full eche10 station.
 # CAM param (axis_ip) is copied verbatim from eche10.yml's CAM block. This is
 # the Axis IP webcam (AxisCam, HTTP JPEG fetch -- NO vendor DLL, NO COM/gclib).
 #
@@ -27,11 +28,3 @@ servers:
     fast: cam_server
     params:
       axis_ip: 192.168.200.210
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'CAM Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/camgold.yml
+++ b/helao/deploy/hte/configs/camgold.yml
@@ -18,11 +18,3 @@ servers:
     fast: cam_server
     params:
       axis_ip: 192.168.200.210
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'CAM Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/camgoldhex.yml
+++ b/helao/deploy/hte/configs/camgoldhex.yml
@@ -1,6 +1,6 @@
 # CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of camhex.yml (keeps
-# `deployment: hexagon` on CAM + ACTVIS -- the hexagon side of the runtime
-# golden diff) used solely by helao.hexagon.tests.smoke.golden_capture_cam /
+# `deployment: hexagon` on CAM -- the hexagon side of the runtime golden
+# diff) used solely by helao.hexagon.tests.smoke.golden_capture_cam /
 # cam_diff.bat to capture a runtime golden-master acquire_image tree. The ONLY
 # change from camhex.yml is `root:`, pointed at a dedicated throwaway path so
 # the capture rig's assert_fresh() has a clean tree to start from and production
@@ -22,12 +22,3 @@ servers:
     deployment: hexagon
     params:
       axis_ip: 192.168.200.210
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'CAM Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/camhex.yml
+++ b/helao/deploy/hte/configs/camhex.yml
@@ -1,10 +1,11 @@
 # HEXAGON CANARY for the cam_server station (P3a special-split). Copy of
-# cam.yml with `deployment: hexagon` flipping CAM (cam_server) and ACTVIS
-# (action_visualizer) onto the hexagon factory. cam.yml stays legacy for
-# rollback; the cut-over is ONLY the two `deployment: hexagon` keys. Ports/root/
-# params match cam.yml so the openapi surface diff compares like-for-like.
-# TWO TIERS -- see cam.yml's header (openapi via cam_canary.bat, runtime
-# acquire_image golden diff via cam_diff.bat + camgold/camgoldhex).
+# cam.yml with `deployment: hexagon` flipping CAM (cam_server) onto the
+# hexagon factory. cam.yml stays legacy for rollback; the cut-over is ONLY the
+# `deployment: hexagon` key. Action-only (see cam.yml's header -- eche10.yml
+# declares no visualizer for CAM). Ports/root/params match cam.yml so the
+# openapi surface diff compares like-for-like. TWO TIERS -- see cam.yml's
+# header (openapi via cam_canary.bat, runtime acquire_image golden diff via
+# cam_diff.bat + camgold/camgoldhex).
 dummy: true
 simulation: true
 run_type: cam_server
@@ -18,12 +19,3 @@ servers:
     deployment: hexagon
     params:
       axis_ip: 192.168.200.210
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'CAM Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/dbpack.yml
+++ b/helao/deploy/hte/configs/dbpack.yml
@@ -16,11 +16,11 @@
 # a placeholder string; no real S3 call happens since /finish_yml is never
 # exercised by this canary.
 #
-# Mirrors sample.yml's 2-server shape (one action server + one
-# action_visualizer) so an openapi diff can compare legacy vs hexagon
-# like-for-like. Port 8010 copied from eche10.yml's DB block; vis 5001
-# matches the repo-wide ACTVIS convention (galil/gamry/sample all reuse 5001
-# since these standalone configs are never run concurrently).
+# This config is action-only: dbpack_server exposes only private/bare
+# endpoints, and no visualizer is declared anywhere DB is used, so a
+# visualizer panel here would only ever be blank. It exists so an openapi
+# diff can compare legacy vs hexagon like-for-like. Port 8010 copied from
+# eche10.yml's DB block.
 dummy: true
 simulation: true
 run_type: dbpack_server
@@ -35,11 +35,3 @@ servers:
       aws_profile: default
       testing: true
       aws_bucket: helao-canary-dummy
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'DB Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/dbpackhex.yml
+++ b/helao/deploy/hte/configs/dbpackhex.yml
@@ -1,11 +1,11 @@
 # HEXAGON CANARY for the dbpack_server station (P3a special-split). Copy of
-# dbpack.yml with `deployment: hexagon` flipping DB (dbpack_server) and
-# ACTVIS (action_visualizer) onto the hexagon factory. dbpack.yml stays
-# legacy for rollback; the cut-over is ONLY the two `deployment: hexagon`
-# keys. Ports/root/params match dbpack.yml so an openapi diff compares
-# like-for-like. See dbpack.yml for the aws_bucket/AWS_CONFIG_PATH gate
-# investigation and the why-openapi-only (no action endpoints -> no runtime
-# RUNS-tree diff) rationale.
+# dbpack.yml with `deployment: hexagon` flipping DB (dbpack_server) onto the
+# hexagon factory. dbpack.yml stays legacy for rollback; the cut-over is
+# ONLY the `deployment: hexagon` key. Action-only (see dbpack.yml's header --
+# no visualizer is declared for DB). Ports/root/params match dbpack.yml so an
+# openapi diff compares like-for-like. See dbpack.yml for the
+# aws_bucket/AWS_CONFIG_PATH gate investigation and the why-openapi-only (no
+# action endpoints -> no runtime RUNS-tree diff) rationale.
 dummy: true
 simulation: true
 run_type: dbpack_server
@@ -21,12 +21,3 @@ servers:
       aws_profile: default
       testing: true
       aws_bucket: helao-canary-dummy
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'DB Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/diapump.yml
+++ b/helao/deploy/hte/configs/diapump.yml
@@ -1,7 +1,9 @@
-# STANDALONE diapump_server canary config (P3a special-split, DIAPUMP). Mirrors
-# cam.yml's 2-server shape (one action server + one action_visualizer) so an
-# at-station openapi surface diff can compare legacy vs hexagon like-for-like
-# without pulling in the full ccsi2 station. The DOSEPUMP params (port/address)
+# STANDALONE diapump_server canary config (P3a special-split, DIAPUMP). This
+# config is action-only: ccsi2.yml declares no action_vis/live_vis for
+# DOSEPUMP, so a visualizer panel here would only ever be blank. It exists so
+# an at-station openapi surface diff can compare legacy vs hexagon
+# like-for-like without pulling in the full ccsi2 station. The DOSEPUMP
+# params (port/address)
 # are copied VERBATIM from ccsi2.yml's DOSEPUMP block. This is the diaphragm
 # dosing pump (serial COM, no vendor DLL, no COM/gclib).
 #
@@ -25,11 +27,3 @@ servers:
     params:
       port: COM7
       address: 0
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'DIAPUMP Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/diapumphex.yml
+++ b/helao/deploy/hte/configs/diapumphex.yml
@@ -1,7 +1,8 @@
 # HEXAGON CANARY for the diapump_server station (P3a special-split). Copy of
-# diapump.yml with `deployment: hexagon` flipping DOSEPUMP (diapump_server) and
-# ACTVIS (action_visualizer) onto the hexagon factory. diapump.yml stays legacy
-# for rollback; the cut-over is ONLY the two `deployment: hexagon` keys.
+# diapump.yml with `deployment: hexagon` flipping DOSEPUMP (diapump_server)
+# onto the hexagon factory. diapump.yml stays legacy for rollback; the
+# cut-over is ONLY the `deployment: hexagon` key. Action-only (see
+# diapump.yml's header -- ccsi2.yml declares no visualizer for DOSEPUMP).
 # Ports/root/params match diapump.yml so the openapi surface diff compares
 # like-for-like.
 #
@@ -24,12 +25,3 @@ servers:
     params:
       port: COM7
       address: 0
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'DIAPUMP Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/galil.yml
+++ b/helao/deploy/hte/configs/galil.yml
@@ -1,6 +1,7 @@
-# STANDALONE galil_motion canary config (P3a special-split, MOTOR). Mirrors
-# gamry.yml's 2-server shape (one action server + one action_visualizer) so
-# an at-station openapi/runtime golden diff can compare legacy vs hexagon
+# STANDALONE galil_motion canary config (P3a special-split, MOTOR). This
+# config is action-only: eche10.yml declares no action_vis/live_vis for
+# MOTOR, so a visualizer panel here would only ever be blank. It exists so an
+# at-station openapi/runtime golden diff can compare legacy vs hexagon
 # like-for-like without pulling in the full eche10 station (ORCH, PSTAT, IO,
 # SAMPLE, SPEC_T, DB, CAM, KMOTOR). Axis params (galil_ip_str/ipstr,
 # axis_id, count_to_mm, axis_zero, speeds, timeout) are copied verbatim from
@@ -51,11 +52,3 @@ servers:
         A: 127.8
         B: 76.7
       timeout: 600
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'MOTOR Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/galilgold.yml
+++ b/helao/deploy/hte/configs/galilgold.yml
@@ -51,11 +51,3 @@ servers:
         A: 127.8
         B: 76.7
       timeout: 600
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'MOTOR Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/galilgoldhex.yml
+++ b/helao/deploy/hte/configs/galilgoldhex.yml
@@ -1,6 +1,6 @@
 # CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of galilhex.yml
-# (keeps `deployment: hexagon` on MOTOR + ACTVIS -- the hexagon side of the
-# runtime golden diff) used solely by
+# (keeps `deployment: hexagon` on MOTOR -- the hexagon side of the runtime
+# golden diff) used solely by
 # helao.hexagon.tests.smoke.golden_capture_galil / galil_diff.bat to capture
 # a runtime golden-master query_positions tree. The ONLY change from
 # galilhex.yml is `root:`, pointed at a dedicated throwaway path so the
@@ -55,12 +55,3 @@ servers:
         A: 127.8
         B: 76.7
       timeout: 600
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'MOTOR Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/galilhex.yml
+++ b/helao/deploy/hte/configs/galilhex.yml
@@ -1,10 +1,10 @@
 # HEXAGON CANARY for the galil_motion station (P3a special-split). Copy of
-# galil.yml with `deployment: hexagon` flipping MOTOR (galil_motion) and
-# ACTVIS (action_visualizer) onto the hexagon factory -- the next hte
-# cut-over target after gamry, run AT-STATION (Windows/gclib). galil.yml
-# stays legacy for rollback; the cut-over is ONLY the two `deployment:
-# hexagon` keys. Ports/root/params match galil.yml so an on-station golden
-# diff compares like-for-like.
+# galil.yml with `deployment: hexagon` flipping MOTOR (galil_motion) onto
+# the hexagon factory -- the next hte cut-over target after gamry, run
+# AT-STATION (Windows/gclib). galil.yml stays legacy for rollback; the
+# cut-over is ONLY the `deployment: hexagon` key. Action-only (see galil.yml's
+# header -- eche10.yml declares no visualizer for MOTOR). Ports/root/params
+# match galil.yml so an on-station golden diff compares like-for-like.
 dummy: true
 simulation: true
 run_type: galil_motion
@@ -49,12 +49,3 @@ servers:
         A: 127.8
         B: 76.7
       timeout: 600
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'MOTOR Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/kmotor.yml
+++ b/helao/deploy/hte/configs/kmotor.yml
@@ -1,8 +1,9 @@
-# STANDALONE kinesis_server canary config (P3a special-split, KMOTOR). Mirrors
-# galil.yml / spec.yml's 2-server shape (one action server + one
-# action_visualizer) so an at-station openapi golden diff can compare legacy
-# vs hexagon like-for-like without pulling in the full hispec station (ORCH,
-# MOTOR, PSTAT, IO, SAMPLE, SPEC_T, DB, CAM). The `axes.z` block (serial_no /
+# STANDALONE kinesis_server canary config (P3a special-split, KMOTOR). This
+# config is action-only: hispec.yml declares no action_vis/live_vis for
+# KMOTOR, so a visualizer panel here would only ever be blank. It exists so
+# an at-station openapi golden diff can compare legacy vs hexagon
+# like-for-like without pulling in the full hispec station (ORCH, MOTOR,
+# PSTAT, IO, SAMPLE, SPEC_T, DB, CAM). The `axes.z` block (serial_no /
 # pos_scale / vel_scale / acc_scale / move_limit_mm) is copied VERBATIM from
 # hispec.yml's KMOTOR block so kinesis_dyn_endpoints registers the identical
 # kmove/cancel_kmove/set_velocity route surface AND so KinesisMotor.connect()
@@ -48,11 +49,3 @@ servers:
           vel_scale: 65970697.6 # device to mm/s
           acc_scale: 13518.2 # device to mm/s2
           move_limit_mm: 5.0
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'KMOTOR Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/kmotorhex.yml
+++ b/helao/deploy/hte/configs/kmotorhex.yml
@@ -1,9 +1,10 @@
 # HEXAGON CANARY for the kinesis_server station (P3a special-split). Copy of
-# kmotor.yml with `deployment: hexagon` flipping KMOTOR (kinesis_server) and
-# ACTVIS (action_visualizer) onto the hexagon factory (makeActionApp shim at
+# kmotor.yml with `deployment: hexagon` flipping KMOTOR (kinesis_server) onto
+# the hexagon factory (makeActionApp shim at
 # helao/deploy/hexagon/servers/action/kinesis_server.py) -- run AT-STATION
 # (Windows / Thorlabs Kinesis). kmotor.yml stays legacy for rollback; the
-# cut-over is ONLY the two `deployment: hexagon` keys. Ports/root/params
+# cut-over is ONLY the `deployment: hexagon` key. Action-only (see kmotor.yml's
+# header -- hispec.yml declares no visualizer for KMOTOR). Ports/root/params
 # match kmotor.yml so an on-station openapi diff compares like-for-like.
 #
 # OPENAPI-ONLY (see kmotor.yml's header): every action route registered
@@ -32,12 +33,3 @@ servers:
           vel_scale: 65970697.6 # device to mm/s
           acc_scale: 13518.2 # device to mm/s2
           move_limit_mm: 5.0
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'KMOTOR Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/pal.yml
+++ b/helao/deploy/hte/configs/pal.yml
@@ -1,10 +1,11 @@
 # STANDALONE pal_server canary config (P3a special-split, PAL -- the 4-way
 # "wrap-then-split" WRAP step: port PAL behind the hexagon shim to openapi
 # parity first; the transport/trigger/sample-reconciliation/job-context split
-# is a later sub-phase). Mirrors ni.yml/kmotor.yml's 2-server shape (one action
-# server + one action_visualizer) so an at-station openapi golden diff can
-# compare legacy vs hexagon like-for-like without pulling in a full PAL station
-# (ORCH, SAMPLE, DB, NI, gamry, ...). The PAL `params:` (SSH user/key/host,
+# is a later sub-phase). This config is action-only: adss3.yml declares no
+# action_vis/live_vis for PAL, so a visualizer panel here would only ever be
+# blank. It exists so an at-station openapi golden diff can compare legacy vs
+# hexagon like-for-like without pulling in a full PAL station (ORCH, SAMPLE,
+# DB, NI, gamry, ...). The PAL `params:` (SSH user/key/host,
 # NI trigger lines, cam_file_path + cams map) are copied VERBATIM from adss3.yml
 # (the live PAL station) so pal_dyn_endpoints registers exactly the same route
 # surface -- the `cams:` entries GATE which PAL_transfer_*/PAL_archive endpoints
@@ -19,8 +20,7 @@
 # is the topology- and safety-appropriate parity check (mirrors ni/kmotor).
 # PAL is an SSH-connected Cytron/PAL autosampler -- WINDOWS-ONLY at station;
 # simulation:true is cosmetic (banner color). The openapi canary only needs the
-# server to boot and serve /openapi.json (connect failures are caught). PAL has
-# no visualizer, so ACTVIS shows an empty panel (as for cam/kmotor).
+# server to boot and serve /openapi.json (connect failures are caught).
 dummy: true
 simulation: true
 run_type: pal_server
@@ -48,11 +48,3 @@ servers:
         archive: custom_to_tray_220214.cam
         transfer_tray_custom: tray_to_custom_220214.cam
         deepclean: deep_clean_220214.cam
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'PAL Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/palhex.yml
+++ b/helao/deploy/hte/configs/palhex.yml
@@ -1,9 +1,10 @@
 # HEXAGON CANARY for the pal_server station (P3a special-split, PAL wrap step).
-# Copy of pal.yml with `deployment: hexagon` flipping PAL (pal_server) and
-# ACTVIS (action_visualizer) onto the hexagon factory (makeActionApp shim,
+# Copy of pal.yml with `deployment: hexagon` flipping PAL (pal_server) onto
+# the hexagon factory (makeActionApp shim,
 # helao/deploy/hexagon/servers/action/pal_server.py) -- run AT-STATION
 # (Windows, PAL autosampler reachable over SSH). pal.yml stays legacy for
-# rollback; the cut-over is ONLY the two `deployment: hexagon` keys.
+# rollback; the cut-over is ONLY the `deployment: hexagon` key. Action-only
+# (see pal.yml's header -- adss3.yml declares no visualizer for PAL).
 # Ports/root/params match pal.yml so an on-station openapi diff compares
 # like-for-like. The RPC port is HTTP+10000 = 18007.
 #
@@ -41,12 +42,3 @@ servers:
         archive: custom_to_tray_220214.cam
         transfer_tray_custom: tray_to_custom_220214.cam
         deepclean: deep_clean_220214.cam
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'PAL Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/sample.yml
+++ b/helao/deploy/hte/configs/sample.yml
@@ -7,8 +7,9 @@
 # back to an empty dict if absent) plus a root dir for its
 # helaodirs.states_root/db_root state files, both of which a plain Linux path
 # satisfies -- see golden_capture_sample.py's docstring for the full Step-0
-# investigation. Mirrors galil.yml's 2-server shape (one action server + one
-# action_visualizer) so an openapi/runtime golden diff can compare legacy vs
+# investigation. This config is action-only: eche10.yml declares no
+# action_vis/live_vis for SAMPLE, so a visualizer panel here would only ever
+# be blank. It exists so an openapi/runtime golden diff can compare legacy vs
 # hexagon like-for-like without pulling in the full eche10 station (ORCH,
 # MOTOR, PSTAT, IO, SPEC_T, DB, CAM, KMOTOR). `positions` is copied verbatim
 # from eche10.yml's SAMPLE block.
@@ -26,11 +27,3 @@ servers:
       positions:
         custom:
           cell1_we: cell
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'SAMPLE Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/samplegold.yml
+++ b/helao/deploy/hte/configs/samplegold.yml
@@ -20,11 +20,3 @@ servers:
       positions:
         custom:
           cell1_we: cell
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'SAMPLE Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/samplegoldhex.yml
+++ b/helao/deploy/hte/configs/samplegoldhex.yml
@@ -1,6 +1,6 @@
 # CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of samplehex.yml (keeps
-# `deployment: hexagon` on SAMPLE + ACTVIS -- the hexagon side of the runtime
-# golden diff) used solely by helao.hexagon.tests.smoke.golden_capture_sample
+# `deployment: hexagon` on SAMPLE -- the hexagon side of the runtime golden
+# diff) used solely by helao.hexagon.tests.smoke.golden_capture_sample
 # / sample_diff.sh to capture a runtime golden-master get_loaded_positions
 # tree. The ONLY change from samplehex.yml is `root:`, pointed at a dedicated
 # throwaway path so the capture rig's assert_fresh() has a clean tree to
@@ -22,12 +22,3 @@ servers:
       positions:
         custom:
           cell1_we: cell
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'SAMPLE Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/samplegraft.yml
+++ b/helao/deploy/hte/configs/samplegraft.yml
@@ -21,12 +21,3 @@ servers:
       positions:
         custom:
           cell1_we: cell
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'SAMPLE Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/samplehex.yml
+++ b/helao/deploy/hte/configs/samplehex.yml
@@ -1,10 +1,11 @@
 # HEXAGON CANARY for the sample_server station (P3a special-split). Copy of
-# sample.yml with `deployment: hexagon` flipping SAMPLE (sample_server) and
-# ACTVIS (action_visualizer) onto the hexagon factory. sample.yml stays
-# legacy for rollback; the cut-over is ONLY the two `deployment: hexagon`
-# keys. Ports/root/params match sample.yml so a golden diff compares
-# like-for-like. Unlike galil/gamry this canary is fully Linux-runnable (no
-# hardware, no COM/gclib) -- see golden_capture_sample.py's docstring.
+# sample.yml with `deployment: hexagon` flipping SAMPLE (sample_server) onto
+# the hexagon factory. sample.yml stays legacy for rollback; the cut-over is
+# ONLY the `deployment: hexagon` key. Action-only (see sample.yml's header --
+# eche10.yml declares no visualizer for SAMPLE). Ports/root/params match
+# sample.yml so a golden diff compares like-for-like. Unlike galil/gamry this
+# canary is fully Linux-runnable (no hardware, no COM/gclib) -- see
+# golden_capture_sample.py's docstring.
 dummy: true
 simulation: true
 run_type: sample_server
@@ -20,12 +21,3 @@ servers:
       positions:
         custom:
           cell1_we: cell
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'SAMPLE Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/syringe.yml
+++ b/helao/deploy/hte/configs/syringe.yml
@@ -1,8 +1,9 @@
 # STANDALONE syringe_server canary config (P3a special-split, SYRINGE pump).
-# Mirrors galil.yml/spec.yml's 2-server shape (one action server + one
-# action_visualizer) so an at-station openapi/runtime golden diff can compare
-# legacy vs hexagon like-for-like without pulling in the full ccsi1 station
-# (ORCH, the other syringe pumps, MFCs, sensors, DB, ...). The WORKSYRINGE
+# This config is action-only: ccsi1.yml declares no action_vis/live_vis for
+# WORKSYRINGE, so a visualizer panel here would only ever be blank. It exists
+# so an at-station openapi/runtime golden diff can compare legacy vs hexagon
+# like-for-like without pulling in the full ccsi1 station (ORCH, the other
+# syringe pumps, MFCs, sensors, DB, ...). The WORKSYRINGE
 # params (port, pumps: zero: {address, diameter}) are copied VERBATIM from
 # ccsi1.yml's WORKSYRINGE block so get_present_volume registers identically
 # (it is gated on nothing beyond the driver being constructed). This is the KD
@@ -32,11 +33,3 @@ servers:
         zero:
           address: 0
           diameter: 26.7
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'WORKSYRINGE Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/syringegold.yml
+++ b/helao/deploy/hte/configs/syringegold.yml
@@ -27,11 +27,3 @@ servers:
         zero:
           address: 0
           diameter: 26.7
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    params:
-      doc_name: 'WORKSYRINGE Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/syringegoldhex.yml
+++ b/helao/deploy/hte/configs/syringegoldhex.yml
@@ -1,6 +1,6 @@
 # CAPTURE-ONLY THROWAWAY ROOT, NEVER PRODUCTION. Copy of syringehex.yml
-# (keeps `deployment: hexagon` on WORKSYRINGE + ACTVIS -- the hexagon side of
-# the runtime golden diff) used solely by
+# (keeps `deployment: hexagon` on WORKSYRINGE -- the hexagon side of the
+# runtime golden diff) used solely by
 # helao.hexagon.tests.smoke.golden_capture_syringe / syringe_diff.bat to
 # capture a runtime golden-master get_present_volume tree. The ONLY change from
 # syringehex.yml is `root:`, pointed at a dedicated throwaway path so the
@@ -28,12 +28,3 @@ servers:
         zero:
           address: 0
           diameter: 26.7
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'WORKSYRINGE Visualizer'
-      launch_browser: true

--- a/helao/deploy/hte/configs/syringehex.yml
+++ b/helao/deploy/hte/configs/syringehex.yml
@@ -1,8 +1,9 @@
 # HEXAGON CANARY for the syringe_server station (P3a special-split). Copy of
 # syringe.yml with `deployment: hexagon` flipping WORKSYRINGE (syringe_server)
-# and ACTVIS (action_visualizer) onto the hexagon factory -- the hte cut-over
-# target, run AT-STATION (Windows/pyserial COM5). syringe.yml stays legacy for
-# rollback; the cut-over is ONLY the two `deployment: hexagon` keys.
+# onto the hexagon factory -- the hte cut-over target, run AT-STATION
+# (Windows/pyserial COM5). syringe.yml stays legacy for rollback; the
+# cut-over is ONLY the `deployment: hexagon` key. Action-only (see
+# syringe.yml's header -- ccsi1.yml declares no visualizer for WORKSYRINGE).
 # Ports/root/params match syringe.yml so an on-station openapi diff compares
 # like-for-like.
 dummy: true
@@ -22,12 +23,3 @@ servers:
         zero:
           address: 0
           diameter: 26.7
-  ACTVIS:
-    host: 127.0.0.1
-    port: 5001
-    group: visualizer
-    bokeh: action_visualizer
-    deployment: hexagon
-    params:
-      doc_name: 'WORKSYRINGE Visualizer'
-      launch_browser: true

--- a/helao/hexagon/tests/smoke/analysis_canary.sh
+++ b/helao/hexagon/tests/smoke/analysis_canary.sh
@@ -15,8 +15,8 @@
 # identical route/schema surface proves the hexagon makeActionApp factory
 # produces a byte-parity action server for this cut-over target.
 #
-# Both configs share root /tmp/INST_hlo_analysis and ports 8014/5001, so they
-# MUST run sequentially (this script does that) -- never launch both at once.
+# Both configs share root /tmp/INST_hlo_analysis and port 8014, so they MUST
+# run sequentially (this script does that) -- never launch both at once.
 #
 # Usage: analysis_canary.sh [root] [outdir]
 #   root   default /tmp/INST_hlo_analysis   (must match the configs' root: key)

--- a/helao/hexagon/tests/smoke/andor_canary.bat
+++ b/helao/hexagon/tests/smoke/andor_canary.bat
@@ -11,13 +11,13 @@ REM ATSpectrograph) cut-over target.
 REM
 REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
 REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
-REM sequences to an orchestrator. andorhex is a 2-server group (ANDOR@8011 +
-REM ACTVIS@5001) with NO orchestrator, so the GM-* scenarios cannot drive it.
+REM sequences to an orchestrator. andorhex is a 1-server group (ANDOR@8011)
+REM with NO orchestrator, so the GM-* scenarios cannot drive it.
 REM The openapi diff is the topology-appropriate parity check (mirrors
 REM spec_canary.bat / cam_canary.bat exactly). See andor_diff.bat for the
 REM runtime `acquire` golden diff, the topology-appropriate DATA check.
 REM
-REM Both configs share root C:\INST_hlo and ports 8011/5001, so they MUST run
+REM Both configs share root C:\INST_hlo and port 8011, so they MUST run
 REM sequentially (this script does that) -- never launch both at once.
 REM NOTE: andor.yml's simulation:true is cosmetic (banner color) -- AndorDriver
 REM has no sim/dummy data path (see golden_capture_andor.py). AndorDriver.connect

--- a/helao/hexagon/tests/smoke/cam_canary.bat
+++ b/helao/hexagon/tests/smoke/cam_canary.bat
@@ -19,10 +19,10 @@ REM epoch_s/filename columns value-masked (see golden_capture_cam.py).
 REM
 REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
 REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
-REM sequences to an orchestrator. camhex is a 2-server group (CAM@8013 +
-REM ACTVIS@5001) with NO orchestrator (mirrors galil_canary.bat exactly).
+REM sequences to an orchestrator. camhex is a 1-server group (CAM@8013) with
+REM NO orchestrator (mirrors galil_canary.bat exactly).
 REM
-REM Both configs share root C:\INST_hlo and ports 8013/5001, so they MUST run
+REM Both configs share root C:\INST_hlo and port 8013, so they MUST run
 REM sequentially (this script does that) -- never launch both at once.
 REM NOTE: AxisCam.connect() opens no network connection (returns success
 REM unconditionally), so this canary boots and serves /openapi.json even without

--- a/helao/hexagon/tests/smoke/dbpack_canary.sh
+++ b/helao/hexagon/tests/smoke/dbpack_canary.sh
@@ -16,8 +16,8 @@
 # route/schema surface proves the hexagon makeActionApp factory produces a
 # byte-parity action server for this cut-over target.
 #
-# Both configs share root /tmp/INST_hlo_dbpack and ports 8010/5001, so they
-# MUST run sequentially (this script does that) -- never launch both at once.
+# Both configs share root /tmp/INST_hlo_dbpack and port 8010, so they MUST
+# run sequentially (this script does that) -- never launch both at once.
 #
 # Usage: dbpack_canary.sh [root] [outdir]
 #   root   default /tmp/INST_hlo_dbpack    (must match the configs' root: key)

--- a/helao/hexagon/tests/smoke/diapump_canary.bat
+++ b/helao/hexagon/tests/smoke/diapump_canary.bat
@@ -18,10 +18,10 @@ REM and analysis_canary.sh.
 REM
 REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
 REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
-REM sequences to an orchestrator. diapumphex is a 2-server group (DOSEPUMP@8016 +
-REM ACTVIS@5001) with NO orchestrator (mirrors cam_canary.bat exactly).
+REM sequences to an orchestrator. diapumphex is a 1-server group (DOSEPUMP@8016)
+REM with NO orchestrator (mirrors cam_canary.bat exactly).
 REM
-REM Both configs share root C:\INST_hlo and ports 8016/5001, so they MUST run
+REM Both configs share root C:\INST_hlo and port 8016, so they MUST run
 REM sequentially (this script does that) -- never launch both at once.
 REM NOTE: this openapi canary only boots each server and reads /openapi.json; it
 REM never dispatches an action, so no pump ever moves fluid and no COM device

--- a/helao/hexagon/tests/smoke/galil_canary.bat
+++ b/helao/hexagon/tests/smoke/galil_canary.bat
@@ -11,12 +11,12 @@ REM major Windows/gclib driver, after gamry).
 REM
 REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
 REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
-REM sequences to an orchestrator. galilhex is a 2-server group (MOTOR@8003 +
-REM ACTVIS@5001) with NO orchestrator, so the GM-* scenarios cannot drive it.
+REM sequences to an orchestrator. galilhex is a 1-server group (MOTOR@8003)
+REM with NO orchestrator, so the GM-* scenarios cannot drive it.
 REM The openapi diff is the topology-appropriate parity check (mirrors
 REM gamryhex_canary.bat exactly).
 REM
-REM Both configs share root C:\INST_hlo and ports 8003/5001, so they MUST run
+REM Both configs share root C:\INST_hlo and port 8003, so they MUST run
 REM sequentially (this script does that) -- never launch both at once.
 REM NOTE: galil.yml's simulation:true is cosmetic (banner color) here --
 REM Galil.connect() has no sim/dummy data path (see golden_capture_galil.py's

--- a/helao/hexagon/tests/smoke/kmotor_canary.bat
+++ b/helao/hexagon/tests/smoke/kmotor_canary.bat
@@ -24,10 +24,10 @@ REM and safety-appropriate parity check (mirrors ni_canary.bat exactly).
 REM
 REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
 REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
-REM sequences to an orchestrator. kmotorhex is a 2-server group (KMOTOR@8015 +
-REM ACTVIS@5001) with NO orchestrator, so the GM-* scenarios cannot drive it.
+REM sequences to an orchestrator. kmotorhex is a 1-server group (KMOTOR@8015)
+REM with NO orchestrator, so the GM-* scenarios cannot drive it.
 REM
-REM Both configs share root C:\INST_hlo and ports 8015/5001, so they MUST run
+REM Both configs share root C:\INST_hlo and port 8015, so they MUST run
 REM sequentially (this script does that) -- never launch both at once.
 REM NOTE: kmotor.yml's simulation:true is cosmetic (banner color) -- Kinesis
 REM has no sim/dummy data path. KinesisMotor.connect() opens a real pylablib

--- a/helao/hexagon/tests/smoke/pal_canary.bat
+++ b/helao/hexagon/tests/smoke/pal_canary.bat
@@ -24,10 +24,10 @@ REM so both legs register the same surface.
 REM
 REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
 REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
-REM sequences to an orchestrator. palhex is a 2-server group (PAL@8007 +
-REM ACTVIS@5001) with NO orchestrator, so the GM-* scenarios cannot drive it.
+REM sequences to an orchestrator. palhex is a 1-server group (PAL@8007) with
+REM NO orchestrator, so the GM-* scenarios cannot drive it.
 REM
-REM Both configs share root C:\INST_hlo_golden and ports 8007/5001, so they MUST
+REM Both configs share root C:\INST_hlo_golden and port 8007, so they MUST
 REM run sequentially (this script does that) -- never launch both at once.
 REM NOTE: simulation:true is cosmetic (banner color) -- PAL has no sim/dummy data
 REM path. The PAL driver opens an SSH session to the autosampler host at startup;

--- a/helao/hexagon/tests/smoke/sample_canary.sh
+++ b/helao/hexagon/tests/smoke/sample_canary.sh
@@ -14,14 +14,14 @@
 #
 # Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
 # golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
-# sequences to an orchestrator. sample/samplehex is a 2-server group
-# (SAMPLE@8008 + ACTVIS@5001) with NO orchestrator, so the GM-* scenarios
-# cannot drive it via that harness -- the openapi diff is the
-# topology-appropriate parity check (see sample_diff.sh for the runtime
-# get_loaded_positions golden diff, the topology-appropriate DATA check).
+# sequences to an orchestrator. sample/samplehex is a 1-server group
+# (SAMPLE@8008) with NO orchestrator, so the GM-* scenarios cannot drive it
+# via that harness -- the openapi diff is the topology-appropriate parity
+# check (see sample_diff.sh for the runtime get_loaded_positions golden diff,
+# the topology-appropriate DATA check).
 #
-# Both configs share root /tmp/INST_hlo_sample and ports 8008/5001, so they
-# MUST run sequentially (this script does that) -- never launch both at once.
+# Both configs share root /tmp/INST_hlo_sample and port 8008, so they MUST
+# run sequentially (this script does that) -- never launch both at once.
 #
 # Usage: sample_canary.sh [root] [outdir]
 #   root   default /tmp/INST_hlo_sample   (must match the configs' root: key)

--- a/helao/hexagon/tests/smoke/syringe_canary.bat
+++ b/helao/hexagon/tests/smoke/syringe_canary.bat
@@ -12,14 +12,14 @@ REM Legato syringe pump) cut-over target.
 REM
 REM Why NOT parity_run.sh / harness.capture: that harness is hardcoded to the
 REM golden SIM group topology (orch@8001, sim@8002, db@8010) and dispatches
-REM sequences to an orchestrator. syringehex is a 2-server group
-REM (WORKSYRINGE@8013 + ACTVIS@5001) with NO orchestrator, so the GM-* scenarios
-REM cannot drive it. The openapi diff is the topology-appropriate parity check
+REM sequences to an orchestrator. syringehex is a 1-server group
+REM (WORKSYRINGE@8013) with NO orchestrator, so the GM-* scenarios cannot
+REM drive it. The openapi diff is the topology-appropriate parity check
 REM (mirrors spec_canary.bat / galil_canary.bat / gamryhex_canary.bat exactly).
 REM See syringe_diff.bat for the runtime get_present_volume golden diff, the
 REM topology-appropriate DATA check.
 REM
-REM Both configs share root C:\INST_hlo and ports 8013/5001, so they MUST run
+REM Both configs share root C:\INST_hlo and port 8013, so they MUST run
 REM sequentially (this script does that) -- never launch both at once.
 REM NOTE: syringe.yml's simulation:true is cosmetic (banner color) -- KDS100 has
 REM no sim/dummy driver swap. KDS100.connect() opens the pyserial COM5 port at

--- a/launch.py
+++ b/launch.py
@@ -592,7 +592,12 @@ def launcher(confArg, confDict, helao_repo_root, extraopt="", restore=False):
     Returns:
         Pidd: An instance of the Pidd class containing the process IDs of the launched servers.
     """
-    confPrefix = os.path.basename(confArg).replace(".py", "")
+    # Strip ANY config extension (.py/.yml/.yaml), not just .py, so launching by
+    # a full path to a .yml config (read_config accepts either a bare prefix or a
+    # full path) yields a clean prefix -- the pid pickle is named
+    # pids_<confPrefix>_<extraopt>.pck and kill_group globs it, so a stray ".yml"
+    # here would change the pickle name. splitext drops only the final extension.
+    confPrefix = os.path.splitext(os.path.basename(confArg))[0]
     # get the BaseModel which contains all the dirs for helao
     helaodirs = helao_dirs(confDict, "launcher")
 


### PR DESCRIPTION
## Visualizer wiring rule
A canary config should launch a visualizer only if the inherited production config points the action server at one (`action_vis:`/`live_vis:`). These hte canaries have no such key, so their `action_visualizer` panel was always blank — this removes the visualizer server from each (action-only 1-server config).

**Dropped (31 configs):** andor / cam / galil / kmotor / pal / syringe / diapump (hardware) + sample / analysis / dbpack (software), across their `{,hex,gold,goldhex}` + `samplegraft` variants.
**Left correctly wired (production points to a vis):** gamry/spec/biologic/ni (`action_vis`), mfc/co2/galilio (`live_vis`), tec/powersupply.

10 smoke scripts had comment-only edits (removed stale `ACTVIS@5001` topology notes); verified none wait-on/poll/kill the vis port 5001.

## launch.py prefix fix
`confPrefix` now uses `os.path.splitext(basename(confArg))[0]` instead of `.replace('.py','')`, so launching by a full `.yml` config path yields a clean prefix (stable `pids_<prefix>_*.pck` name). Bare-prefix launches unchanged.

Verified: all 31 configs valid YAML / single-server, preflight OK sample, launch.py compiles + splitext sanity-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)