### PR TITLE
P3a special-splits + P3a-2 constructor-connect (galil / gamry / andor / biologic) — HOLD for at-station

### DIFF
--- a/docs/superpowers/plans/2026-07-22-P3a-galil-slice4-aligner-extraction.md
+++ b/docs/superpowers/plans/2026-07-22-P3a-galil-slice4-aligner-extraction.md
@@ -1,0 +1,91 @@
+# P3a galil slice-4 — aligner Bokeh/D6 extraction (construct-test tier)
+
+> Sub-slice of the galil special-split (roadmap `2026-07-18-P3a-special-splits-roadmap.md`
+> §"galil slice 4"). **HIGHEST RISK; NOT Linux-runtime-verifiable** (needs a live
+> Bokeh session + an at-station plate-alignment dry-run). Built construct-test-only
+> per an explicit user decision (2026-07-22), accepting rework risk if the design
+> shifts at station. **Do NOT merge until an at-station alignment dry-run passes.**
+
+## The D6 violation being removed
+
+The Galil motion **driver** currently (a) constructs a Bokeh `Server` + `HelaoVis`
+(`start_aligner`/`makeBokehApp`), (b) holds an action `Active` (`self.aligner_active`),
+and (c) exposes a `base` property that exists solely so the Bokeh aligner
+(`layouts/aligner.py`, 1685 LOC) can reach `motor.base.helaodirs` / `motor.base.get_main_error`.
+A hardware driver owning a UI server + an Active + a Base back-reference is the D6
+"Bokeh-Server-in-driver" violation.
+
+## Design — `AlignerMotorContext` + vis-layer `AlignerHost` (minimal-aligner-edit)
+
+Chosen because the 1685-LOC aligner cannot be runtime-verified: keep its body
+almost untouched by handing it a **context object in place of the raw driver**.
+The aligner still calls `self.motor.<x>`; `motor` is now the context, which:
+
+- **Delegates to the legacy driver** (live, cache-nothing): motion (`_motor_move`,
+  `query_axis_position`), `transform`, calibration (`plate_transfermatrix`,
+  `dflt_matrix`, `update_plate_transfermatrix`, `save_transfermatrix`), and the
+  **driver-owned mutual-exclusion/motion flags** `blocked` (shared lock with
+  `_motor_move` D:558-567 — MUST stay on the driver) and `motor_busy`.
+- **Owns** the aligner-session state the hardware driver should never hold:
+  `base` (the real `Base`), `aligner_active` (the `Active`), `aligner_plateid`,
+  `aligning_enabled`, and the `aligner` back-ref (A:104 `self.motor.aligner = self`).
+
+The **`AlignerHost`** (vis layer, `helao/hexagon/adapters/vis/galil_aligner_host.py`)
+owns the Bokeh `Server` + `HelaoVis` construction (relocated `start_aligner` +
+`makeBokehApp`) and the aligner-orchestration verbs the server calls
+(`run_aligner_precheck`, `start_aligner_run`, `stop_aligner`). It builds the
+`AlignerMotorContext(driver, base)`, and on `Aligner` construction wires the
+driver's position-notify sink to the aligner's `motorpos_q`.
+
+### Driver after slice-4
+- **Removed:** imports `Server` (D:41), `HelaoVis` (D:47), `Aligner` (D:56);
+  methods `start_aligner`, `makeBokehApp`, `start_aligner_run`,
+  `run_aligner_precheck`, `stop_aligner`; the `base` property (D:139-147);
+  attrs `bokehapp`, `aligner_active`, `aligner_plateid`, `aligning_enabled`;
+  the `connect()` aligner-start block (D:272-273).
+- **Kept:** `blocked`, `motor_busy` (motion state); `_base_hook` (its own
+  `connect()` reads `helaodirs`/`server_cfg` off it — unrelated to the aligner).
+- **Changed:** `self.aligner` becomes an optional **position-notify sink**
+  (an object with `motorpos_q`, or `None`), set by the host. `update_aligner`
+  (D:1275-1278, called from `query_axis_position` D:1042 / `query_axis_moving`
+  D:1098) pushes to that sink. `shutdown`'s `self.aligner.IOtask.cancel()`
+  (D:1272) moves to `AlignerHost.shutdown()`, invoked from the server shutdown.
+
+### Aligner (`layouts/aligner.py`) edits — kept minimal
+- `Aligner(vis, motor)` unchanged signature; `motor` is now the context.
+  Every `self.motor.<x>` continues to resolve (context provides the surface).
+- A:104 `self.motor.aligner = self` still valid (context stores it + the host
+  reads `aligner.motorpos_q` to wire the driver sink).
+- Teardown A:1203-1206 unchanged: `aligner_active=None`/`aligner_plateid=None`/
+  `aligning_enabled=False` hit context state; `blocked=False` delegates to the
+  driver (correctly clears the shared lock).
+
+### Server (`servers/action/galil_motion.py`) edits
+- After `connect()`, if `enable_aligner` + `galil_enabled`, construct
+  `AlignerHost(driver=app.driver, base=app.base, config=...)` and start it
+  (replaces the driver's self-start).
+- `run_aligner`/`stop_aligner`/`setmotionref` endpoints call the **host**
+  (`host.run_aligner_precheck()`, `host.start_aligner_run(active)`,
+  `host.stop_aligner()`) instead of `app.driver.*`. The `Active` is still built
+  by the endpoint (`app.base.contain_action`, S:156) and handed to the host.
+- Register `host.shutdown()` on the FastAPI shutdown path.
+
+## Construct-test coverage (Linux)
+- Driver imports with NO bokeh/aligner symbols; constructs; `hasattr(driver,
+  "start_aligner") is False`; `hasattr(driver, "base") is False`;
+  `aligner_active`/`bokehapp` gone.
+- `AlignerMotorContext` delegates every driver verb/flag (fake driver records
+  calls); owns base/active/plateid/aligning_enabled; `blocked` r/w hits the
+  driver.
+- `AlignerHost` builds a Bokeh `Server` object (no `.start()`), wires the sink,
+  exposes the 3 orchestration verbs.
+- Aligner still resolves `self.motor.<x>` against the context (smoke-construct
+  with a fake vis + context, guarded — the real `Aligner.__init__` starts an
+  asyncio task + builds Bokeh layout, so this may stay a surface-audit rather
+  than a live construct; decide during impl).
+
+## AT-STATION GATE (do first before merge)
+Real Bokeh session on the galil/aligner station: open the `/Aligner` page,
+run a plate alignment, confirm motion + live position widgets + calibration
+write (`-plate_calib`) + Active finish behave byte-identically to legacy, and
+that estop/`blocked` still serialize aligner-vs-motion. Only then merge.

--- a/docs/superpowers/plans/2026-07-22-P3a-gamry-com-sta-thread.md
+++ b/docs/superpowers/plans/2026-07-22-P3a-gamry-com-sta-thread.md
@@ -1,0 +1,146 @@
+# P3a Gamry COM STA-thread adapter — design plan
+
+> Sub-slice of the galil/PAL/Gamry special splits (roadmap
+> `2026-07-18-P3a-special-splits-roadmap.md` §"Gamry"). **Windows-only
+> (comtypes); NOT Linux-runtime-verifiable** — the whole point is COM
+> apartment/thread affinity, which only manifests on Windows against a live
+> GamryCOM server + potentiostat. Construct-test on Linux; **runtime +
+> apartment-affinity verify at-station** before any cut-over. This is the
+> highest-risk item in the P3a program: it introduces *new* runtime threading
+> semantics (unlike the galil slices, which were behavior-preserving
+> delegation/relocation), so it must be built where it can be iterated against
+> hardware.
+
+## Status
+- **DONE now (Linux-safe prep, this session):** `sys.coinit_flags` moved out of
+  module import into `GamryDriver.connect()` (before the first
+  `import comtypes.client`). Importing the driver — including on Linux in the
+  hexagon import-sweep — no longer mutates a process-global. Value unchanged
+  (`0x0` == `COINIT_MULTITHREADED`, also comtypes' own default); connect() is
+  the driver's first comtypes user, so the Windows apartment model is
+  unchanged. Verified: import sets nothing, pulls no comtypes; pyright delta 0.
+- **PLANNED (this doc):** the STA-thread adapter + the §10.4 constructor-connect
+  fold. Build + verify at-station.
+
+## Current architecture (legacy `GamryDriver`, driver.py 803 LOC)
+
+All COM work runs **on the caller's thread** in the **MTA** (`coinit_flags=0x0`).
+Three distinct COM interaction "strategies" coexist behind one driver:
+
+1. **DC / dtaq-sink** (CV/CA/CP/LSV/OCV/RCA): `setup()` builds a `GamryDtaq*`
+   COM object + `GamryDtaqSink` (a `client.GetEvents(dtaq, sink)` event sink);
+   `measure()` energizes the cell + `dtaq.Run(True)`; `get_data(pump_rate)`
+   calls **`comtypes.client.PumpEvents(pump_rate)`** on the caller thread to
+   drive the COM event loop, then drains `dtaqsink.acquired_points`.
+2. **EIS / ReadZ** (PEIS/GEIS): `setup_eis()` builds a `GamryReadZ` + a `ReadZ`
+   helper (readz.py, its own events); `close_eis()` tears it down. `stop()`
+   must check `readz` first (EIS keeps `dtaqsink == DummySink`).
+3. **Idle poller** (`GamryPoller.get_data`): samples `MeasureV/I/A` directly on
+   the pstat — conflicts with 1/2, idle-only.
+
+`stop()` today branches on *which strategy is live* (readz vs dtaqsink).
+`reset()`/`kill_gamrycom()` force-terminate the out-of-process `GamryCOM.exe`
+via psutil (supervisor concern). `__init__` calls `self.connect()` (§10.4
+constructor-connect violation). `pstat.State()` string parsing in
+`get_status`/`get_gamry_state`.
+
+### Why an STA thread
+- COM objects have **apartment affinity**. In an MTA, event sinks + `PumpEvents`
+  are fragile: `PumpEvents` pumps the *calling thread's* message queue, but MTA
+  threads have no STA message pump, so dtaq event delivery relies on COM's MTA
+  marshalling and the ad-hoc `PumpEvents` poll. The robust pattern for
+  event-sink COM (dtaq `_IGamryDtaqEvents`) is a dedicated **STA** thread that
+  (a) `CoInitializeEx(COINIT_APARTMENTTHREADED)`, (b) creates the COM objects,
+  (c) runs the message pump, (d) delivers sink callbacks on that same thread.
+- Every COM call must then be **marshalled onto that thread** (the pstat/dtaq/
+  readz objects live there); results marshalled back via a queue/future.
+
+## Target design — `GamryComThread` owning all COM, behind a native adapter
+
+New module (proposed): `helao/hexagon/adapters/native/gamry_com.py`.
+
+### `GamryComThread`
+A dedicated worker thread that OWNS the COM apartment and all GamryCOM objects.
+- `start()`: spawn `threading.Thread(target=_run, daemon=True)`. `_run`:
+  `sys.coinit_flags` set → `import comtypes` → `CoInitializeEx` (STA) → create a
+  request queue consumer loop that **also pumps COM messages** (interleave
+  `queue.get(timeout=short)` with `PumpEvents(short)` so dtaq sink callbacks and
+  submitted calls both progress) → on shutdown `CoUninitialize`.
+- `submit(fn, *args) -> Future`: enqueue a callable to run **on the COM thread**;
+  the loop executes it and sets the `Future` result/exception. All pstat/dtaq/
+  readz method calls (connect/setup/measure/get_data/stop/cleanup/disconnect/
+  setup_eis/close_eis/poll) go through `submit`, so COM objects are only ever
+  touched on their owning thread.
+- The dtaq event sink stays the existing `GamryDtaqSink`; it is created and
+  receives callbacks on the COM thread. `get_data` becomes "on the COM thread,
+  the pump has already run; drain acquired_points" — the explicit
+  `PumpEvents(pump_rate)` per call is replaced by the loop's continuous pump,
+  and `get_data` just snapshots new points (marshalled out).
+
+### `GamryComAdapter` (the HardwarePort-ish native adapter)
+- Disconnected construct (§10.4): `__init__(config)` does **zero COM** — no
+  thread start, no connect. `connect()` starts the `GamryComThread` and submits
+  the open. Mirrors the andor/kinesis `_load_*`/relocate-connect pattern and the
+  galil slice-3 adapter.
+- Exposes the same verbs as `GamryDriver` (setup/measure/get_data/stop/cleanup/
+  disconnect/reset/setup_eis/close_eis/get_status/get_gamry_state) but each is a
+  thin `self._thread.submit(...)`; returns the legacy `DriverResponse` verbatim
+  (behavior-preserving at the API boundary).
+- **Three strategies unified:** the adapter tracks the live strategy
+  (`_active: {"dc","eis","idle",None}`) so `stop()`/`cleanup()` dispatch to the
+  right teardown without today's implicit readz-vs-dtaqsink branch. The idle
+  poller (`GamryPoller`) also submits `MeasureV/I/A` onto the COM thread (fixes
+  the current "poller conflicts with measurement" footgun via a single-owner
+  thread + the `_active` guard).
+- **Supervisor (reset/kill):** `kill_gamrycom()` (psutil, out-of-process kill)
+  and the `recover_stale_gamrycom` self-heal stay adapter-level (they act on the
+  OS process, not COM objects); `reset()` = tear down the thread → kill → new
+  thread → connect.
+
+## §10.4 constructor-connect fold (cross-deployment — coordinate)
+
+Removing `self.connect()` from `GamryDriver.__init__` requires the hosting
+server to call `connect()` explicitly (like `galil_dyn_endpoints`). But
+`GamryDriver` is imported+constructed by **three** servers:
+- `helao/deploy/hte/servers/action/gamry_server2.py` (`gamry_dyn_endpoints`
+  waits on `app.driver.ready` then reads `app.driver.model` — set by connect()).
+- **private** `lila/servers/action/potentiostat_server.py`
+- **private** `lila_gl/servers/potentiostat_server.py`
+All three must add an explicit `app.driver.connect()` (in their dyn_endpoints /
+startup) before touching `app.driver.model`. **Do NOT change the shared
+`GamryDriver.__init__` contract without landing the matching server changes in
+the two private repos in the same wave** — else those deployments construct a
+never-connected driver. For the native adapter this is free (the adapter is
+disconnected-construct from day one, connect() started by whoever wires it).
+
+## Construct-test tier (Linux, buildable now if pursued)
+- Adapter `__init__` touches no COM / starts no thread (assert, no comtypes in
+  `sys.modules`).
+- `GamryComThread.submit` executes callables on the worker thread and returns
+  results/exceptions through the Future — testable with a **fake COM object**
+  (no comtypes): prove marshalling + ordering + the interleaved-pump loop's
+  liveness, and that a submitted exception propagates.
+- `_active` strategy state machine transitions (dc/eis/idle/None) unit-tested.
+- Import-sweep: module imports on Linux with comtypes absent (lazy import inside
+  the thread `_run`).
+
+## AT-STATION GATE (must pass before cut-over)
+Windows + live GamryCOM + potentiostat: run OCV/CV (dtaq-sink), PEIS (ReadZ),
+and the idle poller; confirm data parity vs legacy (golden diff — the existing
+`golden_diff.bat` harness), that dtaq events deliver on the STA thread without
+missed points, that stop/estop halt mid-measurement, that reset/kill recover a
+hung `GamryCOM.exe`, and — critically — **apartment affinity**: no cross-thread
+COM call escapes the owning thread (would raise `RPC_E_WRONG_THREAD` /
+`CoInitialize`-not-called). Verify the golden OCV byte-parity still holds.
+
+## Risks / open questions
+- STA message-pump + `queue.get` interleaving cadence vs the current explicit
+  `PumpEvents(pump_rate)` — event delivery latency/coalescing may shift the
+  sampled-point cadence; validate against a golden CV.
+- `ReadZ` (readz.py, 439 LOC) has its own events loop — must also move onto the
+  COM thread; audit its `PumpEvents`/event usage during the build.
+- Whether STA is even required vs staying MTA-with-a-dedicated-pump-thread: STA
+  is the textbook fit for event-sink COM, but if legacy MTA+PumpEvents has been
+  reliable at-station for years, a lower-risk variant is a dedicated **MTA**
+  worker thread (single-owner, continuous pump) WITHOUT switching apartment —
+  decide at-station based on observed event reliability.

--- a/helao/deploy/hte/drivers/motion/galil_motion_driver.py
+++ b/helao/deploy/hte/drivers/motion/galil_motion_driver.py
@@ -30,7 +30,6 @@ __all__ = ["Galil", "MoveModes", "TransformationModes"]
 import numpy as np
 import time
 import asyncio
-from functools import partial
 import json
 import os
 from socket import gethostname
@@ -38,13 +37,10 @@ from copy import deepcopy
 import traceback
 
 
-from bokeh.server.server import Server
-
 from helao.helpers import helao_logging as logging
 
 LOGGER = logging.make_logger(__file__) if logging.LOGGER is None else logging.LOGGER
 from helao.core.error import ErrorCodes
-from helao.core.servers.vis import HelaoVis
 from helao.core.models.sample import SolidSample
 from helao.core.drivers.helao_driver import (
     HelaoDriver,
@@ -53,7 +49,10 @@ from helao.core.drivers.helao_driver import (
     DriverResponseType,
 )
 
-from ...layouts.aligner import Aligner
+# P3a galil-split slice-4: the Bokeh `Server`/`HelaoVis` construction and the
+# `Aligner` import moved to the vis-layer host
+# (`helao/hexagon/adapters/vis/galil_aligner_host.py`); the driver no longer
+# hosts a Bokeh server, holds an Active, or exposes a `base` property (D6 fix).
 from ...drivers.motion.enum import MoveModes, TransformationModes
 from helao.hexagon.domain.motion_transform import TransformXY
 from helao.hexagon.adapters.legacy.calibration_store import JsonFileCalibrationStore
@@ -122,29 +121,30 @@ class Galil(HelaoDriver):
         self.galilcmd = None
         self.galil_enabled = None
 
-        # block gamry
+        # block gamry -- also the shared mutual-exclusion lock between
+        # `_motor_move` and a running plate alignment (driver-owned; the
+        # vis-layer aligner host reads/clears it through AlignerMotorContext).
         self.blocked = False
         # is motor move busy?
         self.motor_busy = False
-        self.bokehapp = None
-        self.aligner = None
-        self.aligning_enabled = False
-        self.aligner_plateid = None
-        self.aligner_active = None
-        # identical to the pre-migration `self.base.server_params.get(...)`
-        # read: `server_api.py:74` makes `config` and `server_params` the
-        # same dict object (K1).
-        self.aligner_enabled = self.config_dict.get("enable_aligner", False)
 
-    @property
-    def base(self):
-        """Backward-compatible alias for `_base_hook`.
+        # P3a galil-split slice-4: the Bokeh aligner + its Active are no longer
+        # owned by the driver. The driver keeps only an optional position-notify
+        # sink (the aligner's asyncio queue) that `update_aligner` feeds; the
+        # vis-layer `GalilAlignerHost` sets it via `set_position_sink`. The old
+        # `bokehapp`/`aligner`/`aligning_enabled`/`aligner_plateid`/
+        # `aligner_active`/`aligner_enabled` attrs and the `base` property moved
+        # to the host / AlignerMotorContext (D6 fix).
+        self._position_sink = None
 
-        `layouts/aligner.py` (out of this migration's scope) reads
-        `motor.base.helaodirs` / `motor.base.get_main_error` directly; this
-        keeps that working without touching the Bokeh aligner module.
+    def set_position_sink(self, sink) -> None:
+        """Register (or clear with ``None``) the aligner position-notify queue.
+
+        Called by the vis-layer ``GalilAlignerHost`` when it constructs the
+        Bokeh ``Aligner``; ``update_aligner`` pushes motor position/status
+        dicts here so the aligner's Bokeh widgets stay live.
         """
-        return self._base_hook
+        self._position_sink = sink
 
     def connect(self) -> DriverResponse:
         """Load plate calibration, build the axis transform, open the gclib
@@ -269,8 +269,9 @@ class Galil(HelaoDriver):
                 LOGGER.error("Galil connection error", exc_info=True)
                 self.galil_enabled = False
 
-            if self.aligner_enabled and self.galil_enabled and self.bokehapp is None:
-                self.start_aligner()
+            # P3a galil-split slice-4: the Bokeh aligner is no longer started
+            # here. The action server constructs `GalilAlignerHost` after
+            # connect() when `enable_aligner` is set (D6 fix).
 
             return DriverResponse(
                 response=DriverResponseType.success,
@@ -356,46 +357,6 @@ class Galil(HelaoDriver):
         Minstr[1][3] = Mplate[1][2]
         return Minstr
 
-    def start_aligner(self):
-        """Launch the embedded Bokeh aligner server on `bokeh_port`.
-
-        `host`/`port` (and the `bokeh_port` fallback) live on the server's
-        top-level `server_cfg` entry, not inside `self.config` (only
-        `server_cfg["params"]` is handed to a migrated driver), so these
-        are read via `self._base_hook.server_cfg` (K2/K8) -- safe here
-        because `connect` (the only caller) runs after the hosting server
-        assigns `_base_hook`.
-        """
-        server_cfg = getattr(self._base_hook, "server_cfg", None)
-        if server_cfg is None:
-            LOGGER.warning(
-                "start_aligner: _base_hook/server_cfg not set; aligner not started"
-            )
-            return
-        servHost = server_cfg["host"]
-        servPort = self.config_dict.get("bokeh_port", server_cfg["port"] + 1000)
-        servPy = "Aligner"
-
-        self.bokehapp = Server(
-            {f"/{servPy}": partial(self.makeBokehApp, motor=self)},
-            port=servPort,
-            address=servHost,
-            allow_websocket_origin=[f"{servHost}:{servPort}"],
-        )
-        LOGGER.info(f"started bokeh server {self.bokehapp}")
-        self.bokehapp.start()
-        # self.bokehapp.io_loop.add_callback(self.bokehapp.show, f"/{servPy}")
-
-    def makeBokehApp(self, doc, motor):
-        """Bokeh document factory that attaches an `Aligner` to `doc`."""
-        app = HelaoVis(
-            server_key=self._base_hook.server.server_name,
-            doc=doc,
-        )
-
-        doc.aligner = Aligner(app.vis, motor)
-        return doc
-
     async def setaxisref(self):
         """Home every linear axis, refine the home position, then zero absolute coords.
 
@@ -478,65 +439,11 @@ class Galil(HelaoDriver):
         else:
             return "error"
 
-    async def stop_aligner(self) -> ErrorCodes:
-        """Ask the Bokeh aligner to terminate its current alignment session."""
-        if self.aligner_enabled and self.aligner:
-            self.aligner.stop_align()
-            return ErrorCodes.none
-        else:
-            return ErrorCodes.not_available
-
-    def run_aligner_precheck(self):
-        """Whether a new aligner run may start, and the code to report if not.
-
-        Exact port of the nested gate from the pre-migration `run_aligner`:
-        the outer check (motor not blocked and Galil enabled) reports
-        `ErrorCodes.in_progress` on failure; only if that passes does the
-        inner check (aligner enabled and constructed) run, reporting
-        `ErrorCodes.not_available` on failure. Kept as one driver-owned
-        decision (K7: the driver decides, the endpoint acts on the verdict)
-        so the two rejection reasons can never be attributed backwards.
-
-        Returns:
-            `(True, ErrorCodes.none)` if a run may start, else
-            `(False, <ErrorCodes>)`.
-        """
-        if self.blocked or not self.galil_enabled:
-            return False, ErrorCodes.in_progress
-        if not self.aligner_enabled or not self.aligner:
-            return False, ErrorCodes.not_available
-        return True, ErrorCodes.none
-
-    async def start_aligner_run(self, active) -> dict:
-        """Attach a server-contained `Active` to the aligner and begin tracking motion.
-
-        K7b: creating the `Active` (`contain_action`) is no longer done by
-        this driver -- the `/run_aligner` endpoint now calls
-        `app.base.contain_action(...)` itself (after checking
-        `run_aligner_precheck`) and passes the result in as `active`. This
-        method does exactly what the tail of the pre-migration
-        `run_aligner` did once the `Active` existed: stores the plate id,
-        stores `active` as `self.aligner_active` (consumed directly by
-        `layouts/aligner.py`, out of this migration's scope), flips the
-        busy/aligning flags, and kicks off a motion-status query.
-
-        Args:
-            active: An `Active` already returned by `contain_action` for
-                this run_aligner request; its `action.action_params` must
-                carry `plateid_or_pmpath`.
-
-        Returns:
-            The active action dict.
-        """
-        self.blocked = True
-        self.aligner_plateid = active.action.action_params["plateid_or_pmpath"]
-        self.aligner_active = active
-        self.aligning_enabled = True
-        activeDict = self.aligner_active.action.as_dict()
-
-        _ = await self.query_axis_moving(axis=self.get_all_axis())
-
-        return activeDict
+    # P3a galil-split slice-4: `stop_aligner`, `run_aligner_precheck`, and
+    # `start_aligner_run` moved to the vis-layer `GalilAlignerHost` (they own
+    # the aligner session + its Active, which no longer live on the driver).
+    # `blocked` (read/set by those verbs and by `_motor_move`) stays here as the
+    # driver-owned shared lock; the host reaches it through AlignerMotorContext.
 
     async def motor_move(self, active) -> dict:
         """Public motor-move entry point that extracts params from `active.action`.
@@ -1254,7 +1161,11 @@ class Galil(HelaoDriver):
         return [ax for ax in self.axis_id]
 
     def shutdown(self) -> set:
-        """Close the gclib connection and cancel the aligner IO task on server shutdown.
+        """Close the gclib connection on server shutdown.
+
+        The aligner IO-task cancellation moved to `GalilAlignerHost.shutdown`
+        (P3a slice-4); the action server invokes it alongside this on the
+        FastAPI shutdown path.
 
         Returns:
             A single-element set containing "shutdown".
@@ -1268,14 +1179,17 @@ class Galil(HelaoDriver):
         except Exception as e:
             tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
             LOGGER.error(f"could not close galil connection: {repr(e), tb,}")
-        if self.aligner_enabled and self.aligner:
-            self.aligner.IOtask.cancel()
         return {"shutdown"}
 
     async def update_aligner(self, msg):
-        """Forward `msg` to the aligner's motor-position queue, if running."""
-        if self.aligner_enabled and self.aligner:
-            await self.aligner.motorpos_q.put(msg)
+        """Forward `msg` to the aligner's motor-position queue, if one is wired.
+
+        The sink is the Bokeh aligner's `motorpos_q`, registered by
+        `GalilAlignerHost` via `set_position_sink` (P3a slice-4). `None` when
+        no aligner is hosted, so this is a no-op then.
+        """
+        if self._position_sink is not None:
+            await self._position_sink.put(msg)
 
     def save_transfermatrix(self, file):
         """Write `self.plate_transfermatrix` to `file` as JSON.

--- a/helao/deploy/hte/drivers/pstat/biologic/driver.py
+++ b/helao/deploy/hte/drivers/pstat/biologic/driver.py
@@ -19,7 +19,10 @@ from helao.helpers import helao_logging as logging
 LOGGER = logging.make_logger(__file__) if logging.LOGGER is None else logging.LOGGER
 import numpy as np
 import pandas as pd
-import easy_biologic as ebl
+
+# easy_biologic (the vendor SDK) is imported lazily in connect() / via
+# technique.resolve_easy_class so the driver imports and constructs without the
+# SDK present (P3a-2 hermetic disconnected-construct).
 
 from helao.core.drivers.helao_driver import (
     HelaoDriver,
@@ -28,7 +31,7 @@ from helao.core.drivers.helao_driver import (
     DriverResponseType,
 )
 
-from .technique import BiologicTechnique
+from .technique import BiologicTechnique, resolve_easy_class
 
 
 # ctypes struct to dict (won't work with arrays, nested structs)
@@ -84,7 +87,9 @@ class BiologicDriver(HelaoDriver):
         self.channels = {i: None for i in range(self.num_channels)}
         self.channel_params = {i: {} for i in range(self.num_channels)}
         self.channel_technique = {i: None for i in range(self.num_channels)}
-        self.connect()
+        # P3a-2 constructor-connect fix: no device I/O here. The action server
+        # (biologic_server.biologic_dyn_endpoints) calls connect() at startup;
+        # this keeps the driver constructible without the instrument/SDK.
         self.stopping = False
         self.connection_ctx = None
 
@@ -101,6 +106,8 @@ class BiologicDriver(HelaoDriver):
                     "Connection already raised. In use by another script."
                 )
             self.connection_raised = True
+            import easy_biologic as ebl
+
             self.pstat = ebl.BiologicDevice(str(self.address))
             self.connection_ctx = self.pstat.connect()
             self.ready = True
@@ -146,7 +153,7 @@ class BiologicDriver(HelaoDriver):
                     if any([x > 0 for x in states])
                     else DriverStatus.ok
                 )
-                
+
                 data = {i: x for i, x in enumerate(states)}
             elif channel not in self.channels:
                 status = DriverStatus.uninitialized
@@ -204,7 +211,7 @@ class BiologicDriver(HelaoDriver):
             listed_params = {
                 k: [v] if k in listed else v for k, v in mapped_params.items()
             }
-            self.channels[channel] = technique.easy_class(
+            self.channels[channel] = resolve_easy_class(technique.easy_class_name)(
                 device=self.pstat, params=listed_params, channels=[channel]
             )
             self.channel_params[channel] = listed_params

--- a/helao/deploy/hte/drivers/pstat/biologic/technique.py
+++ b/helao/deploy/hte/drivers/pstat/biologic/technique.py
@@ -9,11 +9,30 @@ technique name.
 
 from dataclasses import dataclass
 from typing import Optional, Dict
-import easy_biologic.base_programs as blp
-from easy_biologic import BiologicProgram
-
 
 from enum import StrEnum
+
+# P3a-2: the easy-biologic vendor runtime is imported lazily (see
+# `resolve_easy_class`) rather than at module import, so this registry — and
+# the BiologicDriver that imports it — load without the SDK present (hermetic
+# disconnected-construct; the SDK is only needed when a technique is actually
+# instantiated in `BiologicDriver.setup`).
+
+
+def resolve_easy_class(easy_class_name: str):
+    """Lazily import ``easy_biologic.base_programs`` and return a program class.
+
+    Args:
+        easy_class_name: Attribute name of the ``BiologicProgram`` subclass in
+            ``easy_biologic.base_programs`` (e.g. ``"OCV"``, ``"CA"``).
+
+    Returns:
+        The requested easy-biologic ``BiologicProgram`` subclass.
+    """
+    import easy_biologic.base_programs as blp
+
+    return getattr(blp, easy_class_name)
+
 
 # class IRange(StrEnum):
 #     p100 = "p100"
@@ -57,7 +76,9 @@ class BiologicTechnique:
 
     Attributes:
         technique_name: Short name used as the lookup key in ``BIOTECHS``.
-        easy_class: easy-biologic ``BiologicProgram`` subclass to instantiate.
+        easy_class_name: Attribute name of the easy-biologic ``BiologicProgram``
+            subclass in ``easy_biologic.base_programs`` (resolved lazily via
+            :func:`resolve_easy_class` so this module imports without the SDK).
         parameter_map: Mapping from action-server parameter keys to the
             easy-biologic program parameter names.
         field_map: Mapping from easy-biologic data field names to the HELAO
@@ -65,14 +86,14 @@ class BiologicTechnique:
     """
 
     technique_name: str
-    easy_class: BiologicProgram
+    easy_class_name: str
     parameter_map: Optional[Dict[str, str]] = None
     field_map: Optional[Dict[str, str]] = None
 
 
 TECH_OCV = BiologicTechnique(
     technique_name="OCV",
-    easy_class=blp.OCV,
+    easy_class_name="OCV",
     parameter_map={
         "Tval__s": "time",
         "AcqInterval__s": "time_interval",
@@ -85,7 +106,7 @@ TECH_OCV = BiologicTechnique(
 )
 TECH_CA = BiologicTechnique(
     technique_name="CA",
-    easy_class=blp.CA,
+    easy_class_name="CA",
     parameter_map={
         "Vval__V": "voltages",
         "Tval__s": "durations",
@@ -105,7 +126,7 @@ TECH_CA = BiologicTechnique(
 )
 TECH_CP = BiologicTechnique(
     technique_name="CP",
-    easy_class=blp.CP,
+    easy_class_name="CP",
     parameter_map={
         "Ival__A": "currents",
         "Tval__s": "durations",
@@ -125,7 +146,7 @@ TECH_CP = BiologicTechnique(
 )
 TECH_CV = BiologicTechnique(
     technique_name="CV",
-    easy_class=blp.CV,
+    easy_class_name="CV",
     parameter_map={
         "Vinit__V": "start",
         "Vapex1__V": "end",
@@ -149,7 +170,7 @@ TECH_CV = BiologicTechnique(
 
 TECH_PEIS = BiologicTechnique(
     technique_name="PEIS",
-    easy_class=blp.PEIS,
+    easy_class_name="PEIS",
     parameter_map={
         "Vinit__V": "voltage",
         "Vamp__V": "amplitude_voltage",
@@ -188,7 +209,7 @@ TECH_PEIS = BiologicTechnique(
 
 TECH_GEIS = BiologicTechnique(
     technique_name="GEIS",
-    easy_class=blp.GEIS,
+    easy_class_name="GEIS",
     parameter_map={
         "Iinit__A": "current",
         "Iamp__A": "amplitude_current",
@@ -226,7 +247,7 @@ TECH_GEIS = BiologicTechnique(
 )
 TECH_CAOCV = BiologicTechnique(
     technique_name="CAOCV",
-    easy_class=blp.CAOCV,
+    easy_class_name="CAOCV",
     parameter_map={
         "CA_Vval__V_list": "ca_voltages",
         "CA_Tval__s_list": "ca_durations",

--- a/helao/deploy/hte/drivers/pstat/gamry/driver.py
+++ b/helao/deploy/hte/drivers/pstat/gamry/driver.py
@@ -11,8 +11,6 @@ sense/range/filter settings during setup, drives data acquisition via a
 
 import sys
 
-sys.coinit_flags = 0x0
-
 # save a default log file system temp
 from helao.helpers import helao_logging as logging
 
@@ -118,6 +116,16 @@ class GamryDriver(HelaoDriver):
         Returns:
             ``DriverResponse`` reporting connection success or failure.
         """
+        # comtypes reads ``sys.coinit_flags`` when it first initializes COM;
+        # set it here (0x0 == COINIT_MULTITHREADED, comtypes' own default too)
+        # right before the first ``import comtypes.client`` rather than at
+        # module import, so merely importing this driver never mutates a
+        # process-global. Matters because ``GamryDriver`` is shared across
+        # deployments (hte + private potentiostat servers) and is imported on
+        # Linux by the hexagon import-sweep, where a COM apartment flag is
+        # meaningless. connect() is the driver's first comtypes user, so the
+        # apartment model is unchanged on Windows (P3a Gamry COM track).
+        sys.coinit_flags = 0x0
         import comtypes.client as client
 
         try:

--- a/helao/deploy/hte/drivers/spec/andor/driver.py
+++ b/helao/deploy/hte/drivers/spec/andor/driver.py
@@ -63,10 +63,14 @@ class AndorDriver(HelaoDriver):
     frame: int
 
     def __init__(self, config: dict = {}):
-        """Construct the driver and immediately open the camera.
+        """Construct the driver WITHOUT opening the camera (§10.4
+        disconnected-construct).
 
-        Reads ``dev_id`` from ``config`` (default ``0``), instantiates the
-        SDK, calls :meth:`connect`, and marks the driver ready on success.
+        Reads ``dev_id`` from ``config`` (default ``0``) and initializes state
+        only -- no vendor SDK instantiation and no ``connect()`` here, so the
+        driver is constructible without the Andor runtime (e.g. on Linux for a
+        construct-test). ``andor_server.andor_dyn_endpoints`` calls
+        :meth:`connect` at server startup (P3a-2 constructor-connect fix).
 
         Args:
             config: Driver configuration dict from the action server.
@@ -83,21 +87,26 @@ class AndorDriver(HelaoDriver):
 
         self.timeout = 5000
 
-        _load_andor()
-        self.sdk3 = AndorSDK3()
+        # SDK handle created lazily in connect() (was `AndorSDK3()` here); the
+        # vendor runtime is never touched at construction time.
+        self.sdk3 = None
         self.device_id = self.config.get("dev_id", 0)
         LOGGER.info(f"using device_id {self.device_id} from config")
-        # if single context is used and held for the entire session, connect here, otherwise have executor call self.connect() in self.setup()
-        self.connect()
         self.ready = True
 
     def connect(self) -> DriverResponse:
         """Open the camera, configure imaging and prime spectrograph metadata.
 
+        Instantiates the Andor SDK on first call (create-once; reused across
+        reconnects), then opens the camera.
+
         Returns:
             A success :class:`DriverResponse` on connect, ``failed`` on error.
         """
         try:
+            if self.sdk3 is None:
+                _load_andor()
+                self.sdk3 = AndorSDK3()
             self.cam = self.sdk3.GetCamera(self.device_id)
             LOGGER.debug(f"connected to {self.device_id}")
             self.pixel_width = self.setup_image()

--- a/helao/deploy/hte/servers/action/andor_server.py
+++ b/helao/deploy/hte/servers/action/andor_server.py
@@ -242,6 +242,12 @@ async def andor_dyn_endpoints(app: BaseAPI):
     server_key = app.base.server.server_name
     app.base.server_params["allow_concurrent_actions"] = False
 
+    # P3a-2 constructor-connect fix: AndorDriver.__init__ no longer opens the
+    # camera (disconnected construct); open it here at startup before any
+    # acquire request reads app.driver.wl_arr.
+    connect_resp = app.driver.connect()
+    LOGGER.info(f"Andor connect() returned status={connect_resp.status}")
+
     @app.post(f"/{server_key}/acquire", tags=["action"])
     @action_version(2)
     async def acquire(
@@ -279,8 +285,7 @@ async def andor_dyn_endpoints(app: BaseAPI):
         return active_action_dict
 
     @app.post(f"/{server_key}/cancel_acquire", tags=["action"])
-    async def cancel_acquire(
-    ):
+    async def cancel_acquire():
         """Stop any running ``acquire`` executor on this server."""
         active = await app.base.setup_and_contain_action()
         for exec_id, executor in app.base.executors.items():
@@ -303,8 +308,7 @@ async def andor_dyn_endpoints(app: BaseAPI):
         return active_action_dict
 
     @app.post(f"/{server_key}/adjust_nd", tags=["action"])
-    async def adjust_nd(
-    ):
+    async def adjust_nd():
         """Run the ND-filter auto-selection routine via :class:`AndorAdjustND`."""
         active = await app.base.setup_and_contain_action()
         executor = AndorAdjustND(active=active, oneoff=True)

--- a/helao/deploy/hte/servers/action/biologic_server.py
+++ b/helao/deploy/hte/servers/action/biologic_server.py
@@ -7,7 +7,6 @@ Wraps :class:`BiologicDriver` and exposes electrochemistry technique endpoints
 the hardware driver stays decoupled from the action-server base class.
 """
 
-
 __all__ = ["makeApp"]
 
 
@@ -54,7 +53,6 @@ from ...drivers.pstat.biologic.technique import (
     TECH_PEIS,
     TECH_CAOCV,
 )
-
 
 global LOGGER
 LOGGER = logging.make_logger(__file__) if logging.LOGGER is None else logging.LOGGER
@@ -321,6 +319,12 @@ async def biologic_dyn_endpoints(app: BaseAPI):
     """
     server_key = app.base.server.server_name
     app.base.server_params["allow_concurrent_actions"] = False
+
+    # P3a-2 constructor-connect fix: BiologicDriver.__init__ no longer opens the
+    # instrument (disconnected construct); connect here at startup. connect()
+    # sets app.driver.ready on success, satisfying the wait below.
+    connect_resp = app.driver.connect()
+    LOGGER.info(f"Biologic connect() returned status={connect_resp.status}")
 
     while not app.driver.ready:
         LOGGER.info("waiting for biologic init")
@@ -630,6 +634,7 @@ async def biologic_dyn_endpoints(app: BaseAPI):
         executor = BiologicExec(active=active, oneoff=False, technique=TECH_CAOCV)
         active_action_dict = active.start_executor(executor)
         return active_action_dict
+
 
 def makeApp(server_key) -> BaseAPI:
     """Build the Biologic potentiostat FastAPI app.

--- a/helao/deploy/hte/servers/action/galil_motion.py
+++ b/helao/deploy/hte/servers/action/galil_motion.py
@@ -54,6 +54,10 @@ from helao.helpers.sample_api import UnifiedSampleDataAPI
 from helao.core.models.file import FileConnParams
 from helao.core.error import ErrorCodes
 
+# P3a galil-split slice-4: the Bokeh plate-aligner is hosted by the vis layer,
+# not the driver (D6 fix). The server constructs the host after connect().
+from helao.hexagon.adapters.vis.galil_aligner_host import GalilAlignerHost
+
 from helao.helpers import helao_logging as logging
 
 LOGGER = logging.make_logger(__file__) if logging.LOGGER is None else logging.LOGGER
@@ -92,6 +96,27 @@ async def galil_dyn_endpoints(app: BaseAPI):
     LOGGER.info(f"Galil connect() returned status={connect_resp.status}")
 
     if app.driver.galil_enabled is True:
+
+        # P3a galil-split slice-4: construct the Bokeh plate-aligner in the vis
+        # layer (was `Galil.start_aligner` inside connect()). The host owns the
+        # Bokeh Server + HelaoVis + the aligner-session Active, and wires the
+        # driver's position-notify sink; gated on the `enable_aligner` config
+        # exactly as the driver's old `aligner_enabled` gate was.
+        app.aligner_host = None
+        if app.server_params.get("enable_aligner", False):
+            app.aligner_host = GalilAlignerHost(
+                driver=app.driver,
+                base=app.base,
+                server_cfg=app.base.server_cfg,
+                server_name=server_key,
+                config=app.server_params,
+            )
+            app.aligner_host.start()
+
+            @app.on_event("shutdown")
+            async def _shutdown_aligner_host():
+                if getattr(app, "aligner_host", None) is not None:
+                    app.aligner_host.shutdown()
 
         dev_axis = app.server_params.get("axis_id", {})
         dev_axisitems = make_str_enum("axis_id", {key: key for key in dev_axis})
@@ -142,16 +167,20 @@ async def galil_dyn_endpoints(app: BaseAPI):
             """Start the interactive plate-alignment routine.
 
             K7b: containing the action (``contain_action``) is done here,
-            not by the driver -- ``Galil.run_aligner_precheck`` reports
-            whether a new run may start and, if not, the exact rejection
-            code (mirroring the pre-migration nested gate precisely). Only
-            when it reports success is the ``Active`` created and handed to
-            ``Galil.start_aligner_run``, which manages the accompanying
-            Bokeh aligner UI; the final transfer matrix is delivered when
-            the user submits the alignment.
+            not by the driver. P3a slice-4: the precheck + run-start moved
+            from the driver to the vis-layer ``GalilAlignerHost`` (which owns
+            the Bokeh aligner UI + its Active); ``run_aligner_precheck``
+            reports whether a new run may start and, if not, the exact
+            rejection code. Only when it reports success is the ``Active``
+            created and handed to ``host.start_aligner_run``; the final
+            transfer matrix is delivered when the user submits the alignment.
             """
             A = app.base.setup_action()
-            ok, error_code = app.driver.run_aligner_precheck()
+            host = app.aligner_host
+            if host is None:
+                A.error_code = ErrorCodes.not_available
+                return A.as_dict()
+            ok, error_code = host.run_aligner_precheck()
             if ok:
                 active = await app.base.contain_action(
                     ActiveParams(
@@ -170,18 +199,21 @@ async def galil_dyn_endpoints(app: BaseAPI):
                         },
                     )
                 )
-                active_dict = await app.driver.start_aligner_run(active)
+                active_dict = await host.start_aligner_run(active)
             else:
                 A.error_code = error_code
                 active_dict = A.as_dict()
             return active_dict
 
         @app.post(f"/{server_key}/stop_aligner", tags=["action"])
-        async def stop_aligner(
-        ):
+        async def stop_aligner():
             """Abort an in-progress plate-alignment routine."""
             active = await app.base.setup_and_contain_action()
-            active.action.error_code = await app.driver.stop_aligner()
+            host = app.aligner_host
+            if host is None:
+                active.action.error_code = ErrorCodes.not_available
+            else:
+                active.action.error_code = await host.stop_aligner()
             finished_action = await active.finish()
             return finished_action.as_dict()
 
@@ -322,8 +354,7 @@ async def galil_dyn_endpoints(app: BaseAPI):
                 return finished_action.as_dict()
 
         @app.post(f"/{server_key}/disconnect", tags=["action"])
-        async def disconnect(
-        ):
+        async def disconnect():
             """Disconnect from the Galil motion controller."""
             active = await app.base.setup_and_contain_action(action_abbr="disconnect")
             await active.enqueue_data_dflt(datadict=await app.driver.motor_disconnect())
@@ -333,8 +364,7 @@ async def galil_dyn_endpoints(app: BaseAPI):
         if dev_axis:
 
             @app.post(f"/{server_key}/query_positions", tags=["action"])
-            async def query_positions(
-            ):
+            async def query_positions():
                 """Return the current position of every configured axis."""
                 active = await app.base.setup_and_contain_action(
                     action_abbr="query_position"
@@ -520,8 +550,7 @@ async def galil_dyn_endpoints(app: BaseAPI):
             return finished_action.as_dict()
 
         @app.post(f"/{server_key}/stop", tags=["action"])
-        async def stop(
-        ):
+        async def stop():
             """De-energise every configured motor axis."""
             active = await app.base.setup_and_contain_action(action_abbr="stop")
             datadict = await app.driver.motor_off(axis=app.driver.get_all_axis())
@@ -533,8 +562,7 @@ async def galil_dyn_endpoints(app: BaseAPI):
             return finished_action.as_dict()
 
         @app.post(f"/{server_key}/reset", tags=["action"])
-        async def reset(
-        ):
+        async def reset():
             """Reset the Galil controller. Emergency use only.
 
             Calls :meth:`Galil.reset_controller` -- the pre-migration

--- a/helao/hexagon/adapters/native/galil_motion.py
+++ b/helao/hexagon/adapters/native/galil_motion.py
@@ -1,0 +1,218 @@
+"""Native Galil motion HardwarePort adapter (P3a galil-split slice-3).
+
+The native-cut-over seam for the hte Galil motion controller: a hexagon-side
+adapter that satisfies :class:`~helao.hexagon.ports.hardware.HardwarePort` and
+exposes the Galil motion verbs as first-class named methods, delegating to the
+legacy ``Galil`` driver (``helao/deploy/hte/drivers/motion/galil_motion_driver.py``).
+
+Design (roadmap ``2026-07-18-P3a-special-splits-roadmap.md`` §"galil slice 3"):
+
+- **Pure delegation, behavior-preserving.** The adapter does NOT reimplement
+  gclib command sequences; it forwards to the legacy driver so the motion
+  verbs' legacy ``{err_code: ErrorCodes, ...}`` dict returns reach the server
+  (``galil_motion.py`` via ``app.base.get_main_error``) **verbatim** (D6 §4.4).
+  The ~900-LOC ``_motor_move`` device logic and the slice-2 CalibrationStore
+  wiring stay in the legacy driver, unchanged.
+- **Disconnected construct (port contract).** ``__init__`` does zero device
+  I/O — it stores the already-constructed legacy driver. ``from_config`` builds
+  the legacy ``Galil`` (whose own ``__init__`` is I/O-free after slices 1-2) and
+  wraps it; ``import gclib`` stays lazy inside the legacy ``connect()``.
+- **Async-first lifecycle.** The legacy ABC lifecycle methods
+  (``connect``/``get_status``/``reset``/``disconnect``/``shutdown``) are sync;
+  they are offloaded with :func:`asyncio.to_thread` (matching
+  ``LegacyDriverHardwareAdapter``). ``stop``/``estop`` and every motion verb are
+  already ``async`` on the legacy driver and are awaited directly.
+- **Not runtime-wired.** The P3 graft-wrap path keeps ``app.driver`` pointed at
+  the legacy driver; this adapter is the target for a later native cut-over, so
+  nothing constructs it in the server yet. Construct-testable on Linux; motion
+  behavior is an at-station gate (needs the controller + gclib).
+
+CUT-OVER CHECKLIST (resolve before repointing ``app.driver`` at this adapter):
+
+- ``shutdown`` await seam: ``base_api.py``'s shutdown handler calls
+  ``driver.shutdown()`` **synchronously** and only ``await``\\s a separate
+  ``async_shutdown``. This adapter's ``shutdown`` is ``async`` (HardwarePort
+  is async-first, and the sibling ``LegacyDriverHardwareAdapter`` has the same
+  shape), so a naive cut-over would leave the coroutine un-awaited and skip
+  ``GClose()``. The cut-over must resolve this for the whole native-adapter
+  family (expose ``async_shutdown``, or make ``base_api`` await a coroutine
+  ``shutdown``) — it is a framework seam, not a per-driver fix. The
+  ``disconnect()`` path is unaffected (it thread-offloads legacy ``disconnect``
+  -> sync ``shutdown``).
+- Transform-management / aligner / ``solid_get_*`` verbs the server also calls
+  on ``app.driver`` (``transform``, ``reset_plate_transfermatrix``,
+  ``update_plate_transfermatrix``, ``run_aligner_precheck``,
+  ``start_aligner_run``, ``stop_aligner``, ``solid_get_platemap``,
+  ``solid_get_samples_xy``) are intentionally out of this slice's scope
+  (slice-4 aligner split + a later transform/platemap seam).
+"""
+
+import asyncio
+from typing import Any, List, Optional
+
+from helao.core.drivers.helao_driver import (
+    DriverResponse,
+    DriverResponseType,
+    DriverStatus,
+)
+from helao.deploy.hte.drivers.motion.galil_motion_driver import Galil
+
+__all__ = ["GalilMotionHardwareAdapter"]
+
+
+class GalilMotionHardwareAdapter:
+    """HardwarePort-conforming wrapper around the legacy ``Galil`` driver.
+
+    Satisfies the HardwarePort lifecycle (``connect``/``get_status``/``reset``/
+    ``disconnect``/``estop``/``shutdown``/``abort``) and re-exposes the Galil
+    motion verbs (``motor_move``/``query_axis_position``/``query_axis_moving``/
+    ``motor_off``/``motor_on``/``stop_axis``/``setaxisref``/``reset_controller``/
+    ``get_all_axis``) with their legacy return values intact.
+    """
+
+    def __init__(self, driver: Galil):
+        """Wrap an already-constructed legacy ``Galil`` (no device I/O)."""
+        self._driver = driver
+
+    @classmethod
+    def from_config(
+        cls, config: Optional[dict] = None, base_hook: Any = None
+    ) -> "GalilMotionHardwareAdapter":
+        """Build the legacy ``Galil`` from a server ``params`` dict and wrap it.
+
+        Mirrors the server-startup handshake: the legacy driver's
+        ``_base_hook`` (source of ``helaodirs``/``server_cfg`` read in
+        ``connect()``) is assigned post-construction, never in ``__init__``
+        (K8 disconnected-construct). No device I/O happens here.
+        """
+        driver = Galil(config=config or {})
+        driver._base_hook = base_hook
+        return cls(driver)
+
+    @property
+    def driver(self) -> Galil:
+        """The wrapped legacy driver (cut-over / introspection escape hatch)."""
+        return self._driver
+
+    @property
+    def galil_enabled(self) -> Optional[bool]:
+        """Passthrough of the legacy connect-state flag.
+
+        ``None`` before ``connect()``, ``True``/``False`` after. The action
+        server gates its endpoints on this value.
+        """
+        return self._driver.galil_enabled
+
+    @property
+    def _base_hook(self):
+        """Proxy the legacy driver's ``_base_hook``.
+
+        The server startup handshake assigns the hook *after* construction
+        (``app.driver._base_hook = app.base``); proxying keeps that live
+        assignment reaching the wrapped ``Galil`` (whose ``connect()`` reads
+        ``helaodirs``/``server_cfg`` off it) when this adapter is ``app.driver``.
+        """
+        return self._driver._base_hook
+
+    @_base_hook.setter
+    def _base_hook(self, value):
+        self._driver._base_hook = value
+
+    # --- HardwarePort lifecycle -------------------------------------------
+
+    async def connect(self) -> DriverResponse:
+        return await asyncio.to_thread(self._driver.connect)
+
+    async def get_status(self) -> DriverResponse:
+        return await asyncio.to_thread(self._driver.get_status)
+
+    async def reset(self) -> DriverResponse:
+        return await asyncio.to_thread(self._driver.reset)
+
+    async def disconnect(self) -> DriverResponse:
+        return await asyncio.to_thread(self._driver.disconnect)
+
+    async def abort(self, **_kwargs) -> DriverResponse:
+        """HardwarePort ``abort`` maps to the legacy ABC ``stop()`` (abort all
+        motion, device stays enabled). Extra kwargs are accepted for protocol
+        signature parity and ignored (legacy ``stop()`` takes none)."""
+        return await self._driver.stop()
+
+    # --- HardwarePort measurement phase (N/A for a motion controller) -----
+    # A Galil motion controller has no arm/measure/drain/de-arm cycle. These
+    # exist only so the adapter structurally satisfies the full HardwarePort
+    # protocol; they fail loud rather than silently no-op, matching
+    # ``LegacyDriverHardwareAdapter``'s "no legacy method -> raise" contract.
+
+    async def arm(self, **_setup_params) -> DriverResponse:
+        raise NotImplementedError(
+            "galil motion controller has no measurement arm phase"
+        )
+
+    async def start(self, **_measure_params) -> DriverResponse:
+        raise NotImplementedError(
+            "galil motion controller has no measurement start phase"
+        )
+
+    async def drain(self, **_kwargs) -> DriverResponse:
+        raise NotImplementedError(
+            "galil motion controller has no measurement drain phase"
+        )
+
+    async def cleanup(self, **_kwargs) -> DriverResponse:
+        raise NotImplementedError(
+            "galil motion controller has no measurement cleanup phase"
+        )
+
+    async def estop(self, switch: bool) -> DriverResponse:
+        """Engage/clear the motion e-stop.
+
+        The legacy ``estop`` performs the stop + motor-off and returns the
+        ``switch`` bool; the HardwarePort contract returns a ``DriverResponse``,
+        so the bool is wrapped (the device side-effect is unchanged). Server
+        estop-flag bookkeeping stays owned by ``base_api.py``'s ``/estop``.
+        """
+        await self._driver.estop(switch)
+        return DriverResponse(
+            response=DriverResponseType.success, status=DriverStatus.ok
+        )
+
+    async def shutdown(self) -> DriverResponse:
+        """Close the gclib connection (legacy returns ``{"shutdown"}``; wrapped
+        into a ``DriverResponse`` for the port)."""
+        await asyncio.to_thread(self._driver.shutdown)
+        return DriverResponse(
+            response=DriverResponseType.success, status=DriverStatus.ok
+        )
+
+    # --- Galil motion verbs (legacy dict returns intact) ------------------
+
+    async def motor_move(self, active) -> dict:
+        return await self._driver.motor_move(active)
+
+    async def motor_disconnect(self) -> dict:
+        return await self._driver.motor_disconnect()
+
+    async def query_axis_position(self, axis, *args, **kwargs) -> dict:
+        return await self._driver.query_axis_position(axis, *args, **kwargs)
+
+    async def query_axis_moving(self, axis, *args, **kwargs) -> dict:
+        return await self._driver.query_axis_moving(axis, *args, **kwargs)
+
+    async def stop_axis(self, axis) -> dict:
+        return await self._driver.stop_axis(axis)
+
+    async def motor_off(self, axis, *args, **kwargs) -> dict:
+        return await self._driver.motor_off(axis, *args, **kwargs)
+
+    async def motor_on(self, axis, *args, **kwargs) -> dict:
+        return await self._driver.motor_on(axis, *args, **kwargs)
+
+    async def setaxisref(self):
+        return await self._driver.setaxisref()
+
+    async def reset_controller(self):
+        return await self._driver.reset_controller()
+
+    def get_all_axis(self) -> List[str]:
+        return self._driver.get_all_axis()

--- a/helao/hexagon/adapters/native/gamry_com.py
+++ b/helao/hexagon/adapters/native/gamry_com.py
@@ -1,0 +1,337 @@
+"""Gamry COM worker-thread adapter (P3a Gamry COM track — construct-test tier).
+
+The native-cut-over seam for the hte Gamry potentiostat. GamryCOM objects have
+**thread/apartment affinity**: the dtaq event sink + ``PumpEvents`` message loop
+want a single owning thread, and every pstat/dtaq/readz call must happen on that
+thread. This adapter gives them one.
+
+- :class:`GamryComThread` owns a dedicated worker thread that initializes the COM
+  apartment, runs an interleaved request-drain + ``PumpEvents`` loop (so both
+  submitted calls and dtaq sink callbacks progress), and marshals each call's
+  result/exception back through a ``concurrent.futures.Future``. The
+  COM-specific bits (``_com_initialize``/``_com_pump``/``_com_finalize``) are
+  isolated behind three overridable hooks so the thread/queue/Future machinery
+  is testable on Linux with COM stubbed (comtypes is Windows-only).
+- :class:`GamryComAdapter` is disconnected-construct (``__init__`` touches no COM,
+  starts no thread — §10.4). ``connect()`` starts the thread and constructs the
+  **legacy ``GamryDriver`` on that thread**, so all existing COM logic is reused
+  verbatim; every verb is a thin ``submit(...)`` onto the owning thread. An
+  ``_active`` strategy flag (dc/eis/idle) replaces the driver's implicit
+  readz-vs-dtaqsink stop branch.
+
+**Apartment (STA vs MTA) is deferred to at-station.** ``coinit_flags`` defaults
+to ``0x0`` (``COINIT_MULTITHREADED``), matching the legacy driver — i.e. the
+lower-risk "dedicated MTA worker" variant. Switching to STA
+(``COINIT_APARTMENTTHREADED`` = ``0x2``) is a single constructor arg, to be
+decided against observed event reliability on the bench.
+
+**NOT Linux-runtime-verifiable and NOT runtime-wired.** Construct-test tier only;
+the real COM/threading behavior is an at-station gate. See
+``docs/superpowers/plans/2026-07-22-P3a-gamry-com-sta-thread.md``.
+"""
+
+import queue
+import sys
+import threading
+from concurrent.futures import Future
+from typing import Any, Callable, Optional
+
+from helao.helpers import helao_logging as logging
+
+LOGGER = logging.make_logger(__file__) if logging.LOGGER is None else logging.LOGGER
+
+__all__ = ["GamryComThread", "GamryComAdapter"]
+
+# COM apartment models (winbase / objbase COINIT_*).
+COINIT_MULTITHREADED = 0x0
+COINIT_APARTMENTTHREADED = 0x2
+
+_STOP = object()
+
+
+class GamryComThread:
+    """Dedicated worker thread owning the GamryCOM apartment.
+
+    All COM calls are marshalled here via :meth:`submit`; the loop interleaves
+    draining submitted work with pumping COM messages so dtaq event-sink
+    callbacks are delivered on this same (owning) thread.
+    """
+
+    def __init__(
+        self,
+        coinit_flags: int = COINIT_MULTITHREADED,
+        pump_interval_s: float = 0.05,
+    ):
+        self._coinit_flags = coinit_flags
+        self._pump_interval_s = pump_interval_s
+        self._queue: "queue.Queue" = queue.Queue()
+        self._thread: Optional[threading.Thread] = None
+        self._ready = threading.Event()
+        self._init_error: Optional[BaseException] = None
+
+    # --- COM-specific hooks (real comtypes; overridden/no-op in construct-tests)
+    def _com_initialize(self) -> None:
+        """Set the apartment flag and initialize COM on this thread.
+
+        comtypes reads ``sys.coinit_flags`` when it first initializes COM on a
+        thread; set it here (on the owning thread, before any COM use) so this
+        thread gets the chosen apartment. The actual ``CoInitializeEx`` happens
+        lazily on the first COM object creation (when the wrapped ``GamryDriver``
+        is constructed on this thread).
+        """
+        sys.coinit_flags = self._coinit_flags  # type: ignore[attr-defined]
+        import comtypes  # noqa: F401  (import here so Linux/no-comtypes stays lazy)
+
+    def _com_pump(self, timeout_s: float) -> None:
+        """Pump pending COM messages for up to ``timeout_s`` seconds."""
+        import comtypes.client as client
+
+        client.PumpEvents(timeout_s)
+
+    def _com_finalize(self) -> None:
+        """Thread-exit COM teardown (comtypes uninitializes at thread exit)."""
+        return None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            raise RuntimeError("GamryComThread already started")
+        self._thread = threading.Thread(target=self._run, name="gamry-com", daemon=True)
+        self._thread.start()
+        self._ready.wait()
+        if self._init_error is not None:
+            err, self._init_error = self._init_error, None
+            self._thread = None
+            raise err
+
+    def _run(self) -> None:
+        try:
+            self._com_initialize()
+        except BaseException as exc:  # surface init failure to start()
+            self._init_error = exc
+            self._ready.set()
+            return
+        self._ready.set()
+        try:
+            while True:
+                try:
+                    item = self._queue.get(timeout=self._pump_interval_s)
+                except queue.Empty:
+                    self._safe_pump(self._pump_interval_s)
+                    continue
+                if item is _STOP:
+                    break
+                fn, args, kwargs, fut = item
+                if not fut.set_running_or_notify_cancel():
+                    continue
+                try:
+                    fut.set_result(fn(*args, **kwargs))
+                except BaseException as exc:
+                    fut.set_exception(exc)
+                # flush any events the call generated without blocking
+                self._safe_pump(0.0)
+        finally:
+            self._com_finalize()
+
+    def _safe_pump(self, timeout_s: float) -> None:
+        try:
+            self._com_pump(timeout_s)
+        except Exception:
+            LOGGER.error("gamry COM pump failed", exc_info=True)
+
+    def submit(self, fn: Callable[..., Any], *args, **kwargs) -> Future:
+        """Run ``fn`` on the COM thread; return a Future for its result.
+
+        If the thread is not running the Future is failed immediately (fail
+        loud, never a silent no-op).
+        """
+        fut: Future = Future()
+        if self._thread is None or not self._thread.is_alive():
+            fut.set_exception(RuntimeError("GamryComThread is not running"))
+            return fut
+        self._queue.put((fn, args, kwargs, fut))
+        return fut
+
+    def call(self, fn: Callable[..., Any], *args, **kwargs) -> Any:
+        """Blocking :meth:`submit` — run on the COM thread and wait for result."""
+        return self.submit(fn, *args, **kwargs).result()
+
+    @property
+    def running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def stop(self, timeout_s: float = 5.0) -> None:
+        if self._thread is None:
+            return
+        self._queue.put(_STOP)
+        self._thread.join(timeout=timeout_s)
+        self._thread = None
+
+
+def _default_driver_factory(config: dict):
+    """Construct the legacy GamryDriver (lazy import; COM happens in its ctor)."""
+    from helao.deploy.hte.drivers.pstat.gamry.driver import GamryDriver
+
+    return GamryDriver(config=config)
+
+
+class GamryComAdapter:
+    """Disconnected-construct wrapper that runs the legacy GamryDriver on a
+    dedicated COM thread.
+
+    Every verb marshals onto :class:`GamryComThread`; the wrapped legacy driver
+    is constructed on that thread in :meth:`connect`, so all COM object creation
+    and calls share one owning thread. Verb return values are the legacy
+    ``DriverResponse`` objects, unchanged.
+    """
+
+    #: strategy currently occupying the pstat, so stop/cleanup dispatch cleanly
+    #: (replaces the driver's implicit readz-vs-dtaqsink branch): one of
+    #: ``"dc"``, ``"eis"``, ``"idle"``, or ``None``.
+    _active: Optional[str]
+
+    def __init__(
+        self,
+        config: Optional[dict] = None,
+        *,
+        coinit_flags: int = COINIT_MULTITHREADED,
+        thread_factory: Callable[..., GamryComThread] = GamryComThread,
+        driver_factory: Callable[[dict], Any] = _default_driver_factory,
+    ):
+        # No COM, no thread, no driver here (disconnected construct, §10.4).
+        self._config = config or {}
+        self._coinit_flags = coinit_flags
+        self._thread_factory = thread_factory
+        self._driver_factory = driver_factory
+        self._thread: Optional[GamryComThread] = None
+        self._driver: Any = None
+        self._active = None
+
+    @property
+    def thread(self) -> Optional[GamryComThread]:
+        return self._thread
+
+    @property
+    def driver(self) -> Any:
+        """The wrapped legacy driver (only valid after connect())."""
+        return self._driver
+
+    @property
+    def active_strategy(self) -> Optional[str]:
+        return self._active
+
+    def _require_thread(self) -> GamryComThread:
+        if self._thread is None or not self._thread.running:
+            raise RuntimeError("GamryComAdapter is not connected")
+        return self._thread
+
+    # --- lifecycle --------------------------------------------------------
+    def connect(self):
+        """Start the COM thread and construct the legacy driver on it."""
+        if self._thread is None:
+            self._thread = self._thread_factory(coinit_flags=self._coinit_flags)
+            self._thread.start()
+        self._driver = self._thread.call(self._driver_factory, self._config)
+        # GamryDriver.__init__ already runs connect(); return its live status.
+        return self._thread.call(self._driver.get_status)
+
+    def get_status(self):
+        return self._require_thread().call(self._driver.get_status)
+
+    def get_gamry_state(self) -> dict:
+        return self._require_thread().call(self._driver.get_gamry_state)
+
+    # --- DC / dtaq-sink strategy -----------------------------------------
+    def setup(self, *args, **kwargs):
+        resp = self._require_thread().call(self._driver.setup, *args, **kwargs)
+        self._active = "dc"
+        return resp
+
+    def measure(self, *args, **kwargs):
+        return self._require_thread().call(self._driver.measure, *args, **kwargs)
+
+    def get_data(self, *args, **kwargs):
+        return self._require_thread().call(self._driver.get_data, *args, **kwargs)
+
+    # --- EIS / ReadZ strategy --------------------------------------------
+    def setup_eis(self, *args, **kwargs):
+        resp = self._require_thread().call(self._driver.setup_eis, *args, **kwargs)
+        self._active = "eis"
+        return resp
+
+    def close_eis(self, *args, **kwargs):
+        resp = self._require_thread().call(self._driver.close_eis, *args, **kwargs)
+        self._active = None
+        return resp
+
+    # --- idle poll --------------------------------------------------------
+    def poll(self):
+        """Sample V/I/A on the COM thread (idle-only; guarded by _active)."""
+        thread = self._require_thread()
+        self._active = "idle"
+        try:
+            return thread.call(self._driver.get_status)
+        finally:
+            self._active = None
+
+    # --- stop / teardown --------------------------------------------------
+    async def stop(self):
+        """Abort the active measurement on the owning COM thread.
+
+        The legacy ``GamryDriver.stop`` is a coroutine (its EIS path awaits
+        ``ReadZ.stop``); it is run to completion on the COM thread via a nested
+        ``asyncio.run`` (a fresh loop on the *worker* thread, so the COM calls
+        keep their thread affinity and no loop is nested on the caller). The
+        caller awaits the cross-thread ``Future`` via ``wrap_future`` rather
+        than blocking its own event loop on ``.result()``.
+        """
+        import asyncio
+
+        fut = self._require_thread().submit(lambda: asyncio.run(self._driver.stop()))
+        return await asyncio.wrap_future(fut)
+
+    def cleanup(self, *args, **kwargs):
+        resp = self._require_thread().call(self._driver.cleanup, *args, **kwargs)
+        self._active = None
+        return resp
+
+    def disconnect(self):
+        return self._require_thread().call(self._driver.disconnect)
+
+    # --- supervisor (out-of-process; not thread-affine) -------------------
+    def kill_gamrycom(self):
+        """Terminate the GamryCOM OS process (psutil, no COM affinity needed)."""
+        if (
+            self._driver is not None
+            and self._thread is not None
+            and self._thread.running
+        ):
+            return self._thread.call(self._driver.kill_gamrycom)
+        # Before connect() / after shutdown: psutil kill without an owning thread.
+        return self._bare_kill()
+
+    def reset(self):
+        """Tear down the COM thread, kill GamryCOM, rebuild the thread+driver."""
+        self.shutdown()
+        self._bare_kill()
+        return self.connect()
+
+    def shutdown(self) -> None:
+        """Cleanup + disconnect on the COM thread, then stop the thread."""
+        try:
+            if self._thread is not None and self._thread.running and self._driver:
+                self._thread.call(self._driver.shutdown)
+        except Exception:
+            LOGGER.error("gamry adapter shutdown error", exc_info=True)
+        finally:
+            if self._thread is not None:
+                self._thread.stop()
+            self._thread = None
+            self._driver = None
+            self._active = None
+
+    @staticmethod
+    def _bare_kill():
+        """psutil GamryCOM kill without an owning thread (recovery path)."""
+        from helao.deploy.hte.drivers.pstat.gamry.driver import GamryDriver
+
+        return GamryDriver.kill_gamrycom(GamryDriver.__new__(GamryDriver))

--- a/helao/hexagon/adapters/vis/__init__.py
+++ b/helao/hexagon/adapters/vis/__init__.py
@@ -1,0 +1,11 @@
+"""Hexagon vis-layer adapters (P3a): UI/Bokeh hosting relocated OUT of hardware
+drivers (D6 fix). The first member is the Galil plate-aligner host, which owns
+the Bokeh ``Server`` + ``HelaoVis`` construction and the aligner-session
+``Active`` that the legacy Galil driver used to hold in-driver."""
+
+from helao.hexagon.adapters.vis.galil_aligner_host import (
+    AlignerMotorContext,
+    GalilAlignerHost,
+)
+
+__all__ = ["AlignerMotorContext", "GalilAlignerHost"]

--- a/helao/hexagon/adapters/vis/galil_aligner_host.py
+++ b/helao/hexagon/adapters/vis/galil_aligner_host.py
@@ -1,0 +1,191 @@
+"""Galil plate-aligner vis-layer host (P3a galil-split slice-4).
+
+Removes the D6 violation whereby the Galil motion *driver* constructed a Bokeh
+``Server`` + ``HelaoVis`` and held an action ``Active``. Those responsibilities
+move here, to the vis/server layer:
+
+- :class:`GalilAlignerHost` owns the Bokeh ``Server`` construction (relocated
+  ``start_aligner``/``makeBokehApp``) and the aligner-orchestration verbs the
+  action server calls (``run_aligner_precheck``/``start_aligner_run``/
+  ``stop_aligner``/``shutdown``).
+- :class:`AlignerMotorContext` is handed to ``layouts.aligner.Aligner`` in
+  place of the raw driver: it **delegates** motion/transform/calibration and the
+  driver-owned motion flags (``blocked`` — a shared mutual-exclusion lock with
+  ``_motor_move`` — and ``motor_busy``) to the legacy driver, while **owning**
+  the aligner-session state the hardware driver should never hold (``base``,
+  ``aligner_active``, ``aligner_plateid``, ``aligning_enabled``, and the
+  ``aligner`` back-reference set by ``Aligner.__init__``). This keeps the
+  1685-LOC ``aligner.py`` almost untouched — it still calls ``self.motor.<x>``.
+
+**NOT Linux-runtime-verifiable** (needs a live Bokeh session + an at-station
+plate-alignment dry-run). Construct-test tier only; see
+``docs/superpowers/plans/2026-07-22-P3a-galil-slice4-aligner-extraction.md``.
+The heavy imports (``bokeh``, ``HelaoVis``, ``Aligner``) are kept lazy inside
+:meth:`GalilAlignerHost.start` so this module — and the action server that
+constructs the host — import without a Bokeh document context.
+"""
+
+from functools import partial
+from typing import Any, Optional, Tuple
+
+from helao.core.error import ErrorCodes
+
+__all__ = ["AlignerMotorContext", "GalilAlignerHost"]
+
+
+class AlignerMotorContext:
+    """The ``motor`` object handed to ``Aligner`` — a driver façade that keeps
+    aligner-session state off the hardware driver.
+
+    Delegates motion/transform/calibration + the driver-owned ``blocked`` /
+    ``motor_busy`` flags to the wrapped legacy driver; owns ``base`` /
+    ``aligner_active`` / ``aligner_plateid`` / ``aligning_enabled`` / ``aligner``.
+    """
+
+    def __init__(self, driver: Any, base: Any):
+        self._driver = driver
+        # Owned here (was on the driver): the real Base handle the aligner reads
+        # for helaodirs/get_main_error, and the action Active + its session ids.
+        self.base = base
+        self.aligner_active: Any = None
+        self.aligner_plateid: Any = None
+        self.aligning_enabled: bool = False
+        # Back-reference target for `Aligner.__init__`'s `self.motor.aligner = self`.
+        self.aligner: Any = None
+
+    # --- delegated motion verbs -------------------------------------------
+    async def _motor_move(self, *args, **kwargs) -> dict:
+        return await self._driver._motor_move(*args, **kwargs)
+
+    async def query_axis_position(self, *args, **kwargs) -> dict:
+        return await self._driver.query_axis_position(*args, **kwargs)
+
+    async def query_axis_moving(self, *args, **kwargs) -> dict:
+        return await self._driver.query_axis_moving(*args, **kwargs)
+
+    # --- delegated transform / calibration --------------------------------
+    @property
+    def transform(self):
+        return self._driver.transform
+
+    @property
+    def dflt_matrix(self):
+        return self._driver.dflt_matrix
+
+    @property
+    def plate_transfermatrix(self):
+        return self._driver.plate_transfermatrix
+
+    def update_plate_transfermatrix(self, *args, **kwargs):
+        return self._driver.update_plate_transfermatrix(*args, **kwargs)
+
+    def save_transfermatrix(self, *args, **kwargs):
+        return self._driver.save_transfermatrix(*args, **kwargs)
+
+    # --- delegated driver-owned motion flags (live r/w on the driver) -----
+    @property
+    def blocked(self) -> bool:
+        return self._driver.blocked
+
+    @blocked.setter
+    def blocked(self, value: bool) -> None:
+        self._driver.blocked = value
+
+    @property
+    def motor_busy(self) -> bool:
+        return self._driver.motor_busy
+
+    @motor_busy.setter
+    def motor_busy(self, value: bool) -> None:
+        self._driver.motor_busy = value
+
+
+class GalilAlignerHost:
+    """Vis-layer owner of the Bokeh aligner for a Galil motion server.
+
+    Constructed by the action server after the driver connects (when
+    ``enable_aligner`` is set). Owns the Bokeh ``Server`` and the
+    aligner-orchestration verbs formerly on the driver.
+    """
+
+    def __init__(
+        self,
+        driver: Any,
+        base: Any,
+        server_cfg: dict,
+        server_name: str,
+        config: Optional[dict] = None,
+    ):
+        self._driver = driver
+        self._base = base
+        self._server_cfg = server_cfg
+        self._server_name = server_name
+        self._config = config or {}
+        self.context = AlignerMotorContext(driver, base)
+        self.bokehapp: Any = None
+
+    def start(self) -> None:
+        """Build and start the Bokeh ``Server`` hosting the ``/Aligner`` app.
+
+        Relocated verbatim from the legacy ``Galil.start_aligner`` /
+        ``makeBokehApp`` (D6 removal) — same host/port derivation
+        (``bokeh_port`` config, else ``server_cfg['port'] + 1000``).
+        """
+        from bokeh.server.server import Server
+
+        serv_host = self._server_cfg["host"]
+        serv_port = self._config.get("bokeh_port", self._server_cfg["port"] + 1000)
+        serv_py = "Aligner"
+        self.bokehapp = Server(
+            {f"/{serv_py}": partial(self._make_bokeh_app)},
+            port=serv_port,
+            address=serv_host,
+            allow_websocket_origin=[f"{serv_host}:{serv_port}"],
+        )
+        self.bokehapp.start()
+
+    def _make_bokeh_app(self, doc):
+        """Bokeh document factory: attach an ``Aligner`` bound to the context.
+
+        Wires the legacy driver's position-notify sink to the aligner's
+        ``motorpos_q`` so ``Galil.update_aligner`` (called from
+        ``query_axis_position``/``query_axis_moving``) keeps feeding live
+        positions to the Bokeh widgets.
+        """
+        from helao.core.servers.vis import HelaoVis
+        from helao.deploy.hte.layouts.aligner import Aligner
+
+        app = HelaoVis(server_key=self._server_name, doc=doc)
+        aligner = Aligner(app.vis, self.context)  # sets self.context.aligner = aligner
+        self._driver.set_position_sink(aligner.motorpos_q)
+        doc.aligner = aligner
+        return doc
+
+    # --- orchestration verbs (relocated from the driver) ------------------
+    def run_aligner_precheck(self) -> Tuple[bool, ErrorCodes]:
+        if self._driver.blocked or not self._driver.galil_enabled:
+            return False, ErrorCodes.in_progress
+        if self.bokehapp is None or self.context.aligner is None:
+            return False, ErrorCodes.not_available
+        return True, ErrorCodes.none
+
+    async def start_aligner_run(self, active) -> dict:
+        self._driver.blocked = True
+        self.context.aligner_plateid = active.action.action_params["plateid_or_pmpath"]
+        self.context.aligner_active = active
+        self.context.aligning_enabled = True
+        active_dict = self.context.aligner_active.action.as_dict()
+        _ = await self._driver.query_axis_moving(axis=self._driver.get_all_axis())
+        return active_dict
+
+    async def stop_aligner(self) -> ErrorCodes:
+        if self.bokehapp is not None and self.context.aligner is not None:
+            self.context.aligner.stop_align()
+            return ErrorCodes.none
+        return ErrorCodes.not_available
+
+    def shutdown(self) -> None:
+        """Cancel the aligner IO task on server shutdown (was ``Galil.shutdown``)."""
+        aligner = self.context.aligner
+        if aligner is not None:
+            aligner.IOtask.cancel()

--- a/helao/hexagon/tests/test_andor_disconnected_construct.py
+++ b/helao/hexagon/tests/test_andor_disconnected_construct.py
@@ -1,0 +1,70 @@
+"""AndorDriver disconnected-construct guard (P3a-2 constructor-connect fix).
+
+Before P3a-2, ``AndorDriver.__init__`` instantiated the vendor SDK
+(``AndorSDK3()``) and opened the camera (``connect()``), so the driver could
+not be constructed without the Andor runtime + hardware. The fix relocates
+both to ``connect()`` (called by ``andor_server.andor_dyn_endpoints`` at
+startup). These tests pin that the constructor touches no vendor runtime and
+that the SDK handle is created lazily, create-once.
+
+Real camera behavior remains an at-station gate; this is construct-tier only.
+"""
+
+from helao.deploy.hte.drivers.spec.andor import driver as andor_driver
+from helao.deploy.hte.drivers.spec.andor.driver import AndorDriver
+
+
+def test_construct_without_sdk_or_hardware():
+    d = AndorDriver(config={"dev_id": 2})
+    assert d.sdk3 is None  # no AndorSDK3() at construction
+    assert d.cam is None  # camera not opened
+    assert d.wl_arr is None
+    assert d.device_id == 2
+    assert d.ready is True
+
+
+def test_construct_does_not_load_vendor_runtime(monkeypatch):
+    called = {"load": 0}
+
+    def _boom_load():
+        called["load"] += 1
+        raise AssertionError("_load_andor must not run at construction")
+
+    monkeypatch.setattr(andor_driver, "_load_andor", _boom_load)
+    AndorDriver(config={})  # must not raise / must not call _load_andor
+    assert called["load"] == 0
+
+
+def test_connect_creates_sdk_once_then_reuses(monkeypatch):
+    made = {"loads": 0, "sdks": 0}
+
+    class _FakeCam:
+        pass
+
+    class _FakeSDK:
+        def __init__(self):
+            made["sdks"] += 1
+
+        def GetCamera(self, dev_id):
+            return _FakeCam()
+
+    monkeypatch.setattr(
+        andor_driver,
+        "_load_andor",
+        lambda: made.__setitem__("loads", made["loads"] + 1),
+    )
+    monkeypatch.setattr(andor_driver, "AndorSDK3", _FakeSDK, raising=False)
+
+    d = AndorDriver(config={})
+    # stub out the post-open metadata calls (they need real camera COM)
+    monkeypatch.setattr(d, "setup_image", lambda: 1024)
+    monkeypatch.setattr(d, "setup_spectroscope", lambda pw: [0.0])
+    monkeypatch.setattr(d, "get_meta_data", lambda: (1, 1, 1, 1))
+
+    assert d.sdk3 is None
+    d.connect()
+    assert made["sdks"] == 1 and made["loads"] == 1  # created on first connect
+    first_sdk = d.sdk3
+    d.connect()
+    assert made["sdks"] == 1  # reused, not recreated
+    assert d.sdk3 is first_sdk

--- a/helao/hexagon/tests/test_biologic_disconnected_construct.py
+++ b/helao/hexagon/tests/test_biologic_disconnected_construct.py
@@ -1,0 +1,65 @@
+"""BiologicDriver disconnected-construct + lazy technique-registry guard (P3a-2).
+
+Before P3a-2, ``biologic/technique.py`` imported ``easy_biologic.base_programs``
+at module scope and built ``BIOTECHS`` referencing ``blp.OCV`` etc., and
+``BiologicDriver.__init__`` opened the instrument (``connect()``). Since the
+easy-biologic SDK is Windows-only (``import easy_biologic.base_programs`` raises
+``OSError`` on Linux), the driver could neither import nor construct off-Windows.
+
+The fix (a) stores technique-name strings (``easy_class_name``) resolved lazily
+via ``resolve_easy_class`` at ``setup()`` time, and (b) relocates ``connect()``
+to ``biologic_server.biologic_dyn_endpoints``. These tests pin that the module
+imports and the driver constructs without ever loading the vendor SDK.
+
+Real instrument behavior remains an at-station gate; construct-tier only.
+"""
+
+import sys
+import types
+
+from helao.deploy.hte.drivers.pstat.biologic import driver as biologic_driver
+from helao.deploy.hte.drivers.pstat.biologic import technique as biologic_technique
+from helao.deploy.hte.drivers.pstat.biologic.driver import BiologicDriver
+
+
+def test_import_does_not_load_vendor_sdk():
+    # Importing the driver / technique registry must not pull easy_biologic
+    # (Windows-only). If it did, this module's own import above would have
+    # already failed on Linux — assert explicitly for a clear signal.
+    assert "easy_biologic" not in sys.modules
+    assert "easy_biologic.base_programs" not in sys.modules
+
+
+def test_construct_without_hardware_or_sdk():
+    d = BiologicDriver(config={"num_channels": 3})
+    assert d.ready is False  # not connected at construction
+    assert d.pstat is None
+    assert d.num_channels == 3
+    assert len(d.channels) == 3
+    assert "easy_biologic" not in sys.modules  # construct stayed SDK-free
+
+
+def test_registry_holds_names_not_vendor_classes():
+    for key in ("OCV", "CA", "CP", "CV", "PEIS", "GEIS", "CAOCV"):
+        tech = biologic_technique.BIOTECHS[key]
+        assert isinstance(tech.easy_class_name, str)
+    assert biologic_technique.TECH_OCV.easy_class_name == "OCV"
+
+
+def test_resolve_easy_class_is_lazy(monkeypatch):
+    # Inject a fake easy_biologic.base_programs so the resolver works without
+    # the real (Windows-only) SDK; proves it looks the class up by name lazily.
+    fake_bp = types.ModuleType("easy_biologic.base_programs")
+
+    class _FakeOCV:
+        pass
+
+    setattr(fake_bp, "OCV", _FakeOCV)
+    fake_pkg = types.ModuleType("easy_biologic")
+    monkeypatch.setitem(sys.modules, "easy_biologic", fake_pkg)
+    monkeypatch.setitem(sys.modules, "easy_biologic.base_programs", fake_bp)
+
+    resolved = biologic_technique.resolve_easy_class("OCV")
+    assert resolved is _FakeOCV
+    # driver re-exports the resolver it uses in setup()
+    assert biologic_driver.resolve_easy_class("OCV") is _FakeOCV

--- a/helao/hexagon/tests/test_galil_aligner_host.py
+++ b/helao/hexagon/tests/test_galil_aligner_host.py
@@ -1,0 +1,300 @@
+"""GalilAlignerHost + AlignerMotorContext tests (P3a galil-split slice-4).
+
+Linux construct-test tier ONLY. The D6 extraction moves the Bokeh aligner
+Server + HelaoVis + the aligner-session Active OUT of the Galil driver into
+this vis-layer host. Real behavior (Bokeh session, live plate alignment) is an
+at-station gate; these tests prove the seam is wired correctly:
+
+- The context delegates motion/transform/calibration + the driver-owned
+  `blocked`/`motor_busy` flags to the driver, and owns the aligner-session
+  state (`base`/`aligner_active`/`aligner_plateid`/`aligning_enabled`/`aligner`).
+- The context exposes EVERY `motor.*` name `layouts/aligner.py` reaches for, so
+  the near-untouched aligner keeps resolving against the context.
+- The host's orchestration verbs (`run_aligner_precheck`/`start_aligner_run`/
+  `stop_aligner`/`shutdown`) reproduce the legacy driver semantics.
+- The legacy driver has genuinely shed the D6 surface.
+"""
+
+import asyncio
+
+from helao.core.error import ErrorCodes
+from helao.hexagon.adapters.vis.galil_aligner_host import (
+    AlignerMotorContext,
+    GalilAlignerHost,
+)
+
+
+class _FakeDriver:
+    """Records delegation; stands in for the legacy Galil (no gclib)."""
+
+    def __init__(self):
+        self.blocked = False
+        self.motor_busy = False
+        self.galil_enabled = True
+        self.transform = object()
+        self.dflt_matrix = "DFLT"
+        self.plate_transfermatrix = "PTM"
+        self._position_sink = None
+        self.calls = []
+
+    async def _motor_move(self, *a, **k):
+        self.calls.append(("_motor_move", a, k))
+        return {"err_code": 0}
+
+    async def query_axis_position(self, *a, **k):
+        self.calls.append(("query_axis_position", a, k))
+        return {"position": [0.0]}
+
+    async def query_axis_moving(self, *a, **k):
+        self.calls.append(("query_axis_moving", a, k))
+        return {"motor_status": ["stopped"]}
+
+    def update_plate_transfermatrix(self, *a, **k):
+        self.calls.append(("update_plate_transfermatrix", a, k))
+        return "NEWPTM"
+
+    def save_transfermatrix(self, *a, **k):
+        self.calls.append(("save_transfermatrix", a, k))
+
+    def get_all_axis(self):
+        return ["x", "y"]
+
+    def set_position_sink(self, sink):
+        self._position_sink = sink
+
+
+class _FakeAction:
+    def __init__(self, plateid):
+        self.action_params = {"plateid_or_pmpath": plateid}
+
+    def as_dict(self):
+        return {"plateid": self.action_params["plateid_or_pmpath"]}
+
+
+class _FakeActive:
+    def __init__(self, plateid=6353):
+        self.action = _FakeAction(plateid)
+
+
+def _ctx():
+    d = _FakeDriver()
+    return AlignerMotorContext(d, base="BASE"), d
+
+
+# --------------------------------------------------------------------------
+# Context: ownership vs delegation
+# --------------------------------------------------------------------------
+def test_context_owns_aligner_session_state():
+    ctx, _ = _ctx()
+    assert ctx.base == "BASE"
+    assert ctx.aligner_active is None
+    assert ctx.aligner_plateid is None
+    assert ctx.aligning_enabled is False
+    assert ctx.aligner is None
+
+
+def test_context_delegates_flags_to_driver():
+    ctx, d = _ctx()
+    ctx.blocked = True
+    assert d.blocked is True and ctx.blocked is True
+    d.motor_busy = True
+    assert ctx.motor_busy is True  # read reflects live driver state
+    ctx.motor_busy = False
+    assert d.motor_busy is False
+
+
+def test_context_delegates_transform_and_calibration():
+    ctx, d = _ctx()
+    assert ctx.transform is d.transform
+    assert ctx.dflt_matrix == "DFLT"
+    assert ctx.plate_transfermatrix == "PTM"
+    assert ctx.update_plate_transfermatrix(newtransfermatrix="M") == "NEWPTM"
+    ctx.save_transfermatrix(file="f")
+    assert asyncio.run(ctx._motor_move(d_mm=[1, 2])) == {"err_code": 0}
+    assert asyncio.run(ctx.query_axis_position(axis=["x"])) == {"position": [0.0]}
+    assert [c[0] for c in d.calls] == [
+        "update_plate_transfermatrix",
+        "save_transfermatrix",
+        "_motor_move",
+        "query_axis_position",
+    ]
+
+
+def test_context_exposes_full_aligner_motor_surface():
+    """Guard: the context must expose every `motor.*` name aligner.py uses
+    (coupling map, 2026-07-22). A missing name would AttributeError only at
+    at-station runtime, so pin it here."""
+    ctx, _ = _ctx()
+    required = [
+        # motion
+        "_motor_move",
+        "query_axis_position",
+        # transform
+        "transform",
+        # calibration / matrix state
+        "plate_transfermatrix",
+        "dflt_matrix",
+        "update_plate_transfermatrix",
+        "save_transfermatrix",
+        # base reach-through
+        "base",
+        # active reach-through
+        "aligner_active",
+        # flags / ids / back-ref
+        "aligning_enabled",
+        "motor_busy",
+        "blocked",
+        "aligner_plateid",
+        "aligner",
+    ]
+    for name in required:
+        assert hasattr(ctx, name), f"context missing motor.{name}"
+
+
+# --------------------------------------------------------------------------
+# Host: orchestration verbs (no Bokeh)
+# --------------------------------------------------------------------------
+def _host():
+    d = _FakeDriver()
+    h = GalilAlignerHost(
+        driver=d,
+        base="BASE",
+        server_cfg={"host": "127.0.0.1", "port": 8003},
+        server_name="MOTOR",
+        config={"enable_aligner": True},
+    )
+    return h, d
+
+
+def test_precheck_not_available_before_bokeh_start():
+    h, _ = _host()
+    # bokehapp is None until start(); precheck must report not_available
+    ok, code = h.run_aligner_precheck()
+    assert ok is False and code == ErrorCodes.not_available
+
+
+def test_precheck_in_progress_when_blocked_or_disabled():
+    h, d = _host()
+    d.blocked = True
+    ok, code = h.run_aligner_precheck()
+    assert ok is False and code == ErrorCodes.in_progress
+    d.blocked = False
+    d.galil_enabled = False
+    ok, code = h.run_aligner_precheck()
+    assert ok is False and code == ErrorCodes.in_progress
+
+
+def test_precheck_ok_when_bokeh_and_aligner_present():
+    h, _ = _host()
+    h.bokehapp = object()  # simulate started server
+    h.context.aligner = object()  # simulate constructed Aligner
+    ok, code = h.run_aligner_precheck()
+    assert ok is True and code == ErrorCodes.none
+
+
+def test_start_aligner_run_sets_session_state_and_returns_dict():
+    h, d = _host()
+    active = _FakeActive(plateid=1234)
+    result = asyncio.run(h.start_aligner_run(active))
+    assert d.blocked is True  # driver-owned lock engaged
+    assert h.context.aligner_active is active
+    assert h.context.aligner_plateid == 1234
+    assert h.context.aligning_enabled is True
+    assert result == {"plateid": 1234}
+    # kicks off a motion-status query (legacy parity)
+    assert ("query_axis_moving", (), {"axis": ["x", "y"]}) in d.calls
+
+
+def test_stop_aligner_not_available_without_bokeh():
+    h, _ = _host()
+    assert asyncio.run(h.stop_aligner()) == ErrorCodes.not_available
+
+
+def test_stop_aligner_calls_aligner_stop_align():
+    h, _ = _host()
+    h.bokehapp = object()
+
+    class _AL:
+        def __init__(self):
+            self.stopped = False
+
+        def stop_align(self):
+            self.stopped = True
+
+    al = _AL()
+    h.context.aligner = al
+    assert asyncio.run(h.stop_aligner()) == ErrorCodes.none
+    assert al.stopped is True
+
+
+def test_shutdown_cancels_aligner_iotask():
+    h, _ = _host()
+
+    class _Task:
+        def __init__(self):
+            self.cancelled = False
+
+        def cancel(self):
+            self.cancelled = True
+
+    class _AL:
+        def __init__(self):
+            self.IOtask = _Task()
+
+    al = _AL()
+    h.context.aligner = al
+    h.shutdown()
+    assert al.IOtask.cancelled is True
+
+
+def test_shutdown_noop_without_aligner():
+    h, _ = _host()
+    h.shutdown()  # must not raise when no aligner constructed
+
+
+# --------------------------------------------------------------------------
+# Driver: D6 surface genuinely removed
+# --------------------------------------------------------------------------
+def test_driver_shed_d6_surface():
+    from helao.deploy.hte.drivers.motion import galil_motion_driver as gm
+
+    d = gm.Galil(config={"axis_id": {"x": "A"}})
+    for gone in [
+        "start_aligner",
+        "makeBokehApp",
+        "start_aligner_run",
+        "run_aligner_precheck",
+        "stop_aligner",
+        "base",
+        "aligner_active",
+        "bokehapp",
+        "aligner_enabled",
+    ]:
+        assert not hasattr(d, gone), f"driver still exposes {gone}"
+    # module no longer imports the Bokeh/aligner symbols
+    for sym in ["Server", "HelaoVis", "Aligner", "partial"]:
+        assert not hasattr(gm, sym), f"driver module still exposes {sym}"
+    # position-notify sink is the only remaining aligner tie
+    assert d._position_sink is None
+    d.set_position_sink("Q")
+    assert d._position_sink == "Q"
+
+
+def test_update_aligner_pushes_to_sink_only_when_wired():
+    from helao.deploy.hte.drivers.motion import galil_motion_driver as gm
+
+    d = gm.Galil(config={"axis_id": {}})
+    # no sink -> no-op, must not raise
+    asyncio.run(d.update_aligner({"ax": ["x"]}))
+
+    class _Q:
+        def __init__(self):
+            self.items = []
+
+        async def put(self, msg):
+            self.items.append(msg)
+
+    q = _Q()
+    d.set_position_sink(q)
+    asyncio.run(d.update_aligner({"ax": ["x"], "position": [1.0]}))
+    assert q.items == [{"ax": ["x"], "position": [1.0]}]

--- a/helao/hexagon/tests/test_galil_hardware_adapter.py
+++ b/helao/hexagon/tests/test_galil_hardware_adapter.py
@@ -1,0 +1,243 @@
+"""GalilMotionHardwareAdapter behavior tests (P3a galil-split slice-3).
+
+Linux construct-test tier: proves the native adapter is constructible without
+hardware or gclib, structurally satisfies HardwarePort, and delegates every
+lifecycle/motion verb to the wrapped legacy driver with the legacy return
+values intact. Real device I/O (connect + motion on the controller) is an
+at-station gate and is not exercised here.
+"""
+
+import asyncio
+from typing import Tuple
+
+import pytest
+
+from helao.core.drivers.helao_driver import (
+    DriverResponse,
+    DriverResponseType,
+    DriverStatus,
+)
+from helao.hexagon.adapters.native.galil_motion import GalilMotionHardwareAdapter
+from helao.hexagon.ports.hardware import HardwarePort
+
+
+# --------------------------------------------------------------------------
+# Fakes: a stand-in legacy driver recording delegation, so the motion verbs
+# can be exercised without gclib / a controller.
+# --------------------------------------------------------------------------
+class _FakeGalil:
+    def __init__(self):
+        self.galil_enabled = None
+        self.axis_id = {"x": "A", "y": "B"}
+        self.calls = []
+
+    # sync ABC lifecycle
+    def connect(self) -> DriverResponse:
+        self.calls.append(("connect",))
+        self.galil_enabled = True
+        return DriverResponse(
+            response=DriverResponseType.success, status=DriverStatus.ok
+        )
+
+    def get_status(self) -> DriverResponse:
+        self.calls.append(("get_status",))
+        return DriverResponse(
+            response=DriverResponseType.success, status=DriverStatus.ok
+        )
+
+    def reset(self) -> DriverResponse:
+        self.calls.append(("reset",))
+        return DriverResponse(
+            response=DriverResponseType.success, status=DriverStatus.ok
+        )
+
+    def disconnect(self) -> DriverResponse:
+        self.calls.append(("disconnect",))
+        return DriverResponse(
+            response=DriverResponseType.success, status=DriverStatus.ok
+        )
+
+    def shutdown(self) -> set:
+        self.calls.append(("shutdown",))
+        return {"shutdown"}
+
+    def get_all_axis(self) -> list:
+        return [ax for ax in self.axis_id]
+
+    # async device methods (dict / bool returns)
+    async def stop(self) -> DriverResponse:
+        self.calls.append(("stop",))
+        return DriverResponse(
+            response=DriverResponseType.success, status=DriverStatus.ok
+        )
+
+    async def estop(self, switch, *_args, **_kwargs) -> bool:
+        self.calls.append(("estop", switch))
+        return switch
+
+    async def motor_move(self, active) -> dict:
+        self.calls.append(("motor_move", active))
+        return {"err_code": 0, "moved": active}
+
+    async def motor_disconnect(self) -> dict:
+        self.calls.append(("motor_disconnect",))
+        return {"connection": False}
+
+    async def query_axis_position(self, axis, *_args, **_kwargs) -> dict:
+        self.calls.append(("query_axis_position", axis))
+        return {"err_code": 0, "position": [1.0], "ax": axis}
+
+    async def query_axis_moving(self, axis, *_args, **_kwargs) -> dict:
+        self.calls.append(("query_axis_moving", axis))
+        return {"err_code": 0, "motor_status": ["stopped"], "ax": axis}
+
+    async def stop_axis(self, axis) -> dict:
+        self.calls.append(("stop_axis", axis))
+        return {"err_code": 0, "ax": axis}
+
+    async def motor_off(self, axis, *_args, **_kwargs) -> dict:
+        self.calls.append(("motor_off", axis))
+        return {"err_code": 0, "ax": axis}
+
+    async def motor_on(self, axis, *_args, **_kwargs) -> dict:
+        self.calls.append(("motor_on", axis))
+        return {"err_code": 0, "ax": axis}
+
+    async def setaxisref(self):
+        self.calls.append(("setaxisref",))
+        return {"err_code": 0}
+
+    async def reset_controller(self):
+        self.calls.append(("reset_controller",))
+        return ""
+
+
+def _adapter() -> Tuple[GalilMotionHardwareAdapter, _FakeGalil]:
+    fake = _FakeGalil()
+    # duck-typed stand-in for the legacy Galil; the adapter only delegates.
+    return GalilMotionHardwareAdapter(fake), fake  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# Construct / conformance (the real Galil, no hardware)
+# --------------------------------------------------------------------------
+def test_from_config_constructs_without_io():
+    a = GalilMotionHardwareAdapter.from_config(
+        {"axis_id": {"x": "A", "y": "B"}, "timeout": 42}
+    )
+    # slice 1/2 disconnected-construct: no gclib, no connection opened.
+    assert a.galil_enabled is None
+    assert a.driver.g is None
+    assert a.driver.galilcmd is None
+    assert a.get_all_axis() == ["x", "y"]
+
+
+def test_from_config_defaults_and_base_hook():
+    a = GalilMotionHardwareAdapter.from_config()
+    assert a.driver._base_hook is None
+    sentinel = object()
+    b = GalilMotionHardwareAdapter.from_config({}, base_hook=sentinel)
+    assert b.driver._base_hook is sentinel
+
+
+def test_satisfies_hardware_port_protocol():
+    a, _ = _adapter()
+    assert isinstance(a, HardwarePort)
+
+
+def test_galil_enabled_passthrough():
+    a, fake = _adapter()
+    assert a.galil_enabled is None
+    fake.galil_enabled = True
+    assert a.galil_enabled is True
+
+
+def test_base_hook_proxy_reaches_wrapped_driver():
+    # The server handshake assigns `app.driver._base_hook = app.base` AFTER
+    # construction; when the adapter is `app.driver`, that must land on the
+    # wrapped legacy driver so its connect() can read helaodirs/server_cfg.
+    a = GalilMotionHardwareAdapter.from_config({"axis_id": {}})
+    assert a._base_hook is None
+    sentinel = object()
+    a._base_hook = sentinel
+    assert a._base_hook is sentinel
+    assert a.driver._base_hook is sentinel
+
+
+# --------------------------------------------------------------------------
+# Lifecycle delegation
+# --------------------------------------------------------------------------
+def test_connect_delegates_and_passes_through_driver_response():
+    a, fake = _adapter()
+    resp = asyncio.run(a.connect())
+    assert isinstance(resp, DriverResponse)
+    assert resp.response == DriverResponseType.success
+    assert fake.calls == [("connect",)]
+    assert a.galil_enabled is True
+
+
+def test_get_status_reset_disconnect_delegate():
+    a, fake = _adapter()
+    assert isinstance(asyncio.run(a.get_status()), DriverResponse)
+    assert isinstance(asyncio.run(a.reset()), DriverResponse)
+    assert isinstance(asyncio.run(a.disconnect()), DriverResponse)
+    assert [c[0] for c in fake.calls] == ["get_status", "reset", "disconnect"]
+
+
+def test_abort_maps_to_legacy_stop():
+    a, fake = _adapter()
+    resp = asyncio.run(a.abort())
+    assert resp.response == DriverResponseType.success
+    assert fake.calls == [("stop",)]
+
+
+def test_estop_wraps_bool_into_driver_response_but_performs_device_action():
+    a, fake = _adapter()
+    resp = asyncio.run(a.estop(True))
+    assert isinstance(resp, DriverResponse)
+    assert resp.response == DriverResponseType.success
+    assert resp.status == DriverStatus.ok
+    # the device-side estop was actually invoked with the switch value
+    assert fake.calls == [("estop", True)]
+
+
+def test_shutdown_wraps_set_into_driver_response():
+    a, fake = _adapter()
+    resp = asyncio.run(a.shutdown())
+    assert isinstance(resp, DriverResponse)
+    assert resp.response == DriverResponseType.success
+    assert fake.calls == [("shutdown",)]
+
+
+# --------------------------------------------------------------------------
+# Motion verbs: legacy dict returns intact
+# --------------------------------------------------------------------------
+def test_motion_verbs_return_legacy_dicts_verbatim():
+    a, _ = _adapter()
+    assert asyncio.run(a.motor_move("ACT")) == {"err_code": 0, "moved": "ACT"}
+    assert asyncio.run(a.motor_disconnect()) == {"connection": False}
+    assert asyncio.run(a.query_axis_position(["x"])) == {
+        "err_code": 0,
+        "position": [1.0],
+        "ax": ["x"],
+    }
+    assert asyncio.run(a.query_axis_moving(["x"])) == {
+        "err_code": 0,
+        "motor_status": ["stopped"],
+        "ax": ["x"],
+    }
+    assert asyncio.run(a.stop_axis(["x"])) == {"err_code": 0, "ax": ["x"]}
+    assert asyncio.run(a.motor_off("x")) == {"err_code": 0, "ax": "x"}
+    assert asyncio.run(a.motor_on("x")) == {"err_code": 0, "ax": "x"}
+    assert asyncio.run(a.setaxisref()) == {"err_code": 0}
+    assert asyncio.run(a.reset_controller()) == ""
+
+
+# --------------------------------------------------------------------------
+# Measurement phase is N/A and fails loud (never a silent no-op)
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("verb", ["arm", "start", "drain", "cleanup"])
+def test_measurement_phase_raises_not_implemented(verb):
+    a, _ = _adapter()
+    with pytest.raises(NotImplementedError):
+        asyncio.run(getattr(a, verb)())

--- a/helao/hexagon/tests/test_gamry_com.py
+++ b/helao/hexagon/tests/test_gamry_com.py
@@ -1,0 +1,346 @@
+"""GamryComThread + GamryComAdapter tests (P3a Gamry COM track, construct-test).
+
+Linux construct-test tier ONLY. comtypes is Windows-only, so the COM-specific
+hooks are stubbed: these tests prove the *thread/Future marshalling machinery*
+(the novel, risky part) and the adapter's disconnected-construct + verb
+delegation + strategy state — NOT real COM behavior, which is an at-station gate.
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from helao.hexagon.adapters.native.gamry_com import (
+    COINIT_APARTMENTTHREADED,
+    COINIT_MULTITHREADED,
+    GamryComAdapter,
+    GamryComThread,
+)
+
+
+# ==========================================================================
+# GamryComThread — real thread, COM hooks stubbed
+# ==========================================================================
+class _StubComThread(GamryComThread):
+    """GamryComThread with COM replaced by counters (no comtypes)."""
+
+    def __init__(self, coinit_flags=COINIT_MULTITHREADED, pump_interval_s=0.01):
+        super().__init__(coinit_flags=coinit_flags, pump_interval_s=pump_interval_s)
+        self.pump_count = 0
+        self.initialized = False
+        self.finalized = False
+        self.init_thread_ident = None
+        self.applied_coinit = None
+
+    def _com_initialize(self):
+        # record what a real _com_initialize would set, without importing comtypes
+        self.applied_coinit = self._coinit_flags
+        self.initialized = True
+        self.init_thread_ident = threading.get_ident()
+
+    def _com_pump(self, timeout_s):
+        self.pump_count += 1
+
+    def _com_finalize(self):
+        self.finalized = True
+
+
+def test_submit_runs_on_worker_thread_and_returns_result():
+    t = _StubComThread()
+    t.start()
+    try:
+        main = threading.get_ident()
+        run_ident = t.call(threading.get_ident)
+        assert run_ident != main
+        assert run_ident == t.init_thread_ident  # COM init + calls share a thread
+        assert t.call(lambda x: x + 1, 41) == 42
+    finally:
+        t.stop()
+
+
+def test_submit_propagates_exceptions():
+    t = _StubComThread()
+    t.start()
+    try:
+
+        def boom():
+            raise ValueError("com blew up")
+
+        with pytest.raises(ValueError, match="com blew up"):
+            t.call(boom)
+    finally:
+        t.stop()
+
+
+def test_submit_before_start_fails_loud():
+    t = _StubComThread()
+    fut = t.submit(lambda: 1)
+    with pytest.raises(RuntimeError, match="not running"):
+        fut.result()
+
+
+def test_calls_are_ordered_fifo():
+    t = _StubComThread()
+    t.start()
+    try:
+        seen = []
+        futs = [t.submit(seen.append, i) for i in range(20)]
+        for f in futs:
+            f.result()
+        assert seen == list(range(20))
+    finally:
+        t.stop()
+
+
+def test_pump_runs_after_calls_and_while_idle():
+    t = _StubComThread(pump_interval_s=0.005)
+    t.start()
+    try:
+        t.call(lambda: None)
+        assert t.pump_count >= 1  # after-call flush pump
+        before = t.pump_count
+        time.sleep(0.05)
+        assert t.pump_count > before  # idle loop keeps pumping (liveness)
+    finally:
+        t.stop()
+
+
+def test_init_failure_surfaces_to_start():
+    class _BadInit(_StubComThread):
+        def _com_initialize(self):
+            raise OSError("no COM here")
+
+    t = _BadInit()
+    with pytest.raises(OSError, match="no COM here"):
+        t.start()
+    assert t.running is False  # thread reference cleared on failed start
+
+
+def test_apartment_flag_is_applied_on_the_thread():
+    t = _StubComThread(coinit_flags=COINIT_APARTMENTTHREADED)
+    t.start()
+    try:
+        assert t.applied_coinit == COINIT_APARTMENTTHREADED
+    finally:
+        t.stop()
+
+
+def test_stop_joins_and_finalizes():
+    t = _StubComThread()
+    t.start()
+    assert t.running is True
+    t.stop()
+    assert t.running is False
+    assert t.finalized is True
+
+
+def test_double_start_raises():
+    t = _StubComThread()
+    t.start()
+    try:
+        with pytest.raises(RuntimeError, match="already started"):
+            t.start()
+    finally:
+        t.stop()
+
+
+# ==========================================================================
+# GamryComAdapter — fake inline thread + fake driver (no COM, no real thread)
+# ==========================================================================
+class _InlineThread(GamryComThread):
+    """Thread stand-in that runs submitted callables inline (deterministic).
+
+    Subclasses GamryComThread so it satisfies the adapter's thread_factory type
+    without spawning a real thread; every method is overridden to run inline.
+    """
+
+    def __init__(self, coinit_flags=COINIT_MULTITHREADED):
+        super().__init__(coinit_flags=coinit_flags)
+        self.coinit_flags = coinit_flags
+        self._running = False
+        self.stopped = False
+
+    def start(self):
+        self._running = True
+
+    def call(self, fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    def submit(self, fn, *args, **kwargs):  # unused by adapter verbs but part of API
+        from concurrent.futures import Future
+
+        fut: Future = Future()
+        fut.set_result(fn(*args, **kwargs))
+        return fut
+
+    @property
+    def running(self):
+        return self._running
+
+    def stop(self, timeout_s=5.0):
+        self._running = False
+        self.stopped = True
+
+
+class _FakeGamry:
+    def __init__(self, config):
+        self.config = config
+        self.calls = []
+
+    def get_status(self):
+        self.calls.append("get_status")
+        return "STATUS"
+
+    def get_gamry_state(self):
+        return {"state": "idle"}
+
+    def setup(self, *a, **k):
+        self.calls.append("setup")
+        return "SETUP"
+
+    def measure(self, *a, **k):
+        self.calls.append("measure")
+        return "MEASURE"
+
+    def get_data(self, *a, **k):
+        self.calls.append(("get_data", a, k))
+        return "DATA"
+
+    def setup_eis(self, *a, **k):
+        self.calls.append("setup_eis")
+        return "EIS"
+
+    def close_eis(self, *a, **k):
+        self.calls.append("close_eis")
+        return "CLOSE_EIS"
+
+    def cleanup(self, *a, **k):
+        self.calls.append("cleanup")
+        return "CLEANUP"
+
+    def disconnect(self):
+        self.calls.append("disconnect")
+        return "DISCONNECT"
+
+    async def stop(self):
+        self.calls.append("stop")
+        return "STOP"
+
+    def shutdown(self):
+        self.calls.append("shutdown")
+
+    def kill_gamrycom(self):
+        self.calls.append("kill_gamrycom")
+        return "KILLED"
+
+
+def _adapter():
+    made = {}
+
+    def thread_factory(coinit_flags=COINIT_MULTITHREADED):
+        t = _InlineThread(coinit_flags=coinit_flags)
+        made["thread"] = t
+        return t
+
+    def driver_factory(config):
+        d = _FakeGamry(config)
+        made["driver"] = d
+        return d
+
+    a = GamryComAdapter(
+        {"dev_id": 0},
+        thread_factory=thread_factory,
+        driver_factory=driver_factory,
+    )
+    return a, made
+
+
+def test_disconnected_construct_touches_nothing():
+    a, made = _adapter()
+    assert a.thread is None
+    assert a.driver is None
+    assert a.active_strategy is None
+    assert made == {}  # neither thread nor driver constructed at __init__
+
+
+def test_verbs_before_connect_fail_loud():
+    a, _ = _adapter()
+    with pytest.raises(RuntimeError, match="not connected"):
+        a.get_status()
+
+
+def test_connect_starts_thread_and_builds_driver_on_it():
+    a, made = _adapter()
+    status = a.connect()
+    assert a.thread is made["thread"]
+    assert made["thread"].running is True
+    assert a.driver is made["driver"]
+    assert status == "STATUS"
+
+
+def test_verbs_delegate_and_track_strategy():
+    a, made = _adapter()
+    a.connect()
+    d = made["driver"]
+
+    assert a.setup(technique="OCV") == "SETUP"
+    assert a.active_strategy == "dc"
+    assert a.measure() == "MEASURE"
+    assert a.get_data(0.1) == "DATA"
+
+    assert a.cleanup() == "CLEANUP"
+    assert a.active_strategy is None
+
+    assert a.setup_eis() == "EIS"
+    assert a.active_strategy == "eis"
+    assert a.close_eis() == "CLOSE_EIS"
+    assert a.active_strategy is None
+
+    assert a.poll() == "STATUS"
+    assert a.active_strategy is None  # idle poll resets after sampling
+
+    assert "setup" in d.calls and "setup_eis" in d.calls
+
+
+def test_stop_runs_driver_coroutine_on_thread():
+    # Uses a REAL worker thread (stubbed COM) so the driver's stop coroutine
+    # runs via asyncio.run on the worker thread — not nested on the caller's
+    # loop. The inline fake thread can't model this (single-thread collapse).
+    made = {}
+
+    def thread_factory(coinit_flags=COINIT_MULTITHREADED):
+        made["thread"] = _StubComThread(coinit_flags=coinit_flags)
+        return made["thread"]
+
+    def driver_factory(config):
+        made["driver"] = _FakeGamry(config)
+        return made["driver"]
+
+    a = GamryComAdapter(
+        {}, thread_factory=thread_factory, driver_factory=driver_factory
+    )
+    a.connect()
+    try:
+        assert asyncio.run(a.stop()) == "STOP"
+        assert "stop" in made["driver"].calls
+    finally:
+        a.shutdown()
+
+
+def test_shutdown_cleans_and_stops_thread():
+    a, made = _adapter()
+    a.connect()
+    thread = made["thread"]
+    a.shutdown()
+    assert "shutdown" in made["driver"].calls
+    assert thread.stopped is True
+    assert a.thread is None and a.driver is None and a.active_strategy is None
+
+
+def test_coinit_flag_forwarded_to_thread():
+    a, made = _adapter()
+    a._coinit_flags = COINIT_APARTMENTTHREADED
+    a.connect()
+    assert made["thread"].coinit_flags == COINIT_APARTMENTTHREADED

--- a/helao/hexagon/tests/test_hardware_import_sweep.py
+++ b/helao/hexagon/tests/test_hardware_import_sweep.py
@@ -31,29 +31,31 @@ def test_slice1_driver_imports_on_linux(mod):
 
 
 @pytest.mark.parametrize("mod", SLICE2_MODULES)
-@pytest.mark.xfail(
-    reason="P3a-2: biologic/technique.py references blp.OCV/CA/CV/PEIS/GEIS/CP "
-    "at module scope (technique registry built at import) plus an "
-    "`easy_class: BiologicProgram` class annotation — lazy-import requires a "
-    "registry restructure (store technique names/factories, resolve "
-    "getattr(blp, ...) at use), not an import move. Deferred to the biologic "
-    "native-adapter work.",
-    strict=False,
-)
 def test_slice2_driver_imports_on_linux(mod):
+    # P3a-2 DONE (2026-07-22): biologic/technique.py no longer references
+    # blp.OCV/... at module scope. The registry stores technique-name strings
+    # (`easy_class_name`) and resolves the vendor class lazily via
+    # `resolve_easy_class` at setup() time, so the driver now imports on Linux
+    # without the Windows-only easy_biologic runtime.
     importlib.import_module(BASE + mod)
 
 
 @pytest.mark.xfail(
-    reason="P3a-2 constructor-connect backlog: KinesisMotor.__init__ calls "
-    "self.connect() and kinesis_server.py never calls connect() externally, so "
-    "the fix must relocate connect() to the server startup (behavior change beyond "
-    "import relocation). Same §10.4 violation class as GamryDriver/AndorDriver/"
-    "MeerstetterTEC — batched into P3a-2.",
+    reason="P3a-2 status (2026-07-22): KinesisMotor.__init__ still calls "
+    "self.connect(). Unlike the other §10.4 offenders it is CONTESTED, not a "
+    "clean TODO: kinesis_server.py wires poller_class=KinesisPoller, and a "
+    "DriverPoller auto-starts in __init__ needing an open device (see the "
+    "poller-connect-in-__init__ rule), so relocating connect() is not a plain "
+    "behavior-preserving move. The sibling offenders are resolved otherwise: "
+    "AndorDriver fixed (disconnected-construct), GamryDriver deferred (shared "
+    "across private deployments), MeerstetterTEC dropped (no hte driver).",
     strict=False,
 )
 def test_kinesis_constructs_without_connecting(monkeypatch):
-    """§10.4: KinesisMotor(config) must not open devices in __init__."""
+    """§10.4: KinesisMotor(config) must not open devices in __init__.
+
+    Currently xfails by design — kinesis is poller-backed, so connect-in-
+    __init__ may be correct rather than a violation (contested; see reason)."""
     import pylablib.devices.Thorlabs as Thorlabs
     from helao.deploy.hte.drivers.motion import kinesis_driver
 


### PR DESCRIPTION
## Summary

P3a hexagon native-hardening + P3a-2 constructor-connect fixes. **All work is Linux construct-test tier — no live hardware path is exercised on Linux.** Draft/HOLD: the live-path changes must pass the at-station gates below before merge.

Every commit: pyright delta 0 on changed files, `black` clean, hexagon import-sweep green, `run_unit_tests.py` PASS.

## Commits

| Commit | Change | Wires live path? |
|---|---|---|
| `9951ed9e` | **galil slice-3** — `GalilMotionHardwareAdapter` (native gclib HardwarePort adapter, pure delegation to legacy `Galil`, disconnected-construct) | No — dormant, not runtime-wired |
| `e1b5862e` | **galil slice-4** — aligner Bokeh/D6 extraction: `GalilAlignerHost` + `AlignerMotorContext` own the Bokeh `Server`/`HelaoVis`/Active; driver freed of them; `aligner.py` untouched (0 edits) | **Yes** — galil motion server now hosts the aligner |
| `549ee372` | **gamry** `coinit_flags` import-time→lazy fix (removes a process-global mutation at import) + STA-thread design plan | Yes (import side-effect only; no runtime change) |
| `85c3b4e8` | **gamry** `GamryComThread` + `GamryComAdapter` (COM-owning worker thread, `submit()`/Future marshalling, interleaved `PumpEvents`) | No — dormant, not runtime-wired |
| `ca6d3ef7` | **andor §10.4** — `AndorDriver` disconnected-construct; SDK + `connect()` relocated to server startup | **Yes** — andor server connects in `dyn_endpoints` |
| `f5d4326c` | **biologic §10.4 + registry** — lazy `resolve_easy_class` (registry no longer imports the Windows-only SDK at module load) + disconnected-construct; server connects at startup | **Yes** — biologic server connects in `dyn_endpoints` |

## AT-STATION GATES (must pass before merge)

Only the 3 live-path changes need validation now; the 2 dormant adapters (galil-3, gamry-COM) are gated only at a future cut-over.

### Gate A — galil slice-4 aligner (HIGHEST risk)
Galil/aligner station (controller `192.168.200.234`). Launch galil motion with `enable_aligner: true`.
- `/Aligner` Bokeh page loads (host owns the Server now).
- Full plate alignment: go → Add Pt ×3 → Calc → Sub. Motion works; live position widgets update (driver→`_position_sink`→`motorpos_q`); calibration writes `<plateid>_calib.json`; Active finishes.
- estop/`blocked` still serialize aligner-vs-motion (move during alignment must block).
- Normal (non-aligner) motion still works (`query_positions`, `move`, `motor_off/on`).
- Rollback: revert `e1b5862e`.

### Gate B — andor §10.4
Spec station (SM303/Zyla + SDK). Launch andor group.
- Server starts, `connect()` logs OK, `acquire` returns a spectrum (`wl_arr` populated, `ch_0000..` columns). Existing `golden_capture_andor` if convenient.
- Rollback: revert `ca6d3ef7`.

### Gate C — biologic §10.4 + registry
Biologic station (Windows + easy_biologic). Launch biologic group.
- Server starts, `connect()` OK, `ready` true; run `run_OCV` + `run_PEIS` (dtaq + EIS paths) — data streams; `resolve_easy_class` returns the right program class.
- Rollback: revert `f5d4326c`.

### Deferred (only at cut-over — NOT blocking)
- **galil-3 `GalilMotionHardwareAdapter`**: when `app.driver` is repointed at it, verify motion verbs + lifecycle on hardware.
- **gamry `GamryComAdapter`**: when wired — golden_diff parity (OCV/CV dtaq, PEIS ReadZ, idle-poll), dtaq events with no missed points, apartment affinity (no `RPC_E_WRONG_THREAD`), and **decide STA vs MTA** (default MTA `0x0`; switch to STA `0x2` only if dtaq events prove unreliable).

## Recommended order
B (andor) → C (biologic) → A (galil aligner). A needs the most time (manual UI dry-run, highest rework risk).

## Design docs
- `docs/superpowers/plans/2026-07-22-P3a-galil-slice4-aligner-extraction.md`
- `docs/superpowers/plans/2026-07-22-P3a-gamry-com-sta-thread.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)