### PR TITLE
perf(sync): make sync_yml linear in yml size instead of quadratic

### DIFF
--- a/helao/core/drivers/data/sync_driver.py
+++ b/helao/core/drivers/data/sync_driver.py
@@ -232,7 +232,12 @@ class HelaoYml:
         #         pass
         # with self.filelock:
         #     self.meta = yml_load(self.target)
-        self.meta = yml_load(self.target)
+        # fast=True: run ymls are read as data and re-emitted from the pydantic
+        # models, never from the loaded object, so nothing here needs the
+        # round-trip containers -- and those containers are what made syncing a
+        # yml holding a long list quadratic (their __deepcopy__ is O(n^2), and
+        # HelaoDict.as_dict used to copy them).
+        self.meta = yml_load(self.target, fast=True)
 
     @property
     def parts(self) -> list:
@@ -537,9 +542,17 @@ class Progress:
         dict: In-memory copy of the progress dict.
     """
 
-    ymlpath: HelaoYml
+    # Path, not HelaoYml: ``__init__`` only ever assigns a Path here, and the
+    # ``yml`` property is what turns it into a HelaoYml. Declared as HelaoYml
+    # the attribute typed as its own ``exists`` property -- a bool -- so any
+    # ``self.ymlpath.exists()`` read as calling a bool.
+    ymlpath: Path
     prg: Path
     dict: dict
+    #: Last ``HelaoYml`` handed out by :attr:`yml`, and the ``(mtime_ns, size)``
+    #: of the file it parsed. Reused only while that stamp still holds.
+    _yml_cache: Optional[HelaoYml] = None
+    _yml_cache_stamp: tuple = ()
 
     def __init__(self, path: Union[Path, str]):
         """Resolve the yml/prg pair and load (or initialize) the progress dict.
@@ -613,8 +626,43 @@ class Progress:
 
     @property
     def yml(self) -> HelaoYml:
-        """Freshly-constructed ``HelaoYml`` for ``self.ymlpath``."""
-        return HelaoYml(self.ymlpath)
+        """``HelaoYml`` for ``self.ymlpath``, reused while the file is untouched.
+
+        Constructing a ``HelaoYml`` re-parses the yml from disk, and
+        ``sync_yml`` reads this property upwards of thirty times in a single
+        pass -- so an unconditionally fresh object made the parse cost of one
+        sync scale with the number of attribute reads, and dominated a sync
+        even for a yml carrying no bulk data at all.
+
+        The cached object is handed back only when re-constructing one would
+        demonstrably reproduce it: the resolved target must still exist,
+        unchanged in mtime and size, and must still be the file
+        ``HelaoYml.check_paths`` would land on. Anything else -- the yml moved
+        between RUNS_* trees, or was rewritten underneath us -- falls through
+        to a fresh parse, which is exactly what the uncached property did.
+        """
+        cached = getattr(self, "_yml_cache", None)
+        if cached is not None and (
+            cached.target == self.ymlpath or not self.ymlpath.exists()
+        ):
+            try:
+                stat = cached.target.stat()
+            except OSError:
+                stat = None
+            if stat is not None and (
+                stat.st_mtime_ns,
+                stat.st_size,
+            ) == self._yml_cache_stamp:
+                return cached
+        fresh = HelaoYml(self.ymlpath)
+        try:
+            stat = fresh.target.stat()
+            self._yml_cache_stamp = (stat.st_mtime_ns, stat.st_size)
+            self._yml_cache = fresh
+        except OSError:
+            # Nothing on disk to validate a cache entry against; never cache.
+            self._yml_cache = None
+        return fresh
 
     def list_unfinished_procs(self) -> tuple:
         """Return ``(s3_unfinished, api_unfinished)`` process-group indices.
@@ -638,7 +686,7 @@ class Progress:
 
     def read_dict(self):
         """Reload ``self.dict`` from the ``.prg`` file on disk."""
-        self.dict = yml_load(self.prg)
+        self.dict = yml_load(self.prg, fast=True)
 
     def write_dict(self, new_dict: Optional[dict] = None):
         """Persist the progress dict to the ``.prg`` file as YAML.

--- a/helao/core/helaodict.py
+++ b/helao/core/helaodict.py
@@ -4,7 +4,6 @@ __all__ = ["HelaoDict"]
 
 import math
 import types
-from copy import deepcopy
 from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
@@ -107,9 +106,20 @@ class HelaoDict:
             raise ValueError(tmp_str)
 
     def as_dict(self) -> dict:
-        """Return a fully-serialized dict of the instance's attributes with NaNs replaced by `None`."""
-        d = deepcopy(vars(self))
-        attr_only = self._serialize_dict(dict_in=d)
+        """Return a fully-serialized dict of the instance's attributes with NaNs replaced by `None`.
+
+        The attribute mapping is copied shallowly rather than deep-copied.
+        `_serialize_item` never mutates what it is handed and returns a fresh
+        container for every mutable type, so the result already shares no
+        mutable structure with the model and the deep copy was pure overhead --
+        ruinously so for the round-trip YAML containers a syncing model
+        carries, whose ``__deepcopy__`` is quadratic in sequence length: a
+        10k-element ``CommentedSeq`` measured 75s to copy against 0.6ms for the
+        plain list it serializes to. The shallow copy is kept because
+        ``vars(self)`` is the live instance ``__dict__``, and iterating it
+        directly would expose the walk to a concurrent attribute insertion.
+        """
+        attr_only = self._serialize_dict(dict_in=dict(vars(self)))
         clean_nans = {k: nan2None(v) for k, v in attr_only.items()}
         return clean_nans
 

--- a/helao/helpers/yml_tools.py
+++ b/helao/helpers/yml_tools.py
@@ -27,6 +27,10 @@ from helao.helpers.server_keys import get_sync_server_cfg
 #: and are not thread-safe, so each thread gets its own.
 _DUMPERS = threading.local()
 
+#: Per-thread loader cache, for the same reason as ``_DUMPERS``: parser and
+#: scanner state live on the ``YAML`` instance.
+_LOADERS = threading.local()
+
 
 def _represent_none(self, data):
     """Render ``None`` as the literal scalar ``null``."""
@@ -112,11 +116,47 @@ def _dump_to_str(yaml: ruamel.yaml.YAML, obj, options: dict) -> str:
     return output_str
 
 
-def yml_load(input: Union[str, Path]):
+def _get_loader(fast: bool) -> ruamel.yaml.YAML:
+    """Return this thread's cached loader for the ``fast``/round-trip variant.
+
+    ``fast=False`` is the round-trip (``typ="rt"``) loader, which returns
+    ``CommentedMap`` / ``CommentedSeq`` carrying the comments and formatting
+    needed to re-emit a document unchanged.
+
+    ``fast=True`` is the C-backed safe loader (``typ="safe", pure=False``),
+    which returns plain dicts and lists. It is several times faster to parse,
+    but the real cost it avoids is downstream: a ``CommentedSeq``'s
+    ``__deepcopy__`` is quadratic in length, so any consumer that copies the
+    loaded object pays 75s on a 10k-element sequence that a plain list copies
+    in 0.6ms.
+    """
+    key = "fast" if fast else "rt"
+    yaml = getattr(_LOADERS, key, None)
+    if yaml is not None:
+        return yaml
+
+    if fast:
+        # No ``version`` pin here: the C loader is left exactly as measured,
+        # and the round-trip branch keeps the 1.2 pin it has always carried.
+        yaml = ruamel.yaml.YAML(typ="safe", pure=False)
+    else:
+        yaml = ruamel.yaml.YAML(typ="rt")
+        yaml.version = (1, 2)
+
+    setattr(_LOADERS, key, yaml)
+    return yaml
+
+
+def yml_load(input: Union[str, Path], fast: bool = False):
     """Load YAML from a path, :class:`pathlib.Path`, or raw string.
 
     Args:
         input: Filesystem path, ``Path`` object, or YAML string.
+        fast: Use the C-backed safe loader instead of the round-trip one. Only
+            for callers that read a document as data and never re-emit it with
+            its comments intact -- the run-tree ymls the syncer walks are the
+            motivating case. Verified to read all 472 run ymls on a production
+            checkout to objects equal to the round-trip loader's.
 
     Returns:
         Parsed Python object (typically a dict).
@@ -124,16 +164,22 @@ def yml_load(input: Union[str, Path]):
     Raises:
         ruamel.yaml.YAMLError: If the YAML is malformed.
     """
-    yaml = ruamel.yaml.YAML(typ="rt")
-    yaml.version = (1, 2)
-    if isinstance(input, Path):
-        with input.open("r") as f:
-            obj = yaml.load(f)
-    elif os.path.exists(input):
-        with open(input, "r") as f:
-            obj = yaml.load(f)
-    else:
-        obj = yaml.load(input)
+    yaml = _get_loader(fast)
+    try:
+        if isinstance(input, Path):
+            with input.open("r") as f:
+                obj = yaml.load(f)
+        elif os.path.exists(input):
+            with open(input, "r") as f:
+                obj = yaml.load(f)
+        else:
+            obj = yaml.load(input)
+    except Exception:
+        # A load that raised mid-parse can leave scanner/parser state on the
+        # cached instance; drop it so the next document is not read through a
+        # half-consumed one.
+        setattr(_LOADERS, "fast" if fast else "rt", None)
+        raise
     return obj
 
 

--- a/helao/hexagon/adapters/native/sync_driver.py
+++ b/helao/hexagon/adapters/native/sync_driver.py
@@ -241,7 +241,12 @@ class HelaoYml:
         #         pass
         # with self.filelock:
         #     self.meta = yml_load(self.target)
-        self.meta = yml_load(self.target)
+        # fast=True: run ymls are read as data and re-emitted from the pydantic
+        # models, never from the loaded object, so nothing here needs the
+        # round-trip containers -- and those containers are what made syncing a
+        # yml holding a long list quadratic (their __deepcopy__ is O(n^2), and
+        # HelaoDict.as_dict used to copy them).
+        self.meta = yml_load(self.target, fast=True)
 
     @property
     def parts(self) -> list:
@@ -546,9 +551,17 @@ class Progress:
         dict: In-memory copy of the progress dict.
     """
 
-    ymlpath: HelaoYml
+    # Path, not HelaoYml: ``__init__`` only ever assigns a Path here, and the
+    # ``yml`` property is what turns it into a HelaoYml. Declared as HelaoYml
+    # the attribute typed as its own ``exists`` property -- a bool -- so any
+    # ``self.ymlpath.exists()`` read as calling a bool.
+    ymlpath: Path
     prg: Path
     dict: dict
+    #: Last ``HelaoYml`` handed out by :attr:`yml`, and the ``(mtime_ns, size)``
+    #: of the file it parsed. Reused only while that stamp still holds.
+    _yml_cache: Optional[HelaoYml] = None
+    _yml_cache_stamp: tuple = ()
 
     def __init__(self, path: Union[Path, str]):
         """Resolve the yml/prg pair and load (or initialize) the progress dict.
@@ -622,8 +635,43 @@ class Progress:
 
     @property
     def yml(self) -> HelaoYml:
-        """Freshly-constructed ``HelaoYml`` for ``self.ymlpath``."""
-        return HelaoYml(self.ymlpath)
+        """``HelaoYml`` for ``self.ymlpath``, reused while the file is untouched.
+
+        Constructing a ``HelaoYml`` re-parses the yml from disk, and
+        ``sync_yml`` reads this property upwards of thirty times in a single
+        pass -- so an unconditionally fresh object made the parse cost of one
+        sync scale with the number of attribute reads, and dominated a sync
+        even for a yml carrying no bulk data at all.
+
+        The cached object is handed back only when re-constructing one would
+        demonstrably reproduce it: the resolved target must still exist,
+        unchanged in mtime and size, and must still be the file
+        ``HelaoYml.check_paths`` would land on. Anything else -- the yml moved
+        between RUNS_* trees, or was rewritten underneath us -- falls through
+        to a fresh parse, which is exactly what the uncached property did.
+        """
+        cached = getattr(self, "_yml_cache", None)
+        if cached is not None and (
+            cached.target == self.ymlpath or not self.ymlpath.exists()
+        ):
+            try:
+                stat = cached.target.stat()
+            except OSError:
+                stat = None
+            if stat is not None and (
+                stat.st_mtime_ns,
+                stat.st_size,
+            ) == self._yml_cache_stamp:
+                return cached
+        fresh = HelaoYml(self.ymlpath)
+        try:
+            stat = fresh.target.stat()
+            self._yml_cache_stamp = (stat.st_mtime_ns, stat.st_size)
+            self._yml_cache = fresh
+        except OSError:
+            # Nothing on disk to validate a cache entry against; never cache.
+            self._yml_cache = None
+        return fresh
 
     def list_unfinished_procs(self) -> tuple:
         """Return ``(s3_unfinished, api_unfinished)`` process-group indices.
@@ -647,7 +695,7 @@ class Progress:
 
     def read_dict(self):
         """Reload ``self.dict`` from the ``.prg`` file on disk."""
-        self.dict = yml_load(self.prg)
+        self.dict = yml_load(self.prg, fast=True)
 
     def write_dict(self, new_dict: Optional[dict] = None):
         """Persist the progress dict to the ``.prg`` file as YAML.


### PR DESCRIPTION
Syncing one action yml took **96.7 s** when its `action_params` held a 10,000-element array, against 206 ms with no array at all — and the scaling was quadratic, so a 100k-element array ran for hours.

The numpy branch added in 48afa36f is the trigger, not the cost: before it, an ndarray raised `ValueError: Helao as_dict cannot serialize ...` (verified against `48afa36f^`), so long lists never reached a run yml. Now they do, and they land on three independent costs.

## What was slow

1. **`HelaoDict.as_dict` opened with `deepcopy(vars(self))`.** Serialization never mutates its input and returns a fresh container for every mutable type, so the copy bought nothing — and `CommentedSeq.__deepcopy__` is O(n²): **75 s** for 10k elements against **0.6 ms** for the plain list it serializes to. Plain-data deepcopy is irrelevant (2.8 ms for 1e6 floats).
2. **`yml_load` always used ruamel's pure-Python round-trip parser**, so run ymls came back as exactly those `CommentedMap`/`CommentedSeq` containers.
3. **`Progress.yml` re-parsed the yml from disk on every read**, and `sync_yml` reads it ~32 times per pass. That alone is ~97% of the 206 ms floor even with no bulk data — a pre-existing cost, unrelated to numpy.

## What changed

- `as_dict` takes a shallow `dict(vars(self))`. Shallow rather than iterating `vars(self)` directly, since that is the live instance `__dict__` and the walk is long enough to want a snapshot against a concurrent attribute insert.
- `yml_load` gains a `fast=` opt-in mirroring `yml_dumps`' existing one (C-backed safe loader, plain `dict`/`list`). Only `HelaoYml.__init__` and `Progress.read_dict` pass it, so config loading keeps the round-trip loader and its comments. Loaders are now cached per thread like the dumpers, and dropped if a load raises mid-parse.
- `Progress.yml` reuses its `HelaoYml` while `(mtime_ns, size)` hold **and** `check_paths` would still resolve the same target; anything else falls through to a fresh parse, exactly as the uncached property did.

## Measured

One action yml, S3 stubbed, real serialization. `N` = elements in one `action_params` array.

| N | before | after |
|---|---|---|
| 0 | 206 ms | **12 ms** |
| 1,000 | 2.33 s | **36 ms** |
| 10,000 | 96.7 s | **293 ms** |
| 100,000 | hours | **3.0 s** |

Linear now, not quadratic.

## Behaviour is unchanged, verified rather than assumed

- Every object `sync_yml` uploads is **byte-identical** before and after: the same tree run twice with both behaviour-changing knobs flipped, compared as sorted JSON.
- The safe loader reads **472 of 472** run ymls on a production checkout to objects equal to the round-trip loader's, with no errors. Quoted timestamps stay strings.

## Also

Corrects `Progress.ymlpath`'s annotation from `HelaoYml` to `Path`. It has only ever held a `Path`, and typed as `HelaoYml` the attribute resolved to that class's `exists` *property* — a bool — so `self.ymlpath.exists()` type-checked as calling it. Clears 4 pre-existing pyright errors (21 → 17 across the touched files, none added).

`helao/hexagon/adapters/native/sync_driver.py` carries the same edits verbatim, as `test_native_sync_pins.py` requires; both files are black-`force-exclude`d, so the edits are hand-formatted and the region re-spliced rather than reformatted.

## Verification

- Full sweep green: **176 files, 161 PASS / 2 ENV / 13 NOTESTS**, zero failures. (The 2 ENV are the Windows-only Andor SDK, uncollectable on Linux.)
- `run_unit_tests.py` overall PASS.
- 10 source-parity pin tests pass; 73 hexagon sync tests pass.
- `black` clean on the two non-excluded files; the two excluded ones correctly untouched.

## Not addressed here

`yml_dumps` of a 100k-element list still costs 2.9 s against 31 ms for `json.dumps`, so the **write** side (`base_meta_writer`) pays a large cost this PR does not touch. Other run-yml readers (`helao_data.py`, `loaders/localfs.py`, `file_mapper.py`) still use the round-trip loader — no longer exposed to the quadratic now that the deepcopy is gone, but they would parse several times faster with `fast=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)