### PR TITLE
Journal queued analyses so an ANA restart cannot lose them

### DIFF
--- a/helao/core/drivers/data/analysis_driver.py
+++ b/helao/core/drivers/data/analysis_driver.py
@@ -16,20 +16,54 @@ analysis_params)``. Which ``<deployment>`` that is comes from
 :func:`resolve_analyses_package`, which survives a hexagon graft (see its
 docstring); a configured analysis that cannot be loaded raises
 :class:`AnalysisLoadError` rather than leaving the server short a route.
+
+**A queued analysis outlives the process that queued it.** The queue itself
+cannot: it is an ``asyncio.Queue`` of tuples holding a live
+:class:`~helao.core.drivers.data.loaders.localfs.LocalLoader`, so it is neither
+serialisable nor visible from outside the process, and the requesting action
+returns as soon as it has enqueued -- its own record already reads *done*. A
+restart therefore used to drop every queued analysis with no trace anywhere: no
+file, no log line, and an action history claiming the work was requested
+successfully. The fix is a **request journal**, one small json file per queued
+analysis under ``<root>/STATES/ana_pending/``, written *before* the item reaches
+the queue and deleted when its worker finishes with it. At startup the journal
+is swept and every surviving entry is re-enqueued (see
+:meth:`AnalysisSyncer.recover_journal`).
+
+Re-running a recovered analysis is an idempotent upsert rather than a duplicate,
+which is what makes the sweep safe to arm by default: an analysis uuid is the
+deterministic hash of its identity and inputs
+(:meth:`~helao.core.drivers.data.analyses.base_analysis.BaseAnalysis.gen_uuid`),
+so the second run lands on the same uuid, the same local ANALYSES path and the
+same S3 keys as the first. This is the opposite of a run uuid (``uuid7``, 48
+random bits), where re-running is what the batch converter's recovery goes to
+such lengths to avoid.
 """
 
 __all__ = [
+    "ANA_JOURNAL_SCHEMA",
+    "ANA_JOURNAL_SUBDIR",
+    "ANA_JOURNAL_SUFFIX",
     "AnalysisSyncer",
     "AnalysisExecutor",
     "AnalysisLoadError",
+    "analysis_journal_key",
+    "journal_entry_path",
+    "list_journal_entries",
     "load_analysis_classes",
     "make_analysis_app",
+    "read_journal_entry",
+    "remove_journal_entry",
     "resolve_analyses_package",
+    "write_journal_entry",
 ]
 
 import asyncio
+import hashlib
 import inspect
+import json
 import os
+import time
 from importlib import import_module, util as importlib_util
 from typing import Optional
 from uuid import UUID
@@ -55,6 +89,28 @@ from helao.helpers import helao_logging as logging
 from helao.helpers.executor import Executor
 
 LOGGER = logging.make_logger(__file__) if logging.LOGGER is None else logging.LOGGER
+
+
+def _alert(message: str, exc_info: bool = False) -> None:
+    """Raise an alert through the module logger, falling back to ``error``.
+
+    ``helao_logging`` installs ``alert`` with ``setattr(logging.Logger, "alert",
+    ...)`` at import (``helao_logging.py:70``), i.e. on the *class* -- so every
+    ``logging.Logger`` in a process that has loaded this module does carry it,
+    and the direct ``LOGGER.alert`` calls this replaces could not actually raise.
+    What the class patch does not reach is a logger that is not a
+    ``logging.Logger`` at all: a ``LoggerAdapter``, or a test's stub. Alerts here
+    are the mechanism by which a lost analysis stops being invisible, so an alert
+    must never itself be the thing that raises.
+
+    ``LOGGER`` is read at call time rather than bound as a default, so a test
+    that replaces the module logger is honoured. Also invisible to static
+    analysis, which is why pyright reports ``alert`` as unknown on ``Logger``;
+    resolving it through ``getattr`` keeps the type checker quiet as well.
+    """
+    emit = getattr(LOGGER, "alert", None) or LOGGER.error
+    emit(message, exc_info=exc_info)
+
 
 # metadata keys copied from the source process onto the analysis model when present
 _PROCESS_METADATA_KEYS = (
@@ -279,6 +335,151 @@ def load_analysis_classes(
     return loaded
 
 
+#: Subdirectory of ``<root>/STATES`` holding the pending-analysis journal.
+ANA_JOURNAL_SUBDIR = "ana_pending"
+
+#: Extension of one journal entry. Anything else in the directory (notably the
+#: ``.json.tmp`` an interrupted atomic write leaves behind) is not an entry.
+ANA_JOURNAL_SUFFIX = ".json"
+
+#: Schema version of a journal entry's payload. Bump when a field's meaning
+#: changes; a sweep refuses an entry from a newer schema rather than guessing at
+#: it, the way ``batch_converter``'s checkpoints do.
+ANA_JOURNAL_SCHEMA = 1
+
+
+def analysis_journal_key(target: str, process_uuid, analysis_class_name: str) -> str:
+    """Return the journal file name for one analysis request.
+
+    Derived from the three things that identify the request -- the loader
+    ``target`` (the zip or run tree being analysed), the process uuid, and the
+    analysis class -- so re-journalling the same request **overwrites** its entry
+    instead of accumulating a second one. That matters on the recovery path,
+    which re-enqueues an entry and thereby re-journals it.
+
+    The uuid leads the name, unhyphenated separator ``__``, because
+    :meth:`AnalysisSyncer.journal_clear_by_process` can only match on a process
+    uuid (see its docstring) and does so by this prefix. ``target`` is folded
+    into a short digest rather than spelled out: it is an absolute path, so it
+    carries separators and is far too long for a file name.
+
+    Args:
+        target: ``LocalLoader.target`` -- the absolute zip/tree path.
+        process_uuid: Process uuid the analysis runs on.
+        analysis_class_name: ``__name__`` of the :class:`BaseAnalysis` subclass.
+
+    Returns:
+        ``<process uuid>__<class name>__<12-hex digest>.json``.
+    """
+    digest = hashlib.sha1(
+        "\x1f".join([str(target), str(process_uuid), str(analysis_class_name)]).encode(
+            "utf8", errors="replace"
+        )
+    ).hexdigest()[:12]
+    return f"{process_uuid}__{analysis_class_name}__{digest}{ANA_JOURNAL_SUFFIX}"
+
+
+def journal_entry_path(journal_dir: str, key: str) -> str:
+    """Return the full path of journal entry ``key`` inside ``journal_dir``."""
+    return os.path.join(journal_dir, key)
+
+
+def list_journal_entries(journal_dir: Optional[str]) -> list:
+    """Return the sorted journal entry file names in ``journal_dir``.
+
+    Filters to :data:`ANA_JOURNAL_SUFFIX`, which excludes the ``.json.tmp``
+    files an interrupted atomic write leaves behind -- sweeping one of those as
+    an entry would parse a half-written payload. Returns ``[]`` for a missing or
+    unreadable directory, and for journalling being disabled altogether
+    (``journal_dir`` of ``None``).
+    """
+    if not journal_dir:
+        return []
+    try:
+        return sorted(
+            name
+            for name in os.listdir(journal_dir)
+            if name.endswith(ANA_JOURNAL_SUFFIX)
+        )
+    except FileNotFoundError:
+        # Not yet created (nothing has ever been queued on this root), which is
+        # not worth a warning -- it is the normal state of a fresh install.
+        return []
+    except OSError:
+        LOGGER.warning(f"could not list analysis journal dir {journal_dir}")
+        return []
+
+
+def read_journal_entry(path: str) -> Optional[dict]:
+    """Read one journal entry, or ``None`` when it carries no usable payload.
+
+    ``None`` covers "absent", "unreadable" and "not an object" together so the
+    sweep has exactly one no-information case. A corrupt entry is logged and
+    skipped rather than raised: taking a whole recovery sweep down over one bad
+    json file would strand every other queued analysis, which is precisely the
+    silent loss this journal exists to end.
+    """
+    try:
+        with open(path, "r", encoding="utf8") as handle:
+            entry = json.load(handle)
+    except FileNotFoundError:
+        return None
+    except Exception:
+        LOGGER.warning(f"unreadable analysis journal entry {path}; skipping it")
+        return None
+    if not isinstance(entry, dict):
+        LOGGER.warning(f"analysis journal entry {path} is not an object; skipping it")
+        return None
+    return entry
+
+
+def write_journal_entry(journal_dir: str, key: str, entry: dict) -> bool:
+    """Atomically write ``entry`` as journal file ``key``. Never raises.
+
+    ``tmp`` + :func:`os.replace`, so a concurrent sweep never reads a
+    half-written entry. Failure is logged and reported as ``False`` because
+    bookkeeping must never be the thing that breaks the real work: an analysis
+    whose journal write failed still runs, it merely stops being recoverable.
+
+    Args:
+        journal_dir: Directory to write into.
+        key: File name from :func:`analysis_journal_key`.
+        entry: Payload; ``schema`` and ``queued_at`` are filled in here.
+
+    Returns:
+        ``True`` on success, ``False`` if the write failed.
+    """
+    path = journal_entry_path(journal_dir, key)
+    payload = dict(entry)
+    payload["schema"] = ANA_JOURNAL_SCHEMA
+    payload["queued_at"] = time.time()
+    tmp = f"{path}.tmp"
+    try:
+        os.makedirs(journal_dir, exist_ok=True)
+        with open(tmp, "w", encoding="utf8") as handle:
+            json.dump(payload, handle, indent=2, default=str)
+        os.replace(tmp, path)
+        return True
+    except Exception:
+        LOGGER.error(f"could not write analysis journal entry {path}", exc_info=True)
+        try:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+        except OSError:
+            pass
+        return False
+
+
+def remove_journal_entry(path: str) -> None:
+    """Delete one journal entry if it is there. Never raises."""
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+    except OSError:
+        LOGGER.warning(f"could not remove analysis journal entry {path}")
+
+
 class AnalysisSyncer(HelaoSyncer):
     """Queue-based worker that runs analyses and syncs outputs to S3.
 
@@ -304,6 +505,8 @@ class AnalysisSyncer(HelaoSyncer):
         task_set: Set of enqueued process UUIDs used to deduplicate.
         running_tasks: Mapping from process UUID string to worker task.
         syncer_loops: Mapping from worker index to its asyncio.Task.
+        journal_dir: Directory holding the durable request journal, or ``None``
+            when journalling is disabled (no resolvable ``STATES`` root).
         loader: S3/metadata loader shared with analysis classes via ``pgs3.LOADER``.
         s3: S3 client from the loader.
         s3r: S3 resource from the loader.
@@ -338,11 +541,315 @@ class AnalysisSyncer(HelaoSyncer):
         self.task_queue = asyncio.Queue()
         self.task_set = set()
         self.running_tasks = {}
+        self.journal_dir = self._resolve_journal_dir(action_serv)
 
         self.syncer_loops = {
             i: asyncio.create_task(self.syncer(), name=f"syncer_loop__{i}")
             for i in range(self.max_tasks)
         }
+
+    @staticmethod
+    def _resolve_journal_dir(action_serv: Base) -> Optional[str]:
+        """Return ``<STATES>/ana_pending``, or ``None`` to disable journalling.
+
+        The ``STATES`` root is read off the action server's own
+        :class:`~helao.core.models.helaodirs.HelaoDirs` (``Base.helaodirs``,
+        built by :func:`~helao.helpers.helao_dirs.helao_dirs` from the world
+        config's ``root``) rather than re-resolved from the config here, so the
+        journal cannot end up under a different root than the rest of the
+        server's state.
+
+        Every field of ``HelaoDirs`` is ``None`` when the config carries no
+        ``root``, which is a supported construction (``Base`` itself only warns),
+        and a test double need not carry ``helaodirs`` at all. Either way the
+        answer is ``None``: journalling degrades to off with one WARNING and the
+        server keeps behaving exactly as it did before the journal existed.
+        """
+        states_root = getattr(
+            getattr(action_serv, "helaodirs", None), "states_root", None
+        )
+        if not states_root:
+            LOGGER.warning(
+                "No STATES root is available, so queued analyses will not be "
+                "journalled; a restart will silently drop whatever is queued."
+            )
+            return None
+        path = os.path.join(str(states_root), ANA_JOURNAL_SUBDIR)
+        try:
+            os.makedirs(path, exist_ok=True)
+        except OSError:
+            LOGGER.warning(
+                f"Could not create the analysis journal dir {path}; queued "
+                "analyses will not be journalled.",
+                exc_info=True,
+            )
+            return None
+        LOGGER.info(f"Analysis request journal at {path}.")
+        return path
+
+    def _journal_key(self, calc_tup: tuple) -> Optional[str]:
+        """Return the journal file name for ``calc_tup``, or ``None`` if unknown.
+
+        A pure function of the tuple, which is the whole point: the completion
+        path can recompute the exact key from the tuple it just finished with,
+        so no queued-item-to-journal-path mapping has to be maintained anywhere
+        (and none can go stale). ``None`` when the loader carries no ``target``
+        -- a stand-in loader in a test, or a loader kind that is not
+        :class:`LocalLoader` -- since without a target there is nothing a
+        recovered entry could be rebuilt from.
+        """
+        target = getattr(calc_tup[1], "target", None)
+        if not target:
+            return None
+        ana_cls = calc_tup[3]
+        return analysis_journal_key(
+            str(target), calc_tup[0], getattr(ana_cls, "__name__", str(ana_cls))
+        )
+
+    def journal_write(self, calc_tup: tuple) -> Optional[str]:
+        """Record ``calc_tup`` in the journal. Returns the path, or ``None``.
+
+        Called by :meth:`enqueue_calc` **before** the item reaches the queue.
+        The order is the mechanism: a crash in the gap between the two leaves a
+        recoverable record on disk, whereas the reverse order leaves a queued
+        analysis with nothing written about it -- exactly the loss this journal
+        exists to end.
+
+        The entry records the loader's ``target`` rather than the loader, which
+        is what makes it serialisable at all: ``LocalLoader.__init__`` keeps the
+        absolute path on ``self.target``, so ``LocalLoader(target)`` rebuilds an
+        equivalent loader on the recovery path.
+
+        Never raises. A journal that cannot be written is a lost *recovery*
+        guarantee, not a lost analysis.
+        """
+        if not self.journal_dir:
+            return None
+        try:
+            key = self._journal_key(calc_tup)
+            if key is None:
+                LOGGER.warning(
+                    "Queued analysis has no loader target, so it cannot be "
+                    "journalled; a restart would drop it."
+                )
+                return None
+            process_uuid, data_loader, params, ana_cls, action_uuid = calc_tup
+            entry = {
+                "target": str(getattr(data_loader, "target", "")),
+                "process_uuid": str(process_uuid),
+                "params": params if isinstance(params, dict) else {},
+                # The class NAME, resolved back to a class at recovery time
+                # against the same ``analyses`` mapping make_analysis_app built
+                # -- a class object is not serialisable, and an import path
+                # would pin the entry to one deployment's module layout.
+                "analysis_class": getattr(ana_cls, "__name__", str(ana_cls)),
+                "analysis_module": getattr(ana_cls, "__module__", ""),
+                "analysis_action_uuid": (
+                    None if action_uuid is None else str(action_uuid)
+                ),
+            }
+            if write_journal_entry(self.journal_dir, key, entry):
+                return journal_entry_path(self.journal_dir, key)
+        except Exception:
+            LOGGER.error("Failed to journal a queued analysis.", exc_info=True)
+        return None
+
+    def journal_clear(self, calc_tup: tuple) -> None:
+        """Drop ``calc_tup``'s journal entry, its worker having finished with it.
+
+        Keyed by recomputing :meth:`_journal_key` from the tuple, so the entry
+        removed is exactly the one :meth:`journal_write` created -- see
+        :meth:`journal_clear_by_process` for why the task-name route cannot be
+        that precise.
+
+        Removed on **completion**, not on success: a failed analysis has already
+        been alerted by :meth:`syncer`, and keeping its entry would re-run a
+        permanently-failing analysis at every restart, forever. The journal's
+        job is to survive an *interruption* -- a crash, a kill, a graceful stop
+        -- which is exactly the case where no worker ever reaches here.
+        """
+        if not self.journal_dir:
+            return
+        try:
+            key = self._journal_key(calc_tup)
+            if key is not None:
+                remove_journal_entry(journal_entry_path(self.journal_dir, key))
+        except Exception:
+            LOGGER.warning("Failed to clear an analysis journal entry.", exc_info=True)
+
+    def journal_clear_by_process(self, process_uuid_str: str) -> None:
+        """Drop every journal entry for one process uuid. Best effort.
+
+        The seam for a caller that has only a task *name* -- which is the process
+        uuid, and therefore not the journal key: the key also carries the loader
+        target and the analysis class, so one process uuid can in principle own
+        several entries. Matching by the name prefix removes all of them, which
+        is a superset of what such a caller means. :meth:`syncer` uses the exact
+        :meth:`journal_clear` instead and does not go through here.
+        """
+        if not self.journal_dir:
+            return
+        prefix = f"{process_uuid_str}__"
+        for name in list_journal_entries(self.journal_dir):
+            if name.startswith(prefix):
+                remove_journal_entry(journal_entry_path(self.journal_dir, name))
+
+    def journal_pending_keys(self) -> list:
+        """Journal entry file names currently on disk, for the status endpoint."""
+        return list_journal_entries(self.journal_dir)
+
+    async def recover_journal(self, analysis_classes: dict) -> dict:
+        """Re-enqueue every analysis the journal still holds. Startup sweep.
+
+        An entry survives only when its worker never finished with it, so every
+        one found here is an analysis that was requested, reported as
+        successfully requested by its action, and then lost to a restart. The
+        sweep is what stops that from being silent: anything recovered is raised
+        as an alert, not merely logged.
+
+        Re-running is an idempotent upsert rather than a duplicate, which is why
+        this is armed by default and needs no delete-then-rerun dance:
+        ``BaseAnalysis.gen_uuid`` hashes the analysis name, params, process uuid,
+        sample label, codehash and run_use, so the recovered run mints the *same*
+        analysis uuid and writes the same local path and S3 keys as the run it is
+        repeating.
+
+        Four dispositions, all of which keep the sweep going:
+
+        * **re-enqueued** -- the zip is there and the analysis class is
+          configured on this host.
+        * **deleted** -- the loader ``target`` no longer exists. The entry can
+          never run again, so leaving it would alert on every restart forever;
+          it is removed and alerted once, naming the entry and the path.
+        * **left in place, unconfigured** -- the entry names an analysis class
+          this host does not serve. Another host in the group may own it (the
+          ``analyses`` list is per server), so deleting it here would destroy
+          another server's work. Logged, untouched.
+        * **left in place, unreadable** -- corrupt json, a missing field, or a
+          ``schema`` newer than this build's. Logged and skipped; a human decides.
+
+        Args:
+            analysis_classes: The endpoint-name-to-class mapping
+                :func:`make_analysis_app` built from ``params.analyses``.
+
+        Returns:
+            ``{"pending", "recovered", "dropped", "unconfigured", "failed"}``.
+        """
+        summary = {
+            "pending": 0,
+            "recovered": 0,
+            "dropped": 0,
+            "unconfigured": 0,
+            "failed": 0,
+        }
+        if not self.journal_dir:
+            LOGGER.info("Analysis journal is disabled; no recovery sweep to run.")
+            return summary
+
+        by_name = {cls.__name__: cls for cls in (analysis_classes or {}).values()}
+        names = list_journal_entries(self.journal_dir)
+        summary["pending"] = len(names)
+        if not names:
+            LOGGER.info("Analysis journal is empty; nothing to recover.")
+            return summary
+
+        # One loader per distinct zip, matching the live path, where batch_calc
+        # shares a single LocalLoader across every process of one sequence.
+        # Building one is a full index of the archive, so this is not a
+        # micro-optimisation on a plate with dozens of processes.
+        loaders: dict = {}
+        for name in names:
+            path = journal_entry_path(self.journal_dir, name)
+            entry = read_journal_entry(path)
+            if entry is None:
+                summary["failed"] += 1
+                continue
+            try:
+                schema = int(entry.get("schema", ANA_JOURNAL_SCHEMA))
+            except (TypeError, ValueError):
+                schema = ANA_JOURNAL_SCHEMA
+            if schema > ANA_JOURNAL_SCHEMA:
+                LOGGER.warning(
+                    f"Analysis journal entry {name} carries schema {schema}, newer "
+                    f"than this build's {ANA_JOURNAL_SCHEMA}; leaving it alone "
+                    "rather than guessing at its meaning."
+                )
+                summary["failed"] += 1
+                continue
+
+            target = str(entry.get("target") or "")
+            class_name = str(entry.get("analysis_class") or "")
+            if not target or not class_name or not entry.get("process_uuid"):
+                LOGGER.warning(
+                    f"Analysis journal entry {name} is missing target, "
+                    "analysis_class or process_uuid; leaving it alone."
+                )
+                summary["failed"] += 1
+                continue
+
+            ana_cls = by_name.get(class_name)
+            if ana_cls is None:
+                LOGGER.info(
+                    f"Analysis journal entry {name} names '{class_name}', which is "
+                    "not in this server's params.analyses; leaving it for whichever "
+                    "host serves that analysis."
+                )
+                summary["unconfigured"] += 1
+                continue
+
+            if not os.path.exists(target):
+                _alert(
+                    f"Analysis journal entry {name} cannot be recovered: its data "
+                    f"path {target} no longer exists. The analysis requested for "
+                    f"process {entry.get('process_uuid')} will never run; removing "
+                    "the entry."
+                )
+                remove_journal_entry(path)
+                summary["dropped"] += 1
+                continue
+
+            try:
+                process_uuid = UUID(str(entry["process_uuid"]))
+                action_uuid_raw = entry.get("analysis_action_uuid")
+                action_uuid = (
+                    None if not action_uuid_raw else UUID(str(action_uuid_raw))
+                )
+                params = entry.get("params")
+                if not isinstance(params, dict):
+                    params = {}
+                if target not in loaders:
+                    # Indexing a zip is blocking, so it does not belong on the
+                    # server's event loop -- this sweep runs while the server is
+                    # already answering requests.
+                    loaders[target] = await asyncio.to_thread(LocalLoader, target)
+            except Exception:
+                _alert(
+                    f"Could not rebuild the analysis in journal entry {name} from "
+                    f"{target}; leaving the entry in place.",
+                    exc_info=True,
+                )
+                summary["failed"] += 1
+                continue
+
+            await self.enqueue_calc(
+                (process_uuid, loaders[target], params, ana_cls, action_uuid)
+            )
+            summary["recovered"] += 1
+
+        message = (
+            f"Analysis journal recovery: {summary['pending']} entr(ies) on disk, "
+            f"{summary['recovered']} re-enqueued, {summary['dropped']} dropped as "
+            f"unrunnable, {summary['unconfigured']} for another host, "
+            f"{summary['failed']} unreadable."
+        )
+        if summary["recovered"]:
+            # An alert, because the restart that lost these was itself silent:
+            # each recovered analysis had already been reported as done by the
+            # action that requested it.
+            _alert(message)
+        else:
+            LOGGER.info(message)
+        return summary
 
     def has_pending_work(self) -> bool:
         """True while any analysis is queued for or actively running.
@@ -376,6 +883,23 @@ class AnalysisSyncer(HelaoSyncer):
     def sync_exit_callback(self, task: asyncio.Task):
         """Drop the completed ``task`` from ``running_tasks`` and ``task_set``.
 
+        **Not on this class's completion path, for two independent reasons.**
+        Nothing in the tree calls it -- :meth:`syncer` does its own ``finally``
+        cleanup instead, and clears the journal there by the exact key. And the
+        identifier it keys on could not match anyway: ``task.get_name()`` returns
+        the *asyncio task* name, which for the only tasks this class creates is
+        ``syncer_loop__<i>`` (set in :meth:`__init__`), while ``running_tasks`` is
+        keyed by **process uuid** -- ``syncer`` registers
+        ``asyncio.current_task()``, the long-lived worker loop, under the uuid of
+        whichever item it is handling. So the body below is inert here; it is the
+        inherited :class:`HelaoSyncer` seam, where tasks *are* named per uuid.
+
+        Kept, and taught to clear the journal, so that seam stays coherent if it
+        is ever wired: by process uuid, which is all a task name can offer, and
+        therefore a superset of one request (see
+        :meth:`journal_clear_by_process`). The precise clear lives in
+        :meth:`journal_clear`, which recomputes the key from the tuple itself.
+
         Args:
             task: The completed :class:`asyncio.Task` whose name is used as the
                 lookup key.
@@ -387,17 +911,24 @@ class AnalysisSyncer(HelaoSyncer):
                 self.task_set.remove(task_name)
             except KeyError:
                 pass
+            self.journal_clear_by_process(task_name)
 
     async def enqueue_calc(
         self,
         calc_tup: tuple[UUID, LocalLoader, dict, BaseAnalysis, Optional[UUID]],
     ):
-        """Push a single analysis tuple onto :attr:`task_queue`.
+        """Journal, then push, a single analysis tuple onto :attr:`task_queue`.
+
+        The journal write comes first and deliberately so: the queue is in-memory
+        and the requesting action returns as soon as this returns, so between the
+        write and the ``put`` a crash loses nothing, while in the other order it
+        loses the whole request. See :meth:`journal_write`.
 
         Args:
             calc_tup: ``(process_uuid, data_loader, ana_params, analysis_class,
                 analysis_action_uuid)`` describing one analysis to run.
         """
+        self.journal_write(calc_tup)
         self.task_set.add(calc_tup[0])
         await self.task_queue.put(calc_tup)
         LOGGER.info(f"Added {str(calc_tup[0])} to syncer queue.")
@@ -418,18 +949,35 @@ class AnalysisSyncer(HelaoSyncer):
                 LOGGER.debug(
                     f"{proc_uuid_str} ana sync is already in progress, skipping."
                 )
+                # The journal entry stays: this item's analysis genuinely did not
+                # run, so the next startup sweep should offer it again.
                 self.task_queue.task_done()
                 continue
             self.running_tasks[proc_uuid_str] = asyncio.current_task()
+            cancelled = False
             try:
                 await self.sync_ana(calc_tup)
+            except asyncio.CancelledError:
+                # A cancellation is an interruption, not an outcome: this is what
+                # a graceful shutdown does to an analysis that is still running,
+                # and its journal entry must survive so the next start re-enqueues
+                # it. Without this flag the ``finally`` below would clear the
+                # entry of the one analysis that certainly did NOT finish -- the
+                # in-flight one -- while every queued sibling was preserved.
+                # Re-raised so the worker loop still stops on cancellation.
+                cancelled = True
+                raise
             except Exception:
-                LOGGER.alert(
-                    f"Error in ana syncer worker for {proc_uuid_str}", exc_info=True
-                )
+                _alert(f"Error in ana syncer worker for {proc_uuid_str}", exc_info=True)
             finally:
                 self.running_tasks.pop(proc_uuid_str, None)
                 self.task_set.discard(calc_tup[0])
+                if not cancelled:
+                    # This worker is done with the item, success or failure, so
+                    # its durable record goes with it -- keyed off the tuple,
+                    # which is the only place the loader target and analysis
+                    # class are still known.
+                    self.journal_clear(calc_tup)
                 self.task_queue.task_done()
 
     def _calc_and_write_model(
@@ -581,8 +1129,27 @@ class AnalysisSyncer(HelaoSyncer):
             )
 
     def shutdown(self):
-        """Hook for graceful shutdown (no-op)."""
-        pass
+        """Report what a graceful stop is leaving behind for the next startup.
+
+        Nothing is drained or awaited here: an analysis takes seconds to minutes
+        and a shutdown hook is not the place to wait for one. The queue is
+        discarded, as it always was -- what changed is that it is no longer
+        discarded *silently*, because every queued item has a journal entry and
+        :meth:`recover_journal` re-enqueues it on the next launch.
+        """
+        pending = self.journal_pending_keys()
+        if pending:
+            LOGGER.warning(
+                f"Shutting down with {len(pending)} analysis request(s) still "
+                f"journalled in {self.journal_dir}; they will be re-enqueued at "
+                "the next startup."
+            )
+        elif self.task_set or self.running_tasks:
+            LOGGER.warning(
+                f"Shutting down with {len(self.task_set)} queued and "
+                f"{len(self.running_tasks)} running analysis task(s) and no journal "
+                "entries for them; these will be lost."
+            )
 
 
 class AnalysisExecutor(Executor):
@@ -637,7 +1204,8 @@ def make_analysis_app(server_key) -> BaseAPI:
     Constructs a :class:`BaseAPI` backed by :class:`AnalysisSyncer` and registers
     one ``analyze_<module>`` action endpoint per analysis class named in the
     server config ``params.analyses`` list, plus the private ``list_running_tasks``
-    and ``list_queued_tasks`` endpoints.
+    and ``list_queued_tasks`` endpoints, and arms the startup sweep that
+    re-enqueues whatever the request journal still holds.
 
     The analysis classes are resolved from the global ``CONFIG`` at app-build
     time (the driver instance is not created until the FastAPI ``startup``
@@ -705,9 +1273,27 @@ def make_analysis_app(server_key) -> BaseAPI:
         return list(app.driver.running_tasks.keys())
 
     @app.post("/list_queued_tasks", tags=["private"])
-    def list_queued_tasks() -> list:
-        """Return identifiers of analysis tasks queued but not yet running."""
-        return list(app.driver.task_set)
+    def list_queued_tasks() -> dict:
+        """Return the queued analyses, in memory and on disk.
+
+        The in-memory queue is under ``queued``, which is exactly what this
+        endpoint used to return as its whole body. The shape widened to an object
+        so the durable request journal is visible through the *existing* route
+        rather than a new one: ``journal_pending``/``journal_keys`` are what a
+        restart would re-enqueue, and their divergence from ``queued`` is how a
+        journal write failure or a disabled journal shows up from outside the
+        process. Nothing in the tree read the old body (checked: the only
+        occurrences of ``list_queued_tasks`` anywhere are its own definition and
+        priv's frozen route checklist, which pins the path and method, not the
+        response schema).
+        """
+        return {
+            "queued": [str(x) for x in app.driver.task_set],
+            "running": list(app.driver.running_tasks.keys()),
+            "journal_dir": app.driver.journal_dir,
+            "journal_keys": app.driver.journal_pending_keys(),
+            "journal_pending": len(app.driver.journal_pending_keys()),
+        }
 
     # Hot-reload safety: defer restart while an analysis is queued or running.
     # Both ``app.base`` and ``app.driver`` are created in BaseAPI's own startup
@@ -717,6 +1303,41 @@ def make_analysis_app(server_key) -> BaseAPI:
     def _wire_hotreload_busy():
         app.base.hotreload_busy_hook = lambda: (
             app.driver is not None and app.driver.has_pending_work()
+        )
+
+    @app.on_event("startup")
+    def _recover_journalled_analyses():
+        """Re-enqueue whatever a previous process left in the request journal.
+
+        Registered after BaseAPI's startup handler, so ``app.driver`` exists by
+        the time this runs. It launches a task rather than awaiting the sweep:
+        rebuilding a loader indexes a sequence zip, and holding up startup for
+        that would delay the port bind and every route with it.
+
+        Armed by default -- an unswept journal is the silent loss the journal
+        exists to end -- and suppressible per server with
+        ``params.analysis_recovery_on_startup: false``, matching the batch
+        server's ``recovery_on_startup`` knob. Suppressing it stops only this
+        pass; the entries stay on disk and stay visible through
+        ``/list_queued_tasks``, so a backlog can be inspected before anything
+        acts on it.
+        """
+        if app.driver is None:
+            LOGGER.warning(
+                "No analysis driver at startup; the request journal was not swept."
+            )
+            return
+        if not app.driver.config_dict.get("analysis_recovery_on_startup", True):
+            pending = len(app.driver.journal_pending_keys())
+            LOGGER.warning(
+                "analysis_recovery_on_startup is false, so the request journal was "
+                f"not swept; {pending} entr(ies) are waiting in "
+                f"{app.driver.journal_dir}."
+            )
+            return
+        app.driver.recovery_task = asyncio.create_task(
+            app.driver.recover_journal(analysis_classes),
+            name="ana_journal_recovery",
         )
 
     return app

--- a/helao/core/tests/test_analysis_recovery.py
+++ b/helao/core/tests/test_analysis_recovery.py
@@ -1,0 +1,1046 @@
+"""The ANA server's queued analyses survive the process that queued them.
+
+``AnalysisSyncer.task_queue`` is an in-memory ``asyncio.Queue`` of tuples
+holding a live ``LocalLoader``, and the action that requests an analysis returns
+as soon as it has enqueued -- so a restart used to drop every queued analysis
+while the action's own record read *done*, leaving no file and no log line
+anywhere. These tests pin the durable request journal that closes that hole, and
+in particular the parts of it where a plausible-looking implementation is silently
+wrong:
+
+* the entry must exist **before** the item reaches the queue (the other order
+  loses exactly the crash window the journal is for), so one test intercepts
+  ``task_queue.put`` and asserts from inside it;
+* clearing must be keyed by the *journal key*, not by the task name -- the key
+  carries the loader target and analysis class as well as the process uuid;
+* the sweep must survive its own bad inputs: a corrupt entry, a vanished zip and
+  an analysis this host does not serve each have a different disposition, and
+  none of them may stop the other entries from recovering.
+
+Everything here is hermetic: ``tmp_path`` only, no share, no network, no real
+analysis, and no ``Base``. The syncer is built through ``object.__new__`` with
+only the attributes under test set (the same seam priv's
+``test_processing_recovery.py`` uses for ``BatchConverter``), because
+``AnalysisSyncer.__init__`` builds an S3 loader and starts worker coroutines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Any, cast
+from uuid import UUID
+
+import pytest
+
+from helao.core.drivers.data import analysis_driver as m
+
+PROC_A = UUID("11111111-1111-1111-1111-111111111111")
+PROC_B = UUID("22222222-2222-2222-2222-222222222222")
+ACTION_UUID = UUID("33333333-3333-3333-3333-333333333333")
+
+
+class _StubLogger:
+    """Logger stand-in recording what the code under test emitted.
+
+    ``alert`` is a ``helao_logging`` addition attached to logger *instances*, so
+    a stub has to carry it explicitly; the recovery sweep's alerts are the
+    mechanism by which a lost analysis stops being invisible, and a stub without
+    ``alert`` would turn each of them into an ``AttributeError`` and hide the
+    thing being tested.
+    """
+
+    def __init__(self):
+        self.alerts = []
+        self.errors = []
+        self.warnings = []
+        self.infos = []
+
+    def info(self, msg="", *a, **k):
+        self.infos.append(str(msg))
+
+    def debug(self, *a, **k):
+        pass
+
+    def warning(self, msg="", *a, **k):
+        self.warnings.append(str(msg))
+
+    def error(self, msg="", *a, **k):
+        self.errors.append(str(msg))
+
+    def alert(self, msg="", *a, **k):
+        self.alerts.append(str(msg))
+
+
+class _FakeLoader:
+    """``LocalLoader`` stand-in: the one attribute the journal reads.
+
+    ``LocalLoader.__init__`` stores the absolute data path on ``self.target``,
+    which is the only piece of a loader a journal entry records and the only
+    piece needed to rebuild one.
+    """
+
+    def __init__(self, data_path: str):
+        self.target = os.path.abspath(data_path)
+
+
+class _AnaA:
+    """Analysis class stand-in. Only its ``__name__`` reaches the journal."""
+
+
+class _AnaB:
+    pass
+
+
+@pytest.fixture
+def logger(monkeypatch):
+    """Replace the module logger for the duration of one test."""
+    stub = _StubLogger()
+    monkeypatch.setattr(m, "LOGGER", stub)
+    return stub
+
+
+def _syncer(journal_dir, logger=None) -> m.AnalysisSyncer:
+    """Build a syncer with only the attributes the journal paths touch.
+
+    ``object.__new__`` rather than ``__init__``: the real constructor installs a
+    shared S3 loader (reading credentials) and creates ``max_tasks`` worker
+    tasks, none of which any journal behaviour depends on.
+    """
+    syncer = object.__new__(m.AnalysisSyncer)
+    syncer.journal_dir = str(journal_dir) if journal_dir else None
+    syncer.task_queue = asyncio.Queue()
+    syncer.task_set = set()
+    syncer.running_tasks = {}
+    syncer.config_dict = {}
+    return syncer
+
+
+def _tup(zip_path, process_uuid=PROC_A, ana_cls: type = _AnaA, params=None) -> tuple:
+    """One calc tuple in the shape ``enqueue_calc`` accepts.
+
+    Returned as a bare ``tuple`` because the real annotation names
+    ``LocalLoader`` and ``BaseAnalysis``, neither of which a stand-in satisfies;
+    spelling the stub types out would make every call site a type error.
+    """
+    return (
+        process_uuid,
+        _FakeLoader(str(zip_path)),
+        {"foo": 1} if params is None else params,
+        ana_cls,
+        ACTION_UUID,
+    )
+
+
+def _zip(tmp_path, name="seq.zip"):
+    """A stand-in data path. The sweep only asks whether it exists."""
+    path = tmp_path / name
+    path.write_bytes(b"not really a zip")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Key derivation
+# ---------------------------------------------------------------------------
+
+
+def test_journal_key_is_deterministic_and_identifies_the_request():
+    """Same request in, same file name out -- which is what makes re-journalling
+    an overwrite -- and each of the three identity components changes it."""
+    key = m.analysis_journal_key("/data/seq.zip", PROC_A, "AnaA")
+    assert key == m.analysis_journal_key("/data/seq.zip", PROC_A, "AnaA")
+    assert key.startswith(f"{PROC_A}__AnaA__")
+    assert key.endswith(m.ANA_JOURNAL_SUFFIX)
+    assert key != m.analysis_journal_key("/data/other.zip", PROC_A, "AnaA")
+    assert key != m.analysis_journal_key("/data/seq.zip", PROC_B, "AnaA")
+    assert key != m.analysis_journal_key("/data/seq.zip", PROC_A, "AnaB")
+
+
+def test_journal_key_is_a_usable_file_name():
+    """The target is folded into a digest precisely because it is a path; a key
+    carrying a separator would silently write outside the journal dir."""
+    key = m.analysis_journal_key(
+        "/mnt/some/deep/path with spaces/seq.zip", PROC_A, "AnaA"
+    )
+    assert os.sep not in key and "/" not in key
+
+
+# ---------------------------------------------------------------------------
+# Journalling on enqueue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enqueue_writes_exactly_one_entry_with_the_rebuild_fields(
+    tmp_path, logger
+):
+    """One queued analysis, one entry, carrying everything a rebuild needs."""
+    journal = tmp_path / "ana_pending"
+    syncer = _syncer(journal)
+    zip_path = _zip(tmp_path)
+
+    await syncer.enqueue_calc(_tup(zip_path))
+
+    entries = m.list_journal_entries(str(journal))
+    assert len(entries) == 1
+    payload = json.loads((journal / entries[0]).read_text())
+    assert payload["target"] == str(zip_path)
+    assert payload["process_uuid"] == str(PROC_A)
+    assert payload["analysis_class"] == "_AnaA"
+    assert payload["params"] == {"foo": 1}
+    assert payload["analysis_action_uuid"] == str(ACTION_UUID)
+    assert payload["schema"] == m.ANA_JOURNAL_SCHEMA
+    assert payload["queued_at"] > 0
+    # The queue still got the item; journalling is additive.
+    assert syncer.task_queue.qsize() == 1
+    assert syncer.task_set == {PROC_A}
+
+
+@pytest.mark.asyncio
+async def test_entry_is_on_disk_before_the_queue_receives_the_item(tmp_path, logger):
+    """The ordering, asserted from inside ``put``.
+
+    A crash in the window between the two must leave a recoverable record. With
+    the write second, that window loses the request entirely -- and no test that
+    only inspects the end state can tell the two orders apart.
+    """
+    journal = tmp_path / "ana_pending"
+    syncer = _syncer(journal)
+    zip_path = _zip(tmp_path)
+    seen = {}
+
+    real_put = syncer.task_queue.put
+
+    async def _spy_put(item):
+        seen["entries_at_put"] = m.list_journal_entries(str(journal))
+        await real_put(item)
+
+    syncer.task_queue.put = _spy_put  # type: ignore[method-assign]
+    await syncer.enqueue_calc(_tup(zip_path))
+
+    assert len(seen["entries_at_put"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_same_request_journalled_twice_is_one_file(tmp_path, logger):
+    """Re-enqueueing the same request overwrites its entry.
+
+    This is the recovery path's own behaviour -- it re-enqueues, which
+    re-journals -- so an accumulating key would grow the journal by one file per
+    restart forever.
+    """
+    journal = tmp_path / "ana_pending"
+    syncer = _syncer(journal)
+    zip_path = _zip(tmp_path)
+
+    await syncer.enqueue_calc(_tup(zip_path))
+    await syncer.enqueue_calc(_tup(zip_path))
+
+    assert len(m.list_journal_entries(str(journal))) == 1
+
+
+@pytest.mark.asyncio
+async def test_two_different_requests_are_two_entries(tmp_path, logger):
+    """Deduplication is per request, not per process uuid: the same process
+    analysed by two different classes is two pieces of work."""
+    journal = tmp_path / "ana_pending"
+    syncer = _syncer(journal)
+    zip_path = _zip(tmp_path)
+
+    await syncer.enqueue_calc(_tup(zip_path, ana_cls=_AnaA))
+    await syncer.enqueue_calc(_tup(zip_path, ana_cls=_AnaB))
+    await syncer.enqueue_calc(_tup(zip_path, process_uuid=PROC_B))
+
+    assert len(m.list_journal_entries(str(journal))) == 3
+
+
+# ---------------------------------------------------------------------------
+# Clearing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completion_removes_the_entry(tmp_path, logger):
+    """The real completion path: ``syncer``'s ``finally``, driven end to end
+    with a stubbed ``sync_ana`` so no analysis runs."""
+    journal = tmp_path / "ana_pending"
+    syncer = _syncer(journal)
+    zip_path = _zip(tmp_path)
+    calls = []
+
+    async def _fake_sync_ana(calc_tup, retries=3):
+        calls.append(calc_tup[0])
+        return True
+
+    syncer.sync_ana = _fake_sync_ana  # type: ignore[method-assign]
+    await syncer.enqueue_calc(_tup(zip_path))
+    assert len(m.list_journal_entries(str(journal))) == 1
+
+    worker = asyncio.create_task(syncer.syncer())
+    await asyncio.wait_for(syncer.task_queue.join(), timeout=5)
+    worker.cancel()
+
+    assert calls == [PROC_A]
+    assert m.list_journal_entries(str(journal)) == []
+    assert syncer.task_set == set()
+
+
+@pytest.mark.asyncio
+async def test_a_failing_analysis_also_clears_its_entry(tmp_path, logger):
+    """Completion, not success, is what clears an entry.
+
+    Keeping a failed analysis journalled would re-run a permanently-failing
+    analysis at every restart forever. The failure is already alerted by the
+    worker, which this asserts so the entry's removal is not the only trace.
+    """
+    journal = tmp_path / "ana_pending"
+    syncer = _syncer(journal)
+    zip_path = _zip(tmp_path)
+
+    async def _boom(calc_tup, retries=3):
+        raise RuntimeError("analysis exploded")
+
+    syncer.sync_ana = _boom  # type: ignore[method-assign]
+    await syncer.enqueue_calc(_tup(zip_path))
+
+    worker = asyncio.create_task(syncer.syncer())
+    await asyncio.wait_for(syncer.task_queue.join(), timeout=5)
+    worker.cancel()
+
+    assert m.list_journal_entries(str(journal)) == []
+    assert any("ana syncer worker" in a for a in logger.alerts)
+
+
+@pytest.mark.asyncio
+async def test_the_key_written_is_the_key_cleared(tmp_path, logger):
+    """The write key and the clear key are the same string.
+
+    If they diverged, entries would accumulate forever and every restart would
+    re-enqueue analyses that had already completed -- a failure that looks like
+    success from every other angle, since the analysis itself runs fine. Pinned
+    three ways: the file the enqueue actually created is named by
+    ``_journal_key``, that key round-trips through ``journal_entry_path``, and
+    clearing with the same tuple empties the journal.
+    """
+    journal = tmp_path / "ana_pending"
+    syncer = _syncer(journal)
+    tup = _tup(_zip(tmp_path))
+
+    await syncer.enqueue_calc(tup)
+    written = m.list_journal_entries(str(journal))
+    key = syncer._journal_key(tup)
+
+    assert written == [key]
+    assert os.path.isfile(m.journal_entry_path(str(journal), str(key)))
+    syncer.journal_clear(tup)
+    assert m.list_journal_entries(str(journal)) == []
+
+
+@pytest.mark.asyncio
+async def test_sync_exit_callback_keys_on_the_task_name_not_the_journal_key(
+    tmp_path, logger
+):
+    """What the done-callback seam actually receives, pinned both ways.
+
+    ``task.get_name()`` is an *asyncio task* name. For the only tasks this class
+    creates it is ``syncer_loop__<i>``, which is not in ``running_tasks`` (keyed
+    by process uuid), so the callback is inert on the live path -- the real clear
+    is :meth:`journal_clear` from ``syncer``'s ``finally``. Handed a task named
+    for a process uuid, as :class:`HelaoSyncer` names them, it does clear.
+    """
+    journal = tmp_path / "ana_pending"
+    syncer = _syncer(journal)
+    tup = _tup(_zip(tmp_path))
+    await syncer.enqueue_calc(tup)
+
+    async def _noop():
+        return None
+
+    # The live shape: a worker-loop task name, with running_tasks keyed by uuid.
+    loop_task = asyncio.create_task(_noop(), name="syncer_loop__0")
+    await loop_task
+    syncer.running_tasks = {str(PROC_A): loop_task}
+    syncer.sync_exit_callback(loop_task)
+    assert m.list_journal_entries(str(journal)) == [syncer._journal_key(tup)]
+    assert syncer.running_tasks == {str(PROC_A): loop_task}
+
+    # The inherited shape: a task named for the process uuid.
+    uuid_task = asyncio.create_task(_noop(), name=str(PROC_A))
+    await uuid_task
+    syncer.running_tasks = {str(PROC_A): uuid_task}
+    syncer.task_set = {str(PROC_A)}
+    syncer.sync_exit_callback(uuid_task)
+    assert m.list_journal_entries(str(journal)) == []
+    assert syncer.running_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_clearing_one_request_leaves_the_other_entries_alone(tmp_path, logger):
+    """Keyed by the journal key, not the task name.
+
+    Two requests sharing a process uuid differ only in their analysis class, so
+    an implementation that cleared by task name (the process uuid, all a
+    done-callback ever sees) would delete work that never ran.
+    """
+    journal = tmp_path / "ana_pending"
+    syncer = _syncer(journal)
+    zip_path = _zip(tmp_path)
+    tup_a = _tup(zip_path, ana_cls=_AnaA)
+    tup_b = _tup(zip_path, ana_cls=_AnaB)
+
+    await syncer.enqueue_calc(tup_a)
+    await syncer.enqueue_calc(tup_b)
+    syncer.journal_clear(tup_a)
+
+    remaining = m.list_journal_entries(str(journal))
+    assert remaining == [m.analysis_journal_key(str(zip_path), PROC_A, "_AnaB")]
+
+
+@pytest.mark.asyncio
+async def test_clear_by_process_removes_every_entry_for_that_uuid(tmp_path, logger):
+    """The done-callback seam's best-effort route, pinned as the superset it is."""
+    journal = tmp_path / "ana_pending"
+    syncer = _syncer(journal)
+    zip_path = _zip(tmp_path)
+
+    await syncer.enqueue_calc(_tup(zip_path, ana_cls=_AnaA))
+    await syncer.enqueue_calc(_tup(zip_path, ana_cls=_AnaB))
+    await syncer.enqueue_calc(_tup(zip_path, process_uuid=PROC_B))
+
+    syncer.journal_clear_by_process(str(PROC_A))
+
+    remaining = m.list_journal_entries(str(journal))
+    assert len(remaining) == 1
+    assert remaining[0].startswith(str(PROC_B))
+
+
+# ---------------------------------------------------------------------------
+# Degradation: journalling off, or failing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_journalling_disabled_still_enqueues(tmp_path, logger):
+    """No ``STATES`` root means no journal and no behaviour change otherwise."""
+    syncer = _syncer(None)
+    await syncer.enqueue_calc(_tup(_zip(tmp_path)))
+
+    assert syncer.task_queue.qsize() == 1
+    assert syncer.task_set == {PROC_A}
+    assert syncer.journal_pending_keys() == []
+
+
+def test_no_states_root_disables_journalling_with_one_warning(logger):
+    """Both shapes of "no STATES root": an all-``None`` ``HelaoDirs`` (a config
+    without ``root``) and an object carrying no ``helaodirs`` at all."""
+
+    class _Dirs:
+        states_root = None
+
+    class _ServWithDirs:
+        helaodirs = _Dirs()
+
+    class _ServWithout:
+        pass
+
+    assert m.AnalysisSyncer._resolve_journal_dir(cast(Any, _ServWithDirs())) is None
+    assert m.AnalysisSyncer._resolve_journal_dir(cast(Any, _ServWithout())) is None
+    assert len(logger.warnings) == 2
+
+
+def test_states_root_resolves_to_the_subdir_and_creates_it(tmp_path, logger):
+    """The journal lands under the server's own ``STATES``, and is created."""
+
+    class _Dirs:
+        states_root = str(tmp_path / "STATES")
+
+    class _Serv:
+        helaodirs = _Dirs()
+
+    os.makedirs(_Dirs.states_root)
+    resolved = m.AnalysisSyncer._resolve_journal_dir(cast(Any, _Serv()))
+    assert resolved == os.path.join(_Dirs.states_root, m.ANA_JOURNAL_SUBDIR)
+    assert resolved is not None and os.path.isdir(resolved)
+
+
+@pytest.mark.asyncio
+async def test_an_unwritable_journal_dir_does_not_break_enqueue(tmp_path, logger):
+    """Bookkeeping may not break the real work.
+
+    A journal that cannot be written costs the *recovery* guarantee, not the
+    analysis -- so the failure is logged and the item is queued anyway. Driven by
+    a real unwritable location (a plain file where the journal directory should
+    be, which is what an operator pointing ``root`` at the wrong path produces)
+    rather than by patching the writer, so the swallow being tested is the one in
+    :func:`write_journal_entry` itself.
+    """
+    blocker = tmp_path / "ana_pending"
+    blocker.write_text("not a directory")
+    syncer = _syncer(blocker)
+
+    await syncer.enqueue_calc(_tup(_zip(tmp_path)))
+
+    assert syncer.task_queue.qsize() == 1
+    assert syncer.task_set == {PROC_A}
+    assert logger.errors, "a failed journal write must be logged"
+
+
+@pytest.mark.asyncio
+async def test_a_raising_journal_writer_does_not_break_enqueue(
+    tmp_path, logger, monkeypatch
+):
+    """The same guarantee one layer up: even an exception escaping the writer
+    entirely is caught by :meth:`AnalysisSyncer.journal_write`."""
+    syncer = _syncer(tmp_path / "ana_pending")
+
+    def _explode(*a, **k):
+        raise RuntimeError("journal subsystem is broken")
+
+    monkeypatch.setattr(m, "write_journal_entry", _explode)
+    await syncer.enqueue_calc(_tup(_zip(tmp_path)))
+
+    assert syncer.task_queue.qsize() == 1
+    assert logger.errors
+
+
+@pytest.mark.asyncio
+async def test_a_loader_without_a_target_is_queued_but_not_journalled(tmp_path, logger):
+    """A loader kind with no ``target`` cannot be rebuilt, so it is not recorded
+    -- but it must still run, with the un-recoverability logged."""
+    syncer = _syncer(tmp_path / "ana_pending")
+
+    class _NoTarget:
+        pass
+
+    await syncer.enqueue_calc(cast(Any, (PROC_A, _NoTarget(), {}, _AnaA, None)))
+
+    assert syncer.task_queue.qsize() == 1
+    assert m.list_journal_entries(syncer.journal_dir) == []
+    assert any("no loader target" in w for w in logger.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Startup sweep
+# ---------------------------------------------------------------------------
+
+
+def _classes(*pairs) -> dict:
+    """``analysis_classes`` mapping, as ``make_analysis_app`` builds it."""
+    return {f"analyze_{i}": cls for i, cls in enumerate(pairs)}
+
+
+@pytest.mark.asyncio
+async def test_startup_reenqueues_a_journalled_entry(tmp_path, logger, monkeypatch):
+    """The whole point: an entry written by one process is re-enqueued by the
+    next, with its loader rebuilt from the recorded target."""
+    journal = tmp_path / "ana_pending"
+    zip_path = _zip(tmp_path)
+    writer = _syncer(journal)
+    await writer.enqueue_calc(_tup(zip_path))
+
+    monkeypatch.setattr(m, "LocalLoader", _FakeLoader)
+    syncer = _syncer(journal)
+    summary = await syncer.recover_journal(_classes(_AnaA))
+
+    assert summary == {
+        "pending": 1,
+        "recovered": 1,
+        "dropped": 0,
+        "unconfigured": 0,
+        "failed": 0,
+    }
+    assert syncer.task_queue.qsize() == 1
+    process_uuid, loader, params, ana_cls, action_uuid = syncer.task_queue.get_nowait()
+    assert process_uuid == PROC_A
+    assert loader.target == str(zip_path)
+    assert params == {"foo": 1}
+    assert ana_cls is _AnaA
+    assert action_uuid == ACTION_UUID
+    # The entry is still on disk: only a worker finishing with it clears it, so
+    # a crash during the recovered run is itself recoverable.
+    assert len(m.list_journal_entries(str(journal))) == 1
+    # A silent restart is the failure mode; recovery must be loud.
+    assert any("re-enqueued" in a for a in logger.alerts)
+
+
+@pytest.mark.asyncio
+async def test_recovery_shares_one_loader_per_zip(tmp_path, logger, monkeypatch):
+    """Two processes of one sequence rebuild one loader between them, matching
+    ``batch_calc``, where indexing the archive happens once."""
+    journal = tmp_path / "ana_pending"
+    zip_path = _zip(tmp_path)
+    writer = _syncer(journal)
+    await writer.enqueue_calc(_tup(zip_path, process_uuid=PROC_A))
+    await writer.enqueue_calc(_tup(zip_path, process_uuid=PROC_B))
+
+    built = []
+
+    class _CountingLoader(_FakeLoader):
+        def __init__(self, data_path):
+            super().__init__(data_path)
+            built.append(data_path)
+
+    monkeypatch.setattr(m, "LocalLoader", _CountingLoader)
+    syncer = _syncer(journal)
+    summary = await syncer.recover_journal(_classes(_AnaA))
+
+    assert summary["recovered"] == 2
+    assert len(built) == 1
+    first = syncer.task_queue.get_nowait()
+    second = syncer.task_queue.get_nowait()
+    assert first[1] is second[1]
+
+
+@pytest.mark.asyncio
+async def test_an_entry_whose_data_is_gone_is_deleted_and_alerted(
+    tmp_path, logger, monkeypatch
+):
+    """A vanished zip can never run again, so retrying it every restart forever
+    would be noise; it is dropped once, loudly, naming the path."""
+    journal = tmp_path / "ana_pending"
+    zip_path = _zip(tmp_path)
+    writer = _syncer(journal)
+    await writer.enqueue_calc(_tup(zip_path))
+    os.remove(zip_path)
+
+    monkeypatch.setattr(m, "LocalLoader", _FakeLoader)
+    syncer = _syncer(journal)
+    summary = await syncer.recover_journal(_classes(_AnaA))
+
+    assert summary["dropped"] == 1 and summary["recovered"] == 0
+    assert m.list_journal_entries(str(journal)) == []
+    assert syncer.task_queue.qsize() == 0
+    assert any(str(zip_path) in a for a in logger.alerts)
+
+
+@pytest.mark.asyncio
+async def test_an_unconfigured_analysis_class_is_left_in_place(
+    tmp_path, logger, monkeypatch
+):
+    """``params.analyses`` is per server, so an entry naming a class this host
+    does not serve may belong to another host; deleting it here would destroy
+    that host's work."""
+    journal = tmp_path / "ana_pending"
+    writer = _syncer(journal)
+    await writer.enqueue_calc(_tup(_zip(tmp_path), ana_cls=_AnaB))
+
+    monkeypatch.setattr(m, "LocalLoader", _FakeLoader)
+    syncer = _syncer(journal)
+    summary = await syncer.recover_journal(_classes(_AnaA))
+
+    assert summary["unconfigured"] == 1 and summary["recovered"] == 0
+    assert len(m.list_journal_entries(str(journal))) == 1
+    assert syncer.task_queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+async def test_a_corrupt_entry_does_not_abort_the_sweep(tmp_path, logger, monkeypatch):
+    """One bad json file must not strand every other queued analysis.
+
+    Three unusable shapes at once -- unparseable, a json array rather than an
+    object, and an object missing ``target`` -- alongside one good entry, which
+    must still recover.
+    """
+    journal = tmp_path / "ana_pending"
+    zip_path = _zip(tmp_path)
+    writer = _syncer(journal)
+    await writer.enqueue_calc(_tup(zip_path))
+
+    (journal / f"aaa{m.ANA_JOURNAL_SUFFIX}").write_text("{not json at all")
+    (journal / f"bbb{m.ANA_JOURNAL_SUFFIX}").write_text("[1, 2, 3]")
+    (journal / f"ccc{m.ANA_JOURNAL_SUFFIX}").write_text(
+        json.dumps({"process_uuid": str(PROC_B), "analysis_class": "_AnaA"})
+    )
+
+    monkeypatch.setattr(m, "LocalLoader", _FakeLoader)
+    syncer = _syncer(journal)
+    summary = await syncer.recover_journal(_classes(_AnaA))
+
+    assert summary["pending"] == 4
+    assert summary["recovered"] == 1
+    assert summary["failed"] == 3
+    assert syncer.task_queue.qsize() == 1
+    # Unusable entries are left for a human rather than deleted.
+    assert len(m.list_journal_entries(str(journal))) == 4
+
+
+@pytest.mark.asyncio
+async def test_a_newer_schema_is_refused_rather_than_guessed_at(
+    tmp_path, logger, monkeypatch
+):
+    """An entry from a future build is left alone: its fields may not mean what
+    this build would read them as."""
+    journal = tmp_path / "ana_pending"
+    journal.mkdir()
+    zip_path = _zip(tmp_path)
+    (journal / f"future{m.ANA_JOURNAL_SUFFIX}").write_text(
+        json.dumps(
+            {
+                "schema": m.ANA_JOURNAL_SCHEMA + 1,
+                "target": str(zip_path),
+                "process_uuid": str(PROC_A),
+                "analysis_class": "_AnaA",
+                "params": {},
+            }
+        )
+    )
+
+    monkeypatch.setattr(m, "LocalLoader", _FakeLoader)
+    syncer = _syncer(journal)
+    summary = await syncer.recover_journal(_classes(_AnaA))
+
+    assert summary["failed"] == 1 and summary["recovered"] == 0
+    assert len(m.list_journal_entries(str(journal))) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_loader_that_cannot_be_built_leaves_its_entry(
+    tmp_path, logger, monkeypatch
+):
+    """The zip is there but unreadable: an alert, and the entry stays, because
+    unlike a vanished path this may well succeed later."""
+    journal = tmp_path / "ana_pending"
+    writer = _syncer(journal)
+    await writer.enqueue_calc(_tup(_zip(tmp_path)))
+
+    def _bad_loader(path):
+        raise ValueError("not a zip file")
+
+    monkeypatch.setattr(m, "LocalLoader", _bad_loader)
+    syncer = _syncer(journal)
+    summary = await syncer.recover_journal(_classes(_AnaA))
+
+    assert summary["failed"] == 1 and summary["recovered"] == 0
+    assert len(m.list_journal_entries(str(journal))) == 1
+    assert logger.alerts
+
+
+@pytest.mark.asyncio
+async def test_an_empty_or_disabled_journal_recovers_nothing_quietly(tmp_path, logger):
+    """Neither an empty journal nor a disabled one may alert -- an alert on
+    every clean startup is how a real one gets ignored."""
+    empty = _syncer(tmp_path / "ana_pending")
+    assert (await empty.recover_journal(_classes(_AnaA)))["recovered"] == 0
+
+    off = _syncer(None)
+    assert (await off.recover_journal(_classes(_AnaA)))["pending"] == 0
+    assert logger.alerts == []
+
+
+@pytest.mark.asyncio
+async def test_tmp_files_from_an_interrupted_write_are_not_swept(
+    tmp_path, logger, monkeypatch
+):
+    """The atomic write's leftover is not an entry; parsing one would read a
+    half-written payload."""
+    journal = tmp_path / "ana_pending"
+    journal.mkdir()
+    (journal / f"half{m.ANA_JOURNAL_SUFFIX}.tmp").write_text('{"target": "/x"')
+
+    syncer = _syncer(journal)
+    summary = await syncer.recover_journal(_classes(_AnaA))
+
+    assert summary == {
+        "pending": 0,
+        "recovered": 0,
+        "dropped": 0,
+        "unconfigured": 0,
+        "failed": 0,
+    }
+    assert (journal / f"half{m.ANA_JOURNAL_SUFFIX}.tmp").exists()
+
+
+# ---------------------------------------------------------------------------
+# Round trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restart_round_trip_runs_the_lost_analysis(tmp_path, logger, monkeypatch):
+    """End to end, as a station experiences it: enqueue, lose the process before
+    any worker runs, start again, and the analysis actually executes."""
+    journal = tmp_path / "ana_pending"
+    zip_path = _zip(tmp_path)
+
+    first = _syncer(journal)
+    await first.enqueue_calc(_tup(zip_path))
+    # "Restart": the queue, the task set and the syncer itself simply cease to
+    # exist. Only the journal survives.
+    del first
+
+    monkeypatch.setattr(m, "LocalLoader", _FakeLoader)
+    second = _syncer(journal)
+    ran = []
+
+    async def _fake_sync_ana(calc_tup, retries=3):
+        ran.append((calc_tup[0], calc_tup[1].target, calc_tup[3]))
+        return True
+
+    second.sync_ana = _fake_sync_ana  # type: ignore[method-assign]
+    await second.recover_journal(_classes(_AnaA))
+    worker = asyncio.create_task(second.syncer())
+    await asyncio.wait_for(second.task_queue.join(), timeout=5)
+    worker.cancel()
+
+    assert ran == [(PROC_A, str(zip_path), _AnaA)]
+    assert m.list_journal_entries(str(journal)) == []
+
+
+@pytest.mark.asyncio
+async def test_a_replay_interrupted_partway_recovers_only_what_is_outstanding(
+    tmp_path, logger, monkeypatch
+):
+    """A replay that dies partway must lose nothing and repeat nothing.
+
+    Five entries are recovered and re-enqueued; two complete, the third is in
+    flight when the process goes down, and two are still queued. The sweep must
+    therefore not clear an entry merely because it enqueued it -- and the two
+    survivors of the third case matter separately:
+
+    * the **in-flight** analysis is cancelled by a graceful shutdown, so
+      ``syncer``'s ``finally`` runs for it. Its entry must survive anyway: it is
+      the one analysis that certainly did not finish.
+    * the two **completed** analyses must be gone, or the next start would run
+      them a second time.
+    """
+    journal = tmp_path / "ana_pending"
+    zip_path = _zip(tmp_path)
+    # Uuids that sort in a known order, since both the sweep (sorted file names,
+    # which start with the uuid) and the queue are FIFO -- so "the third one" is
+    # deterministic.
+    uuids = [UUID(f"0000000{n}-0000-0000-0000-000000000000") for n in range(1, 6)]
+
+    writer = _syncer(journal)
+    for uuid in uuids:
+        await writer.enqueue_calc(_tup(zip_path, process_uuid=uuid))
+    assert len(m.list_journal_entries(str(journal))) == 5
+    del writer
+
+    monkeypatch.setattr(m, "LocalLoader", _FakeLoader)
+    replay = _syncer(journal)
+    started = []
+    third_in_flight = asyncio.Event()
+
+    async def _fake_sync_ana(calc_tup, retries=3):
+        started.append(calc_tup[0])
+        if len(started) == 3:
+            third_in_flight.set()
+            # The process dies here: this await never returns.
+            await asyncio.Event().wait()
+        return True
+
+    replay.sync_ana = _fake_sync_ana  # type: ignore[method-assign]
+    summary = await replay.recover_journal(_classes(_AnaA))
+    assert summary["recovered"] == 5
+    # Enqueued is not completed: nothing may have been cleared yet.
+    assert len(m.list_journal_entries(str(journal))) == 5
+
+    worker = asyncio.create_task(replay.syncer())
+    await asyncio.wait_for(third_in_flight.wait(), timeout=5)
+    worker.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await worker
+
+    assert started == uuids[:3]
+    remaining = m.list_journal_entries(str(journal))
+    expected = [
+        m.analysis_journal_key(str(zip_path), uuid, "_AnaA") for uuid in uuids[2:]
+    ]
+    assert sorted(remaining) == sorted(expected), (remaining, expected)
+
+    # Next start: exactly the three outstanding analyses come back, and the two
+    # that completed do not.
+    survivor = _syncer(journal)
+    second_summary = await survivor.recover_journal(_classes(_AnaA))
+    assert second_summary["recovered"] == 3
+    assert [item[0] for item in survivor.task_queue._queue] == uuids[2:]  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_reports_what_it_is_leaving_behind(tmp_path, logger):
+    """A graceful stop still discards the queue -- but no longer silently."""
+    journal = tmp_path / "ana_pending"
+    syncer = _syncer(journal)
+    await syncer.enqueue_calc(_tup(_zip(tmp_path)))
+
+    syncer.shutdown()
+    assert any("re-enqueued at the next startup" in w for w in logger.warnings)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_warns_when_queued_work_is_not_journalled(tmp_path, logger):
+    """The journalling-disabled case is the one where work really is lost, and
+    it must say so rather than reusing the reassuring message."""
+    syncer = _syncer(None)
+    await syncer.enqueue_calc(_tup(_zip(tmp_path)))
+
+    syncer.shutdown()
+    assert any("will be lost" in w for w in logger.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Status endpoint / app wiring
+# ---------------------------------------------------------------------------
+
+
+def _app(tmp_path, monkeypatch):
+    """A constructed analysis app, with no startup event ever fired.
+
+    ``BaseAPI`` registers its routes at construction while the driver, its S3
+    loader and ``Base`` are only built from the startup event -- so this needs
+    neither network nor credentials. ``root``/``host``/``port`` are present only
+    because ``HelaoFastAPI.__init__`` reads them unconditionally (the same reason
+    priv's checklist test supplies them), and ``analyses`` is empty so no
+    deployment's analysis modules are imported.
+    """
+    from helao.helpers import config_loader
+
+    monkeypatch.setattr(
+        config_loader,
+        "CONFIG",
+        {
+            "deployment": "hte",
+            "root": str(tmp_path),
+            "servers": {
+                "ANA": {
+                    "host": "127.0.0.1",
+                    "port": 8014,
+                    "params": {"analyses": []},
+                }
+            },
+        },
+    )
+    return m.make_analysis_app("ANA")
+
+
+def _route_handler(app, path: str):
+    """The function registered for ``path``, called directly.
+
+    Direct rather than through a ``TestClient``, whose request would fire the
+    startup events and with them a real ``Base``, S3 loader and NTP sync.
+    """
+    for route in app.routes:
+        if getattr(route, "path", "") == path:
+            return route.endpoint  # type: ignore[attr-defined]
+    raise AssertionError(f"{path} is no longer registered")
+
+
+def test_list_queued_tasks_reports_both_the_queue_and_the_journal(
+    tmp_path, monkeypatch
+):
+    """The response body carries the in-memory queue under ``queued`` -- what the
+    whole body used to be -- and the journal beside it, so a journal write
+    failure or a disabled journal is visible from outside the process."""
+    journal = tmp_path / "ana_pending"
+    journal.mkdir()
+    key = m.analysis_journal_key("/data/seq.zip", PROC_A, "AnaA")
+    (journal / key).write_text("{}")
+
+    app = _app(tmp_path, monkeypatch)
+    syncer = _syncer(journal)
+    syncer.task_set = {PROC_B}
+    syncer.running_tasks = {str(PROC_A): object()}
+    app.driver = syncer
+
+    body = _route_handler(app, "/list_queued_tasks")()
+    assert body["queued"] == [str(PROC_B)]
+    assert body["running"] == [str(PROC_A)]
+    assert body["journal_pending"] == 1
+    assert body["journal_keys"] == [key]
+    assert body["journal_dir"] == str(journal)
+
+
+def test_no_route_was_added_renamed_or_removed(tmp_path, monkeypatch):
+    """priv's frozen endpoint checklist lives in another git repository, and a
+    new private route here would break that gate and force a cross-repo change.
+    The journal is therefore exposed through the existing body, not a new path."""
+    app = _app(tmp_path, monkeypatch)
+    # Everything this module contributes to an app with an empty ``analyses``
+    # list: exactly the two private routes priv's checklist froze. Compared as a
+    # set difference against ``BaseAPI``'s own surface so the assertion stays
+    # exact -- ``/list_executors`` and friends come from BaseAPI, not from here.
+    from helao.core.servers.base_api import BaseAPI
+
+    baseline = {
+        getattr(route, "path", "")
+        for route in BaseAPI(
+            server_key="ANA", server_title="ANA", description="", version=1.0
+        ).routes
+    }
+    contributed = {getattr(route, "path", "") for route in app.routes} - baseline
+    assert contributed == {"/list_queued_tasks", "/list_running_tasks"}
+
+
+def _startup_handler(app):
+    """The registered journal-sweep startup handler."""
+    handlers = [
+        h
+        for h in app.router.on_startup
+        if getattr(h, "__name__", "") == "_recover_journalled_analyses"
+    ]
+    assert len(handlers) == 1, "the journal sweep is not wired into startup"
+    return handlers[0]
+
+
+class _StubDriver:
+    """Driver stand-in exposing only what the startup handler touches."""
+
+    def __init__(self, cfg):
+        self.config_dict = cfg
+        self.journal_dir = "/nowhere"
+        self.swept = False
+
+    def journal_pending_keys(self):
+        return []
+
+    async def recover_journal(self, analysis_classes):
+        self.swept = True
+        return {}
+
+
+def test_recovery_sweep_is_armed_by_default_and_can_be_suppressed(
+    tmp_path, monkeypatch
+):
+    """Armed by default -- an unswept journal is the silent loss it exists to end
+    -- and suppressible per server with ``analysis_recovery_on_startup: false``,
+    matching the batch server's knob."""
+    app = _app(tmp_path, monkeypatch)
+    handler = _startup_handler(app)
+
+    async def _run(cfg):
+        app.driver = _StubDriver(cfg)
+        handler()
+        task = getattr(app.driver, "recovery_task", None)
+        if task is not None:
+            await task
+        return app.driver.swept
+
+    assert asyncio.run(_run({})) is True
+    assert asyncio.run(_run({"analysis_recovery_on_startup": False})) is False
+
+
+def test_the_sweep_runs_as_a_task_rather_than_blocking_startup(tmp_path, monkeypatch):
+    """Rebuilding a loader indexes a sequence zip; holding up startup for that
+    would delay the port bind and every route with it."""
+    app = _app(tmp_path, monkeypatch)
+    handler = _startup_handler(app)
+
+    async def _run():
+        app.driver = _StubDriver({})
+        handler()
+        # The handler has returned and the sweep has NOT run yet -- it is a task.
+        assert app.driver.swept is False
+        assert isinstance(app.driver.recovery_task, asyncio.Task)
+        await app.driver.recovery_task
+        assert app.driver.swept is True
+
+    asyncio.run(_run())
+
+
+def test_a_missing_driver_at_startup_does_not_raise(tmp_path, monkeypatch):
+    """The sweep runs from a startup handler, so raising there would take the
+    server down before it binds its port. It warns instead."""
+    app = _app(tmp_path, monkeypatch)
+    app.driver = None
+    _startup_handler(app)()  # must not raise


### PR DESCRIPTION
## The problem

`AnalysisSyncer.task_queue` is an in-memory `asyncio.Queue` holding tuples that carry a live `LocalLoader` — not serialisable, and nothing on disk recorded that an analysis had been requested. `shutdown()` is a `pass`, and `AnalysisExecutor` returns as soon as `batch_calc` has enqueued, so the requesting action's own record already reads "done".

A restart therefore lost **every queued analysis, with no trace anywhere** — not even a way to enumerate what was dropped.

## What this adds

A durable request journal under `<STATES>/ana_pending/`, one atomic json file per request, written **before** the item reaches the queue. That ordering is the point: a crash between write and enqueue leaves a recoverable record, where the reverse loses the request entirely.

`recover_journal` replays it at startup — armed by default, suppressible with `analysis_recovery_on_startup: false` — and raises an alert for anything recovered, since a silently dropped analysis is the failure this ends. Four dispositions, none aborting the sweep:

| disposition | when | why |
|---|---|---|
| re-enqueued | zip present, class configured here | the normal case |
| deleted | loader `target` gone | can never run again; leaving it would alert every restart forever |
| left untouched | class not served on this host | `analyses` is per server — another host may own it, so deleting would destroy its work |
| left untouched | corrupt json / missing field / newer `schema` | a human decides |

## Why no delete-then-rerun dance (unlike the batch-conversion recovery)

`BaseAnalysis.gen_uuid` hashes analysis name, params, process uuid, sample label, codehash and run_use — so a replayed analysis mints the **same** analysis uuid and writes the same local path and S3 keys. An idempotent upsert, not a duplicate. This is the opposite of run uuids, which are `uuid7` with 48 random bits and forced the batch pipeline to delete records before re-converting.

## Two seams that are easy to get wrong

- **The journal key is not the task name.** The key is a digest of (loader target, process uuid, class name); the task name is only the process uuid. `syncer` clears by recomputing the exact key from the tuple; `journal_clear_by_process` exists for a name-only caller and removes the whole prefix as a deliberate superset. A mismatch here would accumulate entries forever and re-enqueue completed analyses on every restart.
- **Entries clear on completion, not success.** A permanently-failing analysis would otherwise re-run at every restart forever. The journal's job is to survive an *interruption* — precisely the case where no worker reaches the clear. A re-enqueued entry also stays on disk until its worker finishes, so an interrupted sweep leaves the remainder recoverable.

## Degradation

Journalling turns off with one WARNING when no `STATES` root resolves, and every journal helper swallows its own errors: an analysis whose journal write failed still runs, it merely stops being recoverable. Bookkeeping must not break the work.

**No route added or changed** — the pending count and keys ride on the existing `/list_queued_tasks` response, because the route surface is pinned by a frozen checklist that lives in another repository.

## Verification

Run per-file, as `run_tests.py` does (two `tests` packages collide in one pytest session — pre-existing, reproducible with untouched files):

- `test_analysis_recovery.py` — **36 passed**: write-before-enqueue ordering, key symmetry between write and clear, dedup, every recovery disposition, corrupt entry not aborting the sweep, journalling disabled, failed journal write not breaking enqueue
- `test_analysis_resolution.py` — 19 passed
- `test_checklist_content.py` — 8 passed (the route-surface gate)
- `test_import_sweep.py` — 8 passed (no import-time I/O added)
- pyright: **0 new errors** vs HEAD, and one pre-existing `logger.alert` error resolved
- `black` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)