### PR TITLE
Park a process group that can no longer be rebuilt, instead of retrying it forever

### DIFF
--- a/helao/core/drivers/data/sync_driver.py
+++ b/helao/core/drivers/data/sync_driver.py
@@ -689,14 +689,33 @@ class Progress:
         self.dict = yml_load(self.prg, fast=True)
 
     def write_dict(self, new_dict: Optional[dict] = None):
-        """Persist the progress dict to the ``.prg`` file as YAML.
+        """Persist the progress dict to the ``.prg`` file as YAML, atomically.
+
+        Written to a sibling ``.tmp`` and moved into place with
+        :func:`os.replace`, rather than truncating the live file. A plain
+        ``write_text`` leaves a window in which the ``.prg`` on disk is empty or
+        half-written, and this file is on a CIFS share where that window is not
+        small. Any reader landing in it gets either a parse error or -- worse --
+        a *partial* dict, which is one way an experiment ends up with
+        ``process_actions_done`` recording actions whose ``process_metas``
+        entries are absent: a divergence that cannot be rebuilt once the
+        contributing action ymls have moved on, and that used to leave the
+        experiment in a permanent re-enqueue loop (see
+        :meth:`SyncDriver.sync_process`).
+
+        The in-process hierarchical locks already serialize *writers* for one
+        experiment (an action holds its parent's mutex, see
+        :meth:`SyncDriver._acquire_hierarchy_locks`), so this is not about two
+        syncer tasks racing. It closes the reader-side window, and the
+        cross-process one that no asyncio lock can cover.
 
         Args:
             new_dict: Override dict to write. Defaults to ``self.dict``.
         """
         out_dict = self.dict if new_dict is None else new_dict
-        # with self.prglock:
-        self.prg.write_text(str(yml_dumps(out_dict)), encoding="utf-8")
+        tmp = self.prg.with_suffix(self.prg.suffix + ".tmp")
+        tmp.write_text(str(yml_dumps(out_dict)), encoding="utf-8")
+        os.replace(tmp, self.prg)
 
     @property
     def s3_done(self) -> bool:
@@ -1734,14 +1753,53 @@ class SyncDriver:
                             exp_prog.dict["process_api"].append(pidx)
                         exp_prog.write_dict()
                         continue
-                    # Contributing actions exist but their meta is still missing
-                    # -- unexpected after reconcile. Skip this pass rather than
-                    # wiping and re-queuing the whole subtree.
-                    LOGGER.error(
-                        f"Process group {pidx} in {str(exp_prog.yml.target)} has "
-                        f"contributing actions {done_gids} but no process meta after "
-                        f"reconcile; skipping."
+                    # Contributing actions are recorded, but their meta is
+                    # missing after reconcile replayed everything on disk. Whether
+                    # that is retryable depends entirely on whether any of those
+                    # actions is still *readable*, because the action yml is the
+                    # only thing a meta can be rebuilt from.
+                    on_disk = {
+                        c.meta.get("action_order")
+                        for c in exp_prog.yml.children
+                        if c.type == "action"
+                    }
+                    if set(done_gids) & on_disk:
+                        # Rebuildable: an action is there and reconcile still did
+                        # not produce a meta, so something else went wrong on this
+                        # pass. Skip rather than wiping and re-queuing the whole
+                        # subtree; the next pass can legitimately succeed.
+                        LOGGER.error(
+                            f"Process group {pidx} in {str(exp_prog.yml.target)} has "
+                            f"contributing actions {done_gids} on disk but no process "
+                            f"meta after reconcile; skipping this pass."
+                        )
+                        continue
+                    # Unrebuildable: process_actions_done records actions whose
+                    # ymls have left every tree HelaoYml.children scans (they
+                    # synced and were swept into the zipped sequence), so no pass
+                    # will ever rebuild this meta. Leaving it unfinished is what
+                    # kept such experiments in a permanent re-enqueue loop --
+                    # sync_yml returns False forever and anything that touches the
+                    # experiment starts it again. Park it exactly as a phantom
+                    # group is parked, but alert rather than warn: a process that
+                    # existed is being written off, which is a data-completeness
+                    # loss a human needs to see, not a bookkeeping tidy-up.
+                    # ``alert`` is installed onto Logger by helao_logging with a
+                    # setattr, which static analysis cannot see.
+                    LOGGER.alert(  # type: ignore[attr-defined]
+                        f"Process group {pidx} in {str(exp_prog.yml.target)} records "
+                        f"contributing actions {done_gids} whose ymls are no longer on "
+                        f"disk and whose process meta is gone; it cannot be rebuilt. "
+                        f"Parking the group so the experiment can finish -- this "
+                        f"process will NOT be uploaded. Recover it by restoring the "
+                        f"action ymls to RUNS_FINISHED and re-running finish_yml."
                     )
+                    exp_prog.dict["process_groups"].pop(pidx, None)
+                    if pidx not in exp_prog.dict["process_s3"]:
+                        exp_prog.dict["process_s3"].append(pidx)
+                    if pidx not in exp_prog.dict["process_api"]:
+                        exp_prog.dict["process_api"].append(pidx)
+                    exp_prog.write_dict()
                     continue
                 meta = exp_prog.dict["process_metas"][pidx]
                 uuid_key = meta["process_uuid"]
@@ -1900,6 +1958,21 @@ class SyncDriver:
         For each pending yml, any existing ``.progress`` sibling under
         ``RUNS_SYNCED`` triggers :meth:`reset_sync` before the yml is queued.
 
+        **That reset is dead for anything this build writes, deliberately so.**
+        :class:`Progress` writes ``.prg``; ``.progress`` is the legacy sidecar
+        name, kept only in :meth:`reset_sync`'s and :meth:`unsync_dir`'s delete
+        filters. So a yml queued from here keeps its ``.prg`` and *resumes*.
+        Widening the test to ``.prg`` would invert that: every partially synced
+        run would be reset instead, discarding recorded S3/API progress and
+        re-uploading it all -- on a share holding a backlog of pending sequences
+        that is the expensive wrong answer, not a safety net.
+        Nor is it needed. The failure a reset was reached for -- a ``.prg`` whose
+        ``process_actions_done`` records actions whose ``process_metas`` entries
+        are gone -- is repaired in place by :meth:`sync_process`, which parks a
+        group it can no longer rebuild instead of retrying it forever. A diverged
+        sidecar therefore resolves on its next pass without anything being thrown
+        away.
+
         Args:
             omit_manual_exps: Skip files containing ``manual_orch_seq``.
             actions_first: When true, enqueue actions and experiments before
@@ -1910,7 +1983,11 @@ class SyncDriver:
         """
 
         async def reset_and_queue(pp, rank: int = 0):
-            """Reset any stale ``.progress`` sibling under ``RUNS_SYNCED`` and enqueue ``pp``."""
+            """Reset a stale legacy ``.progress`` sibling, then enqueue ``pp``.
+
+            Legacy artifacts only -- see the caller's docstring for why this does
+            not (and must not) look for ``.prg``.
+            """
             if os.path.exists(
                 pp.replace(RunDir.FINISHED.value, RunDir.SYNCED.value).replace(
                     ".yml", ".progress"

--- a/helao/core/tests/unit_test_sync_process_recovery.py
+++ b/helao/core/tests/unit_test_sync_process_recovery.py
@@ -15,6 +15,13 @@ and re-run finish_yml). Three distinct defects are covered:
   4. Phantom groups: a ``process_order_groups`` entry with no contributing
      action on disk is dropped by ``sync_process`` so the experiment finishes,
      instead of looping forever on ``reset_sync`` + re-enqueue.
+  7. Unrebuildable groups: a group whose ``process_metas`` entry is gone while
+     ``process_actions_done`` still records its actions, and whose action ymls
+     have left every tree ``HelaoYml.children`` scans, must be parked rather
+     than retried forever. This is the same permanent loop as 4 reached from the
+     other side -- 4 has no contributing action recorded, so it is recognised as
+     phantom and dropped, while this one *is* recorded and falls through to a
+     ``continue`` that can never make progress.
 
 Hermetic: no AWS configured (``s3`` is None), so uploads are
 no-ops and nothing touches the network.
@@ -24,6 +31,7 @@ __all__ = ["sync_process_recovery_unit_test"]
 
 import asyncio
 import os
+import shutil
 import tempfile
 import traceback
 from datetime import datetime
@@ -325,6 +333,71 @@ async def _run_checks() -> dict:
                 t.cancel()
             await asyncio.gather(*drv.syncer_loops.values(), return_exceptions=True)
 
+    # --- 7. Unrebuildable group: meta gone AND its actions gone from disk ----
+    with tempfile.TemporaryDirectory() as tmp_root:
+        drv = _make_driver(tmp_root)
+        try:
+            from helao.core.drivers.data.sync_driver import HelaoYml
+
+            root = Path(tmp_root)
+            exp_yml = _make_exp_tree(
+                root,
+                RunDir.FINISHED.value,
+                _uuid(1006),
+                process_order_groups={0: [0, 1]},
+            )
+            a0 = _make_action(exp_yml, 0)
+            a1 = _make_action(exp_yml, 1, process_finish=True)
+
+            # Fold both actions the way a live sync would, so the .prg carries a
+            # complete record for group 0.
+            drv.update_process(HelaoYml(a0), _act_meta(0, False))
+            ep = drv.update_process(HelaoYml(a1), _act_meta(1, True))
+
+            # Now reproduce the state seen in production. Two things happened to
+            # this experiment, neither of them recoverable from the other:
+            #
+            #  * ``process_metas`` was lost while ``process_actions_done``
+            #    survived. A .prg written before the legacy-metas fix (scenario 1
+            #    above) is exactly this shape: the legacy branch recorded actions
+            #    as done without ever building their metas.
+            #  * the contributing actions left every tree ``HelaoYml.children``
+            #    scans -- they synced and were swept into the zipped sequence --
+            #    so there is nothing on disk to replay them from.
+            shutil.rmtree(a0.parent)
+            shutil.rmtree(a1.parent)
+            ep.dict["process_metas"] = {}
+            ep.write_dict()
+
+            ep = drv.get_progress(exp_yml)
+            ep = drv.reconcile_processes(ep)
+            # Precondition, not the defect: reconcile has nothing to replay, so
+            # the meta stays missing while the group still looks contributed-to.
+            out["unrebuildable_meta_absent"] = 0 not in ep.dict["process_metas"]
+            out["unrebuildable_actions_still_recorded"] = set(
+                ep.dict["process_actions_done"].keys()
+            ) == {0, 1}
+
+            ep = await drv.sync_process(ep, force=True)
+
+            # The defect: sync_process takes its "contributing actions exist but
+            # no process meta after reconcile" branch and ``continue``s, leaving
+            # the group in list_unfinished_procs forever. sync_yml then returns
+            # False and the experiment is re-queued by whatever touches it next
+            # -- the permanent reset+re-enqueue loop. An unrebuildable group must
+            # instead be parked (flagged done or dropped) with an alert, the way
+            # the phantom-group branch in scenario 4 already parks a group whose
+            # action was never dispatched.
+            out["unrebuildable_group_parked"] = (
+                0 not in ep.dict["process_groups"] or 0 in ep.dict["process_s3"]
+            )
+            s3_unf, api_unf = ep.list_unfinished_procs()
+            out["unrebuildable_experiment_completes"] = not s3_unf and not api_unf
+        finally:
+            for t in drv.syncer_loops.values():
+                t.cancel()
+            await asyncio.gather(*drv.syncer_loops.values(), return_exceptions=True)
+
     return out
 
 
@@ -388,6 +461,24 @@ def sync_process_recovery_unit_test() -> bool:
     reporter.check("both groups synced", lambda: res["overlap_both_synced"])
     reporter.check(
         "experiment completes (no stall)", lambda: res["overlap_experiment_completes"]
+    )
+
+    reporter.section("unrebuildable group (meta gone, contributing actions gone)")
+    reporter.check(
+        "precondition: meta absent after reconcile",
+        lambda: res["unrebuildable_meta_absent"],
+    )
+    reporter.check(
+        "precondition: actions still recorded done",
+        lambda: res["unrebuildable_actions_still_recorded"],
+    )
+    reporter.check(
+        "unrebuildable group parked, not retried forever",
+        lambda: res["unrebuildable_group_parked"],
+    )
+    reporter.check(
+        "experiment completes (no permanent re-enqueue loop)",
+        lambda: res["unrebuildable_experiment_completes"],
     )
 
     return reporter.success()

--- a/helao/hexagon/adapters/native/sync_driver.py
+++ b/helao/hexagon/adapters/native/sync_driver.py
@@ -698,14 +698,33 @@ class Progress:
         self.dict = yml_load(self.prg, fast=True)
 
     def write_dict(self, new_dict: Optional[dict] = None):
-        """Persist the progress dict to the ``.prg`` file as YAML.
+        """Persist the progress dict to the ``.prg`` file as YAML, atomically.
+
+        Written to a sibling ``.tmp`` and moved into place with
+        :func:`os.replace`, rather than truncating the live file. A plain
+        ``write_text`` leaves a window in which the ``.prg`` on disk is empty or
+        half-written, and this file is on a CIFS share where that window is not
+        small. Any reader landing in it gets either a parse error or -- worse --
+        a *partial* dict, which is one way an experiment ends up with
+        ``process_actions_done`` recording actions whose ``process_metas``
+        entries are absent: a divergence that cannot be rebuilt once the
+        contributing action ymls have moved on, and that used to leave the
+        experiment in a permanent re-enqueue loop (see
+        :meth:`SyncDriver.sync_process`).
+
+        The in-process hierarchical locks already serialize *writers* for one
+        experiment (an action holds its parent's mutex, see
+        :meth:`SyncDriver._acquire_hierarchy_locks`), so this is not about two
+        syncer tasks racing. It closes the reader-side window, and the
+        cross-process one that no asyncio lock can cover.
 
         Args:
             new_dict: Override dict to write. Defaults to ``self.dict``.
         """
         out_dict = self.dict if new_dict is None else new_dict
-        # with self.prglock:
-        self.prg.write_text(str(yml_dumps(out_dict)), encoding="utf-8")
+        tmp = self.prg.with_suffix(self.prg.suffix + ".tmp")
+        tmp.write_text(str(yml_dumps(out_dict)), encoding="utf-8")
+        os.replace(tmp, self.prg)
 
     @property
     def s3_done(self) -> bool:
@@ -1743,14 +1762,53 @@ class SyncDriver:
                             exp_prog.dict["process_api"].append(pidx)
                         exp_prog.write_dict()
                         continue
-                    # Contributing actions exist but their meta is still missing
-                    # -- unexpected after reconcile. Skip this pass rather than
-                    # wiping and re-queuing the whole subtree.
-                    LOGGER.error(
-                        f"Process group {pidx} in {str(exp_prog.yml.target)} has "
-                        f"contributing actions {done_gids} but no process meta after "
-                        f"reconcile; skipping."
+                    # Contributing actions are recorded, but their meta is
+                    # missing after reconcile replayed everything on disk. Whether
+                    # that is retryable depends entirely on whether any of those
+                    # actions is still *readable*, because the action yml is the
+                    # only thing a meta can be rebuilt from.
+                    on_disk = {
+                        c.meta.get("action_order")
+                        for c in exp_prog.yml.children
+                        if c.type == "action"
+                    }
+                    if set(done_gids) & on_disk:
+                        # Rebuildable: an action is there and reconcile still did
+                        # not produce a meta, so something else went wrong on this
+                        # pass. Skip rather than wiping and re-queuing the whole
+                        # subtree; the next pass can legitimately succeed.
+                        LOGGER.error(
+                            f"Process group {pidx} in {str(exp_prog.yml.target)} has "
+                            f"contributing actions {done_gids} on disk but no process "
+                            f"meta after reconcile; skipping this pass."
+                        )
+                        continue
+                    # Unrebuildable: process_actions_done records actions whose
+                    # ymls have left every tree HelaoYml.children scans (they
+                    # synced and were swept into the zipped sequence), so no pass
+                    # will ever rebuild this meta. Leaving it unfinished is what
+                    # kept such experiments in a permanent re-enqueue loop --
+                    # sync_yml returns False forever and anything that touches the
+                    # experiment starts it again. Park it exactly as a phantom
+                    # group is parked, but alert rather than warn: a process that
+                    # existed is being written off, which is a data-completeness
+                    # loss a human needs to see, not a bookkeeping tidy-up.
+                    # ``alert`` is installed onto Logger by helao_logging with a
+                    # setattr, which static analysis cannot see.
+                    LOGGER.alert(  # type: ignore[attr-defined]
+                        f"Process group {pidx} in {str(exp_prog.yml.target)} records "
+                        f"contributing actions {done_gids} whose ymls are no longer on "
+                        f"disk and whose process meta is gone; it cannot be rebuilt. "
+                        f"Parking the group so the experiment can finish -- this "
+                        f"process will NOT be uploaded. Recover it by restoring the "
+                        f"action ymls to RUNS_FINISHED and re-running finish_yml."
                     )
+                    exp_prog.dict["process_groups"].pop(pidx, None)
+                    if pidx not in exp_prog.dict["process_s3"]:
+                        exp_prog.dict["process_s3"].append(pidx)
+                    if pidx not in exp_prog.dict["process_api"]:
+                        exp_prog.dict["process_api"].append(pidx)
+                    exp_prog.write_dict()
                     continue
                 meta = exp_prog.dict["process_metas"][pidx]
                 uuid_key = meta["process_uuid"]
@@ -1909,6 +1967,21 @@ class SyncDriver:
         For each pending yml, any existing ``.progress`` sibling under
         ``RUNS_SYNCED`` triggers :meth:`reset_sync` before the yml is queued.
 
+        **That reset is dead for anything this build writes, deliberately so.**
+        :class:`Progress` writes ``.prg``; ``.progress`` is the legacy sidecar
+        name, kept only in :meth:`reset_sync`'s and :meth:`unsync_dir`'s delete
+        filters. So a yml queued from here keeps its ``.prg`` and *resumes*.
+        Widening the test to ``.prg`` would invert that: every partially synced
+        run would be reset instead, discarding recorded S3/API progress and
+        re-uploading it all -- on a share holding a backlog of pending sequences
+        that is the expensive wrong answer, not a safety net.
+        Nor is it needed. The failure a reset was reached for -- a ``.prg`` whose
+        ``process_actions_done`` records actions whose ``process_metas`` entries
+        are gone -- is repaired in place by :meth:`sync_process`, which parks a
+        group it can no longer rebuild instead of retrying it forever. A diverged
+        sidecar therefore resolves on its next pass without anything being thrown
+        away.
+
         Args:
             omit_manual_exps: Skip files containing ``manual_orch_seq``.
             actions_first: When true, enqueue actions and experiments before
@@ -1919,7 +1992,11 @@ class SyncDriver:
         """
 
         async def reset_and_queue(pp, rank: int = 0):
-            """Reset any stale ``.progress`` sibling under ``RUNS_SYNCED`` and enqueue ``pp``."""
+            """Reset a stale legacy ``.progress`` sibling, then enqueue ``pp``.
+
+            Legacy artifacts only -- see the caller's docstring for why this does
+            not (and must not) look for ``.prg``.
+            """
             if os.path.exists(
                 pp.replace(RunDir.FINISHED.value, RunDir.SYNCED.value).replace(
                     ".yml", ".progress"

--- a/helao/hexagon/tests/test_native_sync_process_recovery.py
+++ b/helao/hexagon/tests/test_native_sync_process_recovery.py
@@ -242,3 +242,68 @@ async def test_overlapping_groups_both_built_and_synced(tmp_path):
         assert not s3_unf and not api_unf, "overlap_experiment_completes"
     finally:
         await teardown_driver(drv)
+
+
+# --- 7. Unrebuildable group: meta gone AND its actions gone from disk ------
+
+
+@pytest.mark.asyncio
+async def test_unrebuildable_group_parked_experiment_finishes(tmp_path):
+    """A group whose meta is gone and whose actions left disk must not loop.
+
+    Scenario 4 parks a group that has *no* contributing action recorded, by
+    recognising it as phantom. This is the same permanent loop reached from the
+    other side: the actions *are* recorded in ``process_actions_done``, so the
+    phantom test does not fire, and ``sync_process`` falls through to a
+    ``continue`` that can never make progress -- the group stays in
+    ``list_unfinished_procs`` forever, ``sync_yml`` keeps returning False, and the
+    experiment is re-queued by whatever touches it next.
+
+    Both halves of the state are reproduced because neither implies the other:
+    ``process_metas`` lost while ``process_actions_done`` survived (the shape a
+    .prg written before the scenario-1 legacy-metas fix has), and the
+    contributing action ymls gone from every tree ``HelaoYml.children`` scans
+    (they synced and were swept into the zipped sequence), so
+    ``reconcile_processes`` has nothing to replay.
+    """
+    import shutil
+
+    drv = make_sync_driver(str(tmp_path), NativeSyncDriver)
+    try:
+        root = Path(tmp_path)
+        exp_yml = make_exp_tree(
+            root,
+            RunDir.FINISHED.value,
+            mk_uuid(1006),
+            process_order_groups={0: [0, 1]},
+        )
+        a0 = make_action(exp_yml, 0)
+        a1 = make_action(exp_yml, 1, process_finish=True)
+
+        drv.update_process(HelaoYml(a0), act_meta(0, False))
+        ep = drv.update_process(HelaoYml(a1), act_meta(1, True))
+
+        shutil.rmtree(a0.parent)
+        shutil.rmtree(a1.parent)
+        ep.dict["process_metas"] = {}
+        ep.write_dict()
+
+        ep = drv.get_progress(exp_yml)
+        ep = drv.reconcile_processes(ep)
+        # Preconditions, not the defect: reconcile has nothing to replay, so the
+        # meta stays missing while the group still looks contributed-to.
+        assert 0 not in ep.dict["process_metas"], "unrebuildable_meta_absent"
+        assert set(ep.dict["process_actions_done"].keys()) == {
+            0,
+            1,
+        }, "unrebuildable_actions_still_recorded"
+
+        ep = await drv.sync_process(ep, force=True)
+
+        assert (
+            0 not in ep.dict["process_groups"] or 0 in ep.dict["process_s3"]
+        ), "unrebuildable_group_parked"
+        s3_unf, api_unf = ep.list_unfinished_procs()
+        assert not s3_unf and not api_unf, "unrebuildable_experiment_completes"
+    finally:
+        await teardown_driver(drv)


### PR DESCRIPTION
## The bug

An experiment could sit in a permanent reset + re-enqueue loop, its `.prg` recording a finished action that a process group needed while that group's `process_metas` entry was gone. `sync_process` reached this branch:

```python
# Contributing actions exist but their meta is still missing
# -- unexpected after reconcile. Skip this pass rather than
# wiping and re-queuing the whole subtree.
LOGGER.error(...)
continue
```

`continue` leaves the group in `list_unfinished_procs()` forever → the retry loop exhausts → `sync_yml` returns `False` → the experiment is re-queued by whatever touches it next (a sibling action finishing, `/finish_pending`, a startup sweep). Nothing ever repaired it. The manual workaround was to move the experiment and its actions back to `RUNS_FINISHED`, delete the `.prg` files, and re-run `finish_yml` by hand.

## Why it never healed

"Skip and retry" is right only when a retry *can* succeed, and that turns entirely on something the branch never checked: **whether any contributing action yml is still readable**, since that yml is the only thing a meta can be rebuilt from. So the branch now splits:

| case | condition | action |
|---|---|---|
| rebuildable | an action is on disk, yet reconcile produced no meta | skip, as before — the next pass can legitimately succeed |
| unrebuildable | `process_actions_done` records actions whose ymls left every tree `HelaoYml.children` scans | **park** the group, and `alert` |

Unrebuildable means the actions synced and were swept into the zipped sequence, so no pass will ever rebuild that meta. The group is parked exactly as a phantom group is parked — but with `alert` rather than `warning`, because a process that existed is being written off. That's a data-completeness loss a human must see, not a bookkeeping tidy-up, so the alert names the recovery: restore the action ymls to `RUNS_FINISHED` and re-run `finish_yml`.

**This is the phantom-group case reached from the other side.** A phantom group has *no* contributing action recorded and was already dropped so the experiment could finish. This one *is* recorded, so the phantom test never fired and it fell through. One unrecoverable shape parked while its sibling spun.

## Atomic `.prg` writes

`Progress.write_dict` now writes a sibling `.tmp` and `os.replace`s it into place instead of truncating the live file. Not about two syncer tasks racing — the hierarchical locks already serialise writers for one experiment (an action holds its parent's mutex). It closes the **reader-side** window: on a CIFS share a truncate-then-write leaves a window where a reader gets a parse error or, worse, a *partial* dict — one way `process_actions_done` and `process_metas` come to disagree in the first place — plus the cross-process window no asyncio lock can cover.

## `finish_pending`'s reset branch: documented, not revived

It keys on a `*.progress` sibling, a legacy name **nothing in this build writes** (`Progress` writes `.prg`), so it is dead for current artifacts — the "safety net" that was supposed to clear a stale sidecar has never fired.

Widening it to `.prg` would be actively harmful: every partially synced run would be reset, discarding recorded S3/API progress and re-uploading it, across a share holding a backlog of pending sequences. And it is unnecessary now — a diverged sidecar resolves on its next pass because the group it cannot rebuild is parked in place. So the trap is documented at its own site.

## Tests

Case 7 added to **both** paired regression files, mirroring the existing six:

- `helao/core/tests/unit_test_sync_process_recovery.py` (standalone, run by `run_unit_tests.py`)
- `helao/hexagon/tests/test_native_sync_process_recovery.py` (native twin)

It reproduces both halves of the state, since neither implies the other: the meta lost while `process_actions_done` survived (the shape a `.prg` written before the legacy-metas fix in case 1 has), and the contributing action ymls gone from disk so `reconcile_processes` has nothing to replay. Its two **preconditions are asserted separately from the outcome**, so a fixture that stops reproducing the state fails as a precondition rather than passing vacuously.

Confirmed red before the fix (`unrebuildable_group_parked` / `unrebuildable_experiment_completes` failing, both preconditions passing), green after.

## Dual-copy discipline

Both `sync_driver.py` copies changed together and the verbatim region is byte-identical again — `test_native_sync_pins.py` **10 passed**. Note `pyproject.toml`'s `force-exclude` covers both sides of every pinned pair, so `black` deliberately refuses these files to protect that parity; the added lines were hand-held to the 88-column baseline instead.

## Verification

- pins **10 passed**; native process-recovery 6; native parity 3; core standalone 23 checks PASS
- `run_unit_tests.py` overall PASS
- full `run_tests.py`: **249 files ALL GREEN** (229 pass, 2 ENV = known Windows-only SDK, 17 NOTESTS, 1 NOTATEST)
- pyright: **0 new errors** in either copy (legacy 9→9, native 0→0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)